### PR TITLE
fix: preserve original file extension on asset downloads (#41)

### DIFF
--- a/apps/api/routers/assets.py
+++ b/apps/api/routers/assets.py
@@ -15,7 +15,7 @@ from ..models.activity import Mention, Notification, NotificationType
 from ..schemas.asset import AssetResponse, AssetVersionResponse, AssetUpdate, StreamUrlResponse, MediaFileResponse
 from ..schemas.notification import AssignmentUpdate
 from ..services.permissions import require_project_role, require_asset_access, can_access_asset, is_public_project, get_project_member
-from ..services.s3_service import generate_presigned_get_url
+from ..services.s3_service import generate_presigned_get_url, build_download_filename
 from ..schemas.upload import InitiateUploadRequest, InitiateUploadResponse, ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES, mime_to_asset_type
 from ..services.s3_service import create_multipart_upload
 
@@ -266,13 +266,18 @@ def get_stream_url(
         if download:
             # For video downloads, use the raw file (original upload) so user gets a single file
             s3_key = media_file.s3_key_raw or media_file.s3_key_processed
-            url = generate_presigned_get_url(s3_key, download_filename=asset.name)
+            filename = build_download_filename(asset.name, media_file.original_filename or s3_key)
+            url = generate_presigned_get_url(s3_key, download_filename=filename)
         else:
             s3_key = f"{media_file.s3_key_processed}/master.m3u8"
             url = generate_presigned_get_url(s3_key)
     else:
         s3_key = media_file.s3_key_processed or media_file.s3_key_raw
-        url = generate_presigned_get_url(s3_key, download_filename=asset.name if download else None)
+        if download:
+            filename = build_download_filename(asset.name, media_file.original_filename or s3_key)
+            url = generate_presigned_get_url(s3_key, download_filename=filename)
+        else:
+            url = generate_presigned_get_url(s3_key)
 
     return StreamUrlResponse(url=url, asset_type=asset.asset_type)
 

--- a/apps/api/routers/share.py
+++ b/apps/api/routers/share.py
@@ -36,7 +36,7 @@ from ..schemas.share import (
 )
 from ..services.permissions import require_project_role, validate_share_link, validate_share_link_with_session
 from ..services.redis_service import create_share_session
-from ..services.s3_service import generate_presigned_get_url
+from ..services.s3_service import generate_presigned_get_url, build_download_filename
 from ..services.crypto_service import encrypt_password, decrypt_password
 from ..models.project import Project, ProjectRole
 from ..tasks.email_tasks import send_share_email
@@ -1369,13 +1369,18 @@ def get_share_stream_url(
     if asset.asset_type == AssetType.video and media_file.s3_key_processed:
         if download:
             s3_key = media_file.s3_key_raw or media_file.s3_key_processed
-            url = generate_presigned_get_url(s3_key, download_filename=asset.name)
+            filename = build_download_filename(asset.name, media_file.original_filename or s3_key)
+            url = generate_presigned_get_url(s3_key, download_filename=filename)
         else:
             s3_key = f"{media_file.s3_key_processed}/master.m3u8"
             url = generate_presigned_get_url(s3_key)
     else:
         s3_key = media_file.s3_key_processed or media_file.s3_key_raw
-        url = generate_presigned_get_url(s3_key, download_filename=asset.name if download else None)
+        if download:
+            filename = build_download_filename(asset.name, media_file.original_filename or s3_key)
+            url = generate_presigned_get_url(s3_key, download_filename=filename)
+        else:
+            url = generate_presigned_get_url(s3_key)
 
     # Log activity
     activity_action = ShareActivityAction.downloaded if download else ShareActivityAction.viewed_asset

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import boto3
 from botocore.exceptions import ClientError
@@ -177,6 +178,23 @@ def abort_multipart_upload(s3_key: str, upload_id: str) -> None:
         Key=s3_key,
         UploadId=upload_id,
     )
+
+def build_download_filename(display_name: str, source: str | None) -> str:
+    """Return display_name with an extension appended from `source` if missing.
+
+    `source` is an original upload filename or an S3 key — whichever is most
+    authoritative for the file's real extension. If the display name already
+    ends with that extension (case-insensitive), it is returned unchanged.
+    """
+    if not source:
+        return display_name
+    ext = os.path.splitext(source)[1]
+    if not ext:
+        return display_name
+    if display_name.lower().endswith(ext.lower()):
+        return display_name
+    return f"{display_name}{ext}"
+
 
 def generate_presigned_get_url(s3_key: str, expires_in: int = 3600, download_filename: str | None = None) -> str:
     """Generate a presigned GET URL for an object.

--- a/apps/web/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/page.tsx
@@ -1144,15 +1144,15 @@ export default function ProjectDetailPage() {
                         className="gap-1"
                         onClick={async () => {
                           try {
-                            const res = await api.get<{ url: string }>(`/assets/${selectedAsset.id}/stream`);
+                            const res = await api.get<{ url: string }>(
+                              `/assets/${selectedAsset.id}/stream?download=true`,
+                            );
                             if (res.url) {
-                              const a = document.createElement('a');
-                              a.href = res.url;
-                              a.download = selectedAsset.name;
-                              a.rel = 'noopener noreferrer';
-                              document.body.appendChild(a);
-                              a.click();
-                              document.body.removeChild(a);
+                              const iframe = document.createElement("iframe");
+                              iframe.style.display = "none";
+                              iframe.src = res.url;
+                              document.body.appendChild(iframe);
+                              setTimeout(() => iframe.remove(), 30000);
                             }
                           } catch {
                             // Silent fail

--- a/apps/web/components/share/folder-share-viewer.tsx
+++ b/apps/web/components/share/folder-share-viewer.tsx
@@ -105,12 +105,11 @@ function getAssetTypeBadgeLabel(assetType: string): string {
 
 // ─── Download handler ─────────────────────────────────────────────────────────
 
-function triggerDownload(url: string, filename: string) {
-  // Use an anchor click — works reliably for cross-origin URLs when the
-  // server sets Content-Disposition: attachment (which our backend does).
+function triggerDownload(url: string) {
+  // Let the server's Content-Disposition filename win — don't set `a.download`,
+  // since it would strip the extension the backend appended.
   const a = document.createElement('a')
   a.href = url
-  a.download = filename
   a.rel = 'noopener noreferrer'
   a.style.display = 'none'
   document.body.appendChild(a)
@@ -130,9 +129,9 @@ async function fetchDownloadUrl(token: string, assetId: string, shareSession?: s
   }
 }
 
-async function handleDownload(token: string, assetId: string, assetName: string, shareSession?: string | null) {
+async function handleDownload(token: string, assetId: string, shareSession?: string | null) {
   const url = await fetchDownloadUrl(token, assetId, shareSession)
-  if (url) triggerDownload(url, assetName)
+  if (url) triggerDownload(url)
 }
 
 async function collectAllAssetsRecursive(
@@ -169,14 +168,11 @@ async function handleDownloadAll(
   // sequentially with a delay so the browser doesn't block them.
   const allAssets = await collectAllAssetsRecursive(token, folderId, shareSession)
   const urls = await Promise.all(
-    allAssets.map(async (a) => ({
-      name: a.name,
-      url: await fetchDownloadUrl(token, a.id, shareSession),
-    })),
+    allAssets.map((a) => fetchDownloadUrl(token, a.id, shareSession)),
   )
-  for (const { url, name } of urls) {
+  for (const url of urls) {
     if (!url) continue
-    triggerDownload(url, name)
+    triggerDownload(url)
     await new Promise((r) => setTimeout(r, 800))
   }
 }
@@ -332,7 +328,7 @@ function AssetGridCard({ asset, allowDownload, token, shareSession, isSelected, 
             className="absolute top-2 right-2 flex items-center justify-center h-6 w-6 rounded-md bg-bg-primary/70 hover:bg-bg-primary/90 text-text-primary backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
             onClick={(e) => {
               e.stopPropagation()
-              handleDownload(token, asset.id, asset.name, shareSession)
+              handleDownload(token, asset.id, shareSession)
             }}
             title="Download"
           >
@@ -854,7 +850,7 @@ function ShareReviewInner({
         </div>
         <div className="flex items-center gap-2">
           {allowDownload && (
-            <button className="flex items-center gap-1.5 h-7 px-3 rounded-md text-xs font-medium text-text-inverse bg-accent hover:bg-accent-hover transition-colors" onClick={() => handleDownload(token, asset.id, assetName, shareSession)}>
+            <button className="flex items-center gap-1.5 h-7 px-3 rounded-md text-xs font-medium text-text-inverse bg-accent hover:bg-accent-hover transition-colors" onClick={() => handleDownload(token, asset.id, shareSession)}>
               <Download className="h-3 w-3" /> Download
             </button>
           )}
@@ -1508,7 +1504,7 @@ export function FolderShareViewer({
                                   {allowDownload && (
                                     <button
                                       className="w-7 shrink-0 flex items-center justify-center h-7 rounded text-text-tertiary opacity-0 group-hover:opacity-100 hover:text-text-primary transition-all"
-                                      onClick={(e) => { e.stopPropagation(); handleDownload(token, asset.id, asset.name, shareSession) }}
+                                      onClick={(e) => { e.stopPropagation(); handleDownload(token, asset.id, shareSession) }}
                                       title="Download"
                                     >
                                       <Download className="h-4 w-4" />


### PR DESCRIPTION
Closes #41

## Summary
- Downloads were saving as `Video_Title` instead of `Video_Title.mp4` because the API passed `asset.name` (no extension) as the `Content-Disposition` filename, and the dashboard further overrode it via `a.download`.
- Backend: new `build_download_filename()` helper derives the extension from `MediaFile.original_filename` (authoritative) or the S3 key, and appends it to `asset.name` when missing (case-insensitive). Applied in `/assets/{id}/stream` and `/share/{token}/stream/{asset_id}`.
- Frontend: the dashboard Download button now calls `/stream?download=true` and uses a hidden iframe instead of setting `a.download`. `folder-share-viewer` no longer overrides `a.download` so the browser honors the server's `Content-Disposition` filename.

## Test plan
- [x] Download a video from the dashboard — file saves with `.mp4` (or original) extension
- [x] Download an image / audio / carousel item from the dashboard — extension preserved
- [x] Download an asset from a public share link — extension preserved
- [x] "Download all" from a folder share link — each file saves with its extension
- [x] Assets whose `name` already includes the extension (e.g. `clip.mp4`) don't get it duplicated (`clip.mp4.mp4`)
- [x] HLS streaming (non-download) URLs are unchanged for video playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)