### PR TITLE
fix: useSSE URL constructor crash with relative API_URL (#46)

### DIFF
--- a/apps/web/hooks/__tests__/use-sse.test.ts
+++ b/apps/web/hooks/__tests__/use-sse.test.ts
@@ -156,3 +156,30 @@ describe('useSSE hook', () => {
     vi.useRealTimers()
   })
 })
+
+describe('useSSE with relative NEXT_PUBLIC_API_URL', () => {
+  beforeEach(() => {
+    MockEventSource.reset()
+    vi.stubGlobal('EventSource', MockEventSource)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  // Regression for issue #46: deployments behind nginx set NEXT_PUBLIC_API_URL
+  // to a relative path like "/api". `new URL("/api/events/abc")` throws
+  // "Failed to construct 'URL': Invalid URL" without a base, crashing the
+  // dashboard the moment UploadSSEBridge first opens an SSE connection.
+  it('builds a valid URL when NEXT_PUBLIC_API_URL is a relative path', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', '/api')
+    vi.resetModules()
+    const { useSSE: useSSEFresh } = await import('../use-sse')
+
+    expect(() => renderHook(() => useSSEFresh('project-123'))).not.toThrow()
+    expect(MockEventSource.instances).toHaveLength(1)
+    expect(MockEventSource.instances[0].url).toContain('/api/events/project-123')
+  })
+})

--- a/apps/web/hooks/use-sse.ts
+++ b/apps/web/hooks/use-sse.ts
@@ -126,7 +126,11 @@ export function useSSE(projectId: string | null | undefined, options: UseSSEOpti
       if (destroyed) return
 
       const token = getAccessToken()
-      const url = new URL(`${API_URL}/events/${projectId}`)
+      // Use window.location.origin as a base so deployments behind a reverse
+      // proxy can set NEXT_PUBLIC_API_URL to a relative path like "/api"
+      // without crashing the URL constructor.
+      const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+      const url = new URL(`${API_URL}/events/${projectId}`, base)
       if (token) {
         url.searchParams.set('token', token)
       }


### PR DESCRIPTION
## Summary
- Pass `window.location.origin` as the base URL when constructing the SSE EventSource URL in `useSSE`, so deployments that set `NEXT_PUBLIC_API_URL` to a relative path (e.g. `/api` behind nginx) no longer crash the dashboard.
- Adds a regression test that stubs `NEXT_PUBLIC_API_URL='/api'` and asserts the hook can mount without throwing.

## Root cause
`new URL("/api/events/abc")` throws `TypeError: Failed to construct 'URL': Invalid URL` — the constructor requires either an absolute URL or a base. `UploadSSEBridge` opens its first SSE connection the moment any asset starts processing after an upload, which is exactly when the reporter saw the crash.

The issue body attributes the crash to a null `thumbnail_url` in the layout chunk, but reproduction (re-running on a working dev build with `NEXT_PUBLIC_API_URL='/api'`) confirmed the URL constructor is the actual culprit. `useSSE` gets bundled into the same layout chunk by Next.js, which is why the minified stack pointed there.

Closes #46.

## Test plan
- [x] `npx vitest run hooks/__tests__/use-sse.test.ts` — new test fails before fix, passes after (10 / 10 green)
- [x] `npx vitest run` — full frontend suite (108 passing; 5 pre-existing failures in `api.test.ts` and `notification-store.test.ts` are unrelated to this change, present on `main`)
- [x] Verified in browser: `new URL('/api/events/x', window.location.origin)` resolves to `http://localhost:3000/api/events/x` instead of throwing
- [x] Manually retest in a deployment with `NEXT_PUBLIC_API_URL='/api'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)