### PR TITLE
feat: block all routes until initial setup is complete

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -6,6 +6,7 @@ from .config import settings
 from .routers import auth, users, projects, upload, events, assets, me, comments, approvals, share, metadata, branding, notifications, admin, setup, folders, hls_proxy
 from .services.s3_service import ensure_bucket_exists
 from .middleware.global_rate_limit import GlobalRateLimitMiddleware
+from .middleware.setup_guard import SetupGuardMiddleware
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -38,6 +39,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(GlobalRateLimitMiddleware)
+app.add_middleware(SetupGuardMiddleware)
 
 app.include_router(auth.router)
 app.include_router(users.router)

--- a/apps/api/middleware/setup_guard.py
+++ b/apps/api/middleware/setup_guard.py
@@ -1,0 +1,68 @@
+"""
+Setup guard middleware.
+
+Blocks all API requests (except /setup/*, /health, /docs, /redoc, /openapi.json)
+until initial setup is complete (a superadmin exists).
+
+Uses a cached flag so the database check only runs once — after setup completes,
+all subsequent requests pass through without any DB query.
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+# Once setup is confirmed, skip the check for all future requests
+_setup_complete = False
+
+EXEMPT_PREFIXES = (
+    "/setup",
+    "/health",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/share/",     # Public share links should work regardless
+)
+
+
+class SetupGuardMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        global _setup_complete
+
+        if _setup_complete:
+            return await call_next(request)
+
+        path = request.url.path
+
+        # Always allow exempt paths
+        if any(path.startswith(prefix) for prefix in EXEMPT_PREFIXES):
+            return await call_next(request)
+
+        # Check if setup is done (query DB once, then cache)
+        try:
+            from ..database import SessionLocal
+            from ..models.user import User
+
+            db = SessionLocal()
+            try:
+                has_admin = db.query(User).filter(
+                    User.is_superadmin == True,
+                    User.deleted_at.is_(None),
+                ).first() is not None
+            finally:
+                db.close()
+
+            if has_admin:
+                _setup_complete = True
+                return await call_next(request)
+        except Exception:
+            # If DB check fails, allow the request through (fail open)
+            return await call_next(request)
+
+        return JSONResponse(
+            status_code=503,
+            content={
+                "detail": "FreeFrame is not set up yet. Please complete initial setup.",
+                "needs_setup": True,
+            },
+        )

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -4,23 +4,46 @@ import type { NextRequest } from 'next/server'
 const PUBLIC_ROUTES = ['/login', '/setup']
 const PUBLIC_PREFIXES = ['/invite/', '/share/']
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
 function isPublicRoute(pathname: string): boolean {
   if (PUBLIC_ROUTES.includes(pathname)) return true
   if (PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))) return true
   return false
 }
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  // Allow public routes through
+  // Always allow public routes
   if (isPublicRoute(pathname)) {
     return NextResponse.next()
   }
 
-  // Check for auth tokens in cookies (middleware runs on server, no localStorage)
-  // Allow through if either access token or refresh token exists
-  // (client-side JS will handle token refresh if access token is expired)
+  // Check if setup is needed — redirect to /setup if no superadmin exists
+  // Uses a cookie cache to avoid calling the API on every request
+  const setupDone = request.cookies.get('ff_setup_done')?.value
+  if (!setupDone) {
+    try {
+      const res = await fetch(`${API_URL}/setup/status`, {
+        next: { revalidate: 60 }, // Cache for 60 seconds
+      })
+      if (res.ok) {
+        const data = await res.json()
+        if (data.needs_setup) {
+          return NextResponse.redirect(new URL('/setup', request.url))
+        }
+        // Setup is done — set cookie so we don't check again
+        const response = NextResponse.next()
+        response.cookies.set('ff_setup_done', '1', { path: '/', maxAge: 60 * 60 * 24 }) // 24 hours
+        return response
+      }
+    } catch {
+      // API unreachable — let the request through, the page will show errors
+    }
+  }
+
+  // Check for auth tokens
   const accessToken = request.cookies.get('ff_access_token')?.value
   const refreshToken = request.cookies.get('ff_refresh_token')?.value
 


### PR DESCRIPTION
## Summary

- Backend `SetupGuardMiddleware` returns 503 for all API routes until a superadmin exists
- Frontend middleware redirects to `/setup` if `needs_setup` is true
- Exempt paths: `/setup/*`, `/health`, `/docs`, `/share/*`
- Cached after first check — zero DB overhead after setup is done

## Test plan

- [x] Fresh instance (no users) → all routes return 503 except `/setup/status` and `/health`
- [x] Navigate to any page → redirected to `/setup`
- [x] Complete setup → all routes work normally
- [x] Restart server → cached flag resets, re-checks DB once, then caches again

🤖 Generated with [Claude Code](https://claude.com/claude-code)