### PR TITLE
fix: route HLS video streams through /stream/hls proxy (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to FreeFrame are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2026-04-14
+
+### Security
+- **HLS video streams now route through the API proxy so S3 objects can stay private** ([#51](https://github.com/Techiebutler/freeframe/issues/51)) — the `/stream/hls/{path}` proxy router was already built and registered in `main.py` but was never actually called. `GET /assets/{id}/stream`, `GET /share/{token}`, and `GET /share/{token}/stream/{asset_id}` all previously handed out a direct presigned URL to `master.m3u8`, which forced the HLS player to fetch variant playlists and `.ts` segments as unsigned requests — only working on buckets with public-read ACL. Non-AWS providers (Exoscale SOS, Cloudflare R2, etc.) do not inherit bucket-level ACL on new objects, so processed files returned 403 Forbidden. The three stream endpoints now mint a short-lived HLS JWT scoped to the asset's S3 prefix and return `/stream/hls/master.m3u8?token=…`; the proxy rewrites variant playlist URLs to stay inside the proxy (with the same token) and rewrites segment URLs to freshly-presigned S3 URLs. Result: the bucket can stay fully private on every S3-compatible provider, captured segment URLs expire in 24h instead of living forever via public-read, and a leaked master URL can't be replayed after its token expires. Token and segment presign TTLs both bumped from 4h to 24h so pause-and-resume works without refresh logic. Includes regression tests for the assets, share asset detail, and share stream endpoints.
+
+---
+
 ## [1.1.4] - 2026-04-13
 
 ### Fixed

--- a/apps/api/routers/assets.py
+++ b/apps/api/routers/assets.py
@@ -16,6 +16,7 @@ from ..schemas.asset import AssetResponse, AssetVersionResponse, AssetUpdate, St
 from ..schemas.notification import AssignmentUpdate
 from ..services.permissions import require_project_role, require_asset_access, can_access_asset, is_public_project, get_project_member
 from ..services.s3_service import generate_presigned_get_url, build_download_filename
+from .hls_proxy import create_hls_token
 from ..schemas.upload import InitiateUploadRequest, InitiateUploadResponse, ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES, mime_to_asset_type
 from ..services.s3_service import create_multipart_upload
 
@@ -269,8 +270,11 @@ def get_stream_url(
             filename = build_download_filename(asset.name, media_file.original_filename or s3_key)
             url = generate_presigned_get_url(s3_key, download_filename=filename)
         else:
-            s3_key = f"{media_file.s3_key_processed}/master.m3u8"
-            url = generate_presigned_get_url(s3_key)
+            # Route through the HLS proxy so the master playlist, variant
+            # playlists, and .ts segments all get served via short-lived
+            # presigned URLs — the S3 bucket can stay fully private. (#51)
+            token = create_hls_token(media_file.s3_key_processed)
+            url = f"/stream/hls/master.m3u8?token={token}"
     else:
         s3_key = media_file.s3_key_processed or media_file.s3_key_raw
         if download:

--- a/apps/api/routers/hls_proxy.py
+++ b/apps/api/routers/hls_proxy.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/stream", tags=["streaming"])
 
 
-def create_hls_token(s3_prefix: str, expires_hours: int = 4) -> str:
+def create_hls_token(s3_prefix: str, expires_hours: int = 24) -> str:
     """Create a short-lived JWT for HLS proxy access."""
     payload = {
         "sub": "hls",
@@ -72,9 +72,10 @@ def _rewrite_manifest(content: str, s3_prefix: str, manifest_path: str, token: s
             # Variant playlist -> proxy URL with token
             result.append(f"{relative_key}?token={token}")
         elif stripped.endswith(".ts"):
-            # Segment -> presigned S3 URL (direct to S3, 4-hour expiry)
+            # Segment -> presigned S3 URL (direct to S3, 24-hour expiry to
+            # match the outer token lifetime so pause-and-resume works)
             s3_key = f"{s3_prefix}/{relative_key}"
-            result.append(generate_presigned_get_url(s3_key, expires_in=14400))
+            result.append(generate_presigned_get_url(s3_key, expires_in=86400))
         else:
             result.append(line)
 

--- a/apps/api/routers/share.py
+++ b/apps/api/routers/share.py
@@ -38,6 +38,7 @@ from ..services.permissions import require_project_role, validate_share_link, va
 from ..services.redis_service import create_share_session
 from ..services.s3_service import generate_presigned_get_url, build_download_filename
 from ..services.crypto_service import encrypt_password, decrypt_password
+from .hls_proxy import create_hls_token
 from ..models.project import Project, ProjectRole
 from ..tasks.email_tasks import send_share_email
 from ..tasks.celery_app import send_task_safe
@@ -296,10 +297,11 @@ def validate_share_link_endpoint(
         if media_file:
             if media_file.s3_key_processed:
                 if asset.asset_type == AssetType.video:
-                    s3_key = f"{media_file.s3_key_processed}/master.m3u8"
+                    # Route through /stream/hls so S3 can stay private (#51)
+                    hls_token = create_hls_token(media_file.s3_key_processed)
+                    stream_url = f"/stream/hls/master.m3u8?token={hls_token}"
                 else:
-                    s3_key = media_file.s3_key_processed
-                stream_url = generate_presigned_get_url(s3_key)
+                    stream_url = generate_presigned_get_url(media_file.s3_key_processed)
             elif media_file.s3_key_raw:
                 stream_url = generate_presigned_get_url(media_file.s3_key_raw)
 
@@ -1376,8 +1378,9 @@ def get_share_stream_url(
             filename = build_download_filename(asset.name, media_file.original_filename or s3_key)
             url = generate_presigned_get_url(s3_key, download_filename=filename)
         else:
-            s3_key = f"{media_file.s3_key_processed}/master.m3u8"
-            url = generate_presigned_get_url(s3_key)
+            # Route through /stream/hls so S3 can stay private (#51)
+            hls_token = create_hls_token(media_file.s3_key_processed)
+            url = f"/stream/hls/master.m3u8?token={hls_token}"
     else:
         s3_key = media_file.s3_key_processed or media_file.s3_key_raw
         if download:

--- a/apps/api/tests/test_assets_stream_url.py
+++ b/apps/api/tests/test_assets_stream_url.py
@@ -1,0 +1,122 @@
+"""Regression tests for issue #51 — /assets/{id}/stream must route video HLS
+through the /stream/hls proxy so S3 objects can stay private."""
+import uuid
+from unittest.mock import MagicMock, patch
+
+from jose import jwt
+
+from apps.api.config import settings
+
+
+def _setup_video_asset(mock_db, asset_type):
+    from apps.api.models.asset import ProcessingStatus
+
+    # The conftest mock_db only chains query/filter back to itself — order_by
+    # creates a new auto-mock otherwise, so .first() wouldn't return our values.
+    mock_db.order_by.return_value = mock_db
+
+    asset = MagicMock()
+    asset.id = uuid.uuid4()
+    asset.project_id = uuid.uuid4()
+    asset.asset_type = asset_type
+    asset.name = "demo"
+    asset.deleted_at = None
+
+    version = MagicMock()
+    version.id = uuid.uuid4()
+    version.asset_id = asset.id
+    version.processing_status = ProcessingStatus.ready
+    version.deleted_at = None
+
+    media_file = MagicMock()
+    media_file.version_id = version.id
+    media_file.s3_key_processed = "processed/proj/version-xyz"
+    media_file.s3_key_raw = "raw/proj/version-xyz/input.mp4"
+    media_file.original_filename = "input.mp4"
+
+    mock_db.first.side_effect = [asset, version, media_file]
+    return asset, version, media_file
+
+
+@patch("apps.api.routers.assets.require_asset_access")
+def test_video_stream_returns_hls_proxy_url_with_token(
+    mock_require_access,
+    client,
+    mock_db,
+    auth_headers,
+):
+    from apps.api.models.asset import AssetType
+
+    asset, _, media_file = _setup_video_asset(mock_db, AssetType.video)
+    mock_require_access.return_value = None
+
+    response = client.get(f"/assets/{asset.id}/stream", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    url = body["url"]
+
+    # The URL must route through the HLS proxy, not directly to S3.
+    assert url.startswith("/stream/hls/master.m3u8?token="), (
+        f"Expected /stream/hls/master.m3u8?token=..., got: {url}"
+    )
+    assert "s3" not in url.lower(), (
+        f"Stream URL must not contain a presigned S3 URL, got: {url}"
+    )
+
+    # The token must be a valid HLS JWT scoped to this asset's S3 prefix.
+    token = url.split("token=", 1)[1]
+    payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    assert payload["sub"] == "hls"
+    assert payload["pfx"] == media_file.s3_key_processed
+    assert "exp" in payload
+
+
+@patch("apps.api.routers.assets.generate_presigned_get_url")
+@patch("apps.api.routers.assets.require_asset_access")
+def test_video_download_still_returns_presigned_raw(
+    mock_require_access,
+    mock_presign,
+    client,
+    mock_db,
+    auth_headers,
+):
+    from apps.api.models.asset import AssetType
+
+    asset, _, _ = _setup_video_asset(mock_db, AssetType.video)
+    mock_require_access.return_value = None
+    mock_presign.return_value = "https://s3.example.com/raw.mp4?sig=x"
+
+    response = client.get(
+        f"/assets/{asset.id}/stream?download=true", headers=auth_headers
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Downloads bypass the HLS proxy — they need the original file, not a playlist.
+    assert body["url"] == "https://s3.example.com/raw.mp4?sig=x"
+    assert "/stream/hls/" not in body["url"]
+
+
+@patch("apps.api.routers.assets.generate_presigned_get_url")
+@patch("apps.api.routers.assets.require_asset_access")
+def test_image_stream_still_returns_presigned(
+    mock_require_access,
+    mock_presign,
+    client,
+    mock_db,
+    auth_headers,
+):
+    """Images and audio don't go through the HLS proxy — only video does."""
+    from apps.api.models.asset import AssetType
+
+    asset, _, _ = _setup_video_asset(mock_db, AssetType.image)
+    mock_require_access.return_value = None
+    mock_presign.return_value = "https://s3.example.com/image.webp?sig=x"
+
+    response = client.get(f"/assets/{asset.id}/stream", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["url"] == "https://s3.example.com/image.webp?sig=x"
+    assert "/stream/hls/" not in body["url"]

--- a/apps/api/tests/test_hls_proxy.py
+++ b/apps/api/tests/test_hls_proxy.py
@@ -63,7 +63,7 @@ class TestRewriteManifest:
         result = _rewrite_manifest(content, "hls/proj/ver", "720p/index.m3u8", "tok123")
 
         assert "https://s3.example.com/presigned-segment.ts" in result
-        mock_presign.assert_called_once_with("hls/proj/ver/720p/segment0.ts", expires_in=14400)
+        mock_presign.assert_called_once_with("hls/proj/ver/720p/segment0.ts", expires_in=86400)
 
     @patch("apps.api.routers.hls_proxy.generate_presigned_get_url")
     def test_rewrites_m3u8_to_proxy_url(self, mock_presign):

--- a/apps/api/tests/test_share_video_stream.py
+++ b/apps/api/tests/test_share_video_stream.py
@@ -1,6 +1,14 @@
-"""Regression test for issue #45 — share endpoint must return master.m3u8 for video assets."""
+"""Regression tests for share-link video streaming.
+
+#45 — share endpoint must return master.m3u8 (not the HLS folder) for video.
+#51 — all video HLS traffic must route through /stream/hls so S3 can stay private.
+"""
 import uuid
 from unittest.mock import MagicMock, patch
+
+from jose import jwt
+
+from apps.api.config import settings
 
 
 @patch("apps.api.routers.share.generate_presigned_get_url")
@@ -59,10 +67,22 @@ def test_validate_share_link_video_returns_master_m3u8(
     assert response.status_code == 200
     body = response.json()
     assert body["asset"] is not None
-    assert body["asset"]["stream_url"] is not None
-    assert body["asset"]["stream_url"].startswith(
-        "https://s3.example/processed/proj/version-abc/master.m3u8"
-    ), f"Expected master.m3u8 suffix, got: {body['asset']['stream_url']}"
+    stream_url = body["asset"]["stream_url"]
+    assert stream_url is not None
+
+    # #51: video stream URLs must route through the HLS proxy, not directly to S3.
+    assert stream_url.startswith("/stream/hls/master.m3u8?token="), (
+        f"Expected /stream/hls/master.m3u8?token=..., got: {stream_url}"
+    )
+    assert "s3.example" not in stream_url, (
+        f"Stream URL must not contain a presigned S3 URL, got: {stream_url}"
+    )
+
+    # The token must be scoped to this version's S3 prefix — never the bucket.
+    token = stream_url.split("token=", 1)[1]
+    payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    assert payload["sub"] == "hls"
+    assert payload["pfx"] == "processed/proj/version-abc"
 
 
 @patch("apps.api.routers.share.generate_presigned_get_url")
@@ -125,3 +145,62 @@ def test_validate_share_link_image_does_not_append_master_m3u8(
     assert body["asset"]["stream_url"].startswith(
         "https://s3.example/processed/proj/version-img/out.webp"
     )
+
+
+@patch("apps.api.routers.share._validate_asset_in_share")
+@patch("apps.api.routers.share._log_share_activity")
+@patch("apps.api.routers.share._get_latest_media_file")
+@patch("apps.api.routers.share._get_asset")
+@patch("apps.api.routers.share.validate_share_link_with_session")
+def test_share_stream_endpoint_video_returns_hls_proxy_url(
+    mock_validate,
+    mock_get_asset,
+    mock_get_latest_media_file,
+    mock_log_activity,
+    mock_validate_in_share,
+    client,
+    mock_db,
+):
+    """#51 — /share/{token}/stream/{asset_id} must also route video through /stream/hls."""
+    from apps.api.models.asset import AssetType
+
+    asset_id = uuid.uuid4()
+
+    link = MagicMock()
+    link.id = uuid.uuid4()
+    link.asset_id = asset_id
+    link.allow_download = False
+    link.permission = "view"
+    mock_validate.return_value = link
+    mock_validate_in_share.return_value = None
+    mock_log_activity.return_value = None
+
+    asset = MagicMock()
+    asset.id = asset_id
+    asset.name = "stream endpoint video"
+    asset.asset_type = AssetType.video
+    asset.project_id = uuid.uuid4()
+    mock_get_asset.return_value = asset
+
+    media_file = MagicMock()
+    media_file.s3_key_processed = "processed/proj/version-stream"
+    media_file.s3_key_raw = "raw/proj/version-stream/input.mp4"
+    media_file.s3_key_thumbnail = None
+    media_file.version_id = uuid.uuid4()
+    media_file.duration_seconds = 120.0
+    mock_get_latest_media_file.return_value = media_file
+
+    response = client.get(f"/share/some-token/stream/{asset_id}")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    url = body["url"]
+
+    assert url.startswith("/stream/hls/master.m3u8?token="), (
+        f"Expected /stream/hls/master.m3u8?token=..., got: {url}"
+    )
+
+    token = url.split("token=", 1)[1]
+    payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    assert payload["sub"] == "hls"
+    assert payload["pfx"] == "processed/proj/version-stream"


### PR DESCRIPTION
## Summary

Fixes #51. The `/stream/hls/{path}` proxy router was already built, tested, and registered in `main.py` — it just wasn't wired up. The three stream endpoints (`get_stream_url`, `validate_share_link`, `get_share_stream_url`) all handed out a direct presigned URL to `master.m3u8`, which forced the HLS player to fetch variant playlists and `.ts` segments as unsigned requests. That only works on buckets with public-read, which non-AWS providers (Exoscale SOS, Cloudflare R2, etc.) don't grant by default to new objects — hence the 403s in the reporter's setup.

- Each stream endpoint now mints a short-lived HLS JWT scoped to `MediaFile.s3_key_processed` and returns `/stream/hls/master.m3u8?token=…`
- The proxy rewrites variant `.m3u8` references to stay inside the proxy (same token) and rewrites `.ts` references to freshly-presigned S3 URLs
- **Bucket can stay fully private** on every S3-compatible provider — no ACL, no public bucket policy
- **Captured URLs expire in 24h** instead of living forever via public-read
- **Zero frontend changes** — `video-player.tsx` already resolved relative `/stream/hls/…` paths
- Bumped HLS token + segment presign TTLs from 4h → 24h so pause-and-resume works without refresh logic

## Security model

| | Before | After |
|---|---|---|
| Bucket ACL | Had to be public-read | Fully private |
| `master.m3u8` access | Indefinite presigned S3 link | Token-scoped via API (24h) |
| Captured `.ts` URL lifetime | Forever | ≤24h |
| Works on Exoscale/R2/MinIO/AWS | No (non-AWS 403) | Yes, identical on all |

Segments still stream directly from S3 via presigned URLs (industry standard, matches Frame.io / Vimeo). Full tunneling through the API would cost 2x egress and add Range-request complexity — deferred as a follow-up if a specific threat model needs it.

## Test plan

- [x] New `test_assets_stream_url.py` — video returns `/stream/hls/…?token=…` with a valid HLS JWT scoped to `s3_key_processed`; `download=true` still returns a presigned raw URL; image/audio paths still presigned
- [x] Updated `test_share_video_stream.py` — the #45 regression test now expects the proxy URL, plus a new test for `/share/{token}/stream/{asset_id}`
- [x] Updated `test_hls_proxy.py` — segment presign expectation bumped to 86400s
- [x] Full backend suite: `58 passed, 1 warning`
- [x] **Browser end-to-end** via chrome-devtools-mcp against MinIO: `/assets/{id}/stream` → `/stream/hls/master.m3u8?token=…` → `/stream/hls/0/playlist.m3u8?token=…` → 14 presigned `.ts` segment requests, all 200, video `readyState: 4`, buffered `0 → 38.94s`, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)