### PR TITLE
fix: handle both array and object response shapes for single-asset share comments

### DIFF
--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -201,7 +201,10 @@ function GuestCommentList({ token, refreshKey }: GuestCommentListProps) {
     setLoading(true)
     fetch(`${API_URL}/share/${token}/comments`)
       .then((r) => (r.ok ? r.json() : Promise.resolve({ comments: [] })))
-      .then((data: CommentsResponse) => setComments(data.comments ?? []))
+      .then((data: CommentsResponse | GuestComment[]) => {
+        // Handle both array (single-asset) and object (folder) response shapes
+        setComments(Array.isArray(data) ? data : data.comments ?? [])
+      })
       .catch(() => setComments([]))
       .finally(() => setLoading(false))
   }, [token, refreshKey])


### PR DESCRIPTION
## Problem

Reported in #67 by @ducknoodledance.

When opening a public single-asset share link, the comments panel is always empty even when comments exist. Project/folder shares work correctly.

## Root Cause

Response shape mismatch between API and frontend:

- **API** (`apps/api/routers/comments.py:567`) returns a bare array:
  ```python
  return [_build_comment_response(c, db) for c in top_level]
  ```

- **Frontend** (`apps/web/app/share/[token]/page.tsx:204`) expected an object:
  ```typescript
  .then((data: CommentsResponse) => setComments(data.comments ?? []))
  ```

Since `data.comments` is `undefined` on an array, it silently falls back to `[]`.

The folder-share viewer uses a different code path that handles the array correctly, which is why project shares work.

## Solution

Updated `GuestCommentList` to handle both response formats:

```typescript
.then((data: CommentsResponse | GuestComment[]) => {
  // Handle both array (single-asset) and object (folder) response shapes
  setComments(Array.isArray(data) ? data : data.comments ?? [])
})
```

This approach:
- ✅ Fixes single-asset share comments
- ✅ Preserves folder share compatibility
- ✅ Avoids breaking API changes
- ✅ Follows the frontend fix recommendation from the issue

## Testing

Tested with:
- Single-asset public share links with comments
- Folder share links with comments
- Empty comment states

Closes #67