### PR TITLE
Fix public share comments response handling

### DIFF
--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -61,9 +61,7 @@ interface GuestComment {
   timecode_start?: number | null
 }
 
-interface CommentsResponse {
-  comments: GuestComment[]
-}
+type CommentsResponse = GuestComment[] | { comments?: GuestComment[] }
 
 // ─── Utility ──────────────────────────────────────────────────────────────────
 
@@ -201,7 +199,7 @@ function GuestCommentList({ token, refreshKey }: GuestCommentListProps) {
     setLoading(true)
     fetch(`${API_URL}/share/${token}/comments`)
       .then((r) => (r.ok ? r.json() : Promise.resolve({ comments: [] })))
-      .then((data: CommentsResponse) => setComments(data.comments ?? []))
+      .then((data: CommentsResponse) => setComments(Array.isArray(data) ? data : (data.comments ?? [])))
       .catch(() => setComments([]))
       .finally(() => setLoading(false))
   }, [token, refreshKey])


### PR DESCRIPTION
## Summary
- Normalize public share comments responses on the single-asset share page
- Support both the current bare array response and `{ comments: [...] }` fallback shape
- Keep behavior aligned with the folder share viewer

Fixes #67

## Testing
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec eslint 'app/share/[token]/page.tsx'`