### PR TITLE
Normalize share comments response shape

### DIFF
--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -554,7 +554,7 @@ def list_share_comments(
     # Determine the asset_id to list comments for
     target_asset_id = link.asset_id or asset_id
     if not target_asset_id:
-        return {"comments": []}
+        return []
     asset_id = target_asset_id
 
     # Get top-level comments — reuse same format as authenticated endpoint

--- a/apps/api/tests/test_share_comments.py
+++ b/apps/api/tests/test_share_comments.py
@@ -1,0 +1,75 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+
+@patch("apps.api.routers.comments._build_comment_response")
+@patch("apps.api.routers.comments.validate_share_link")
+def test_share_comments_returns_array_for_asset_share(
+    mock_validate,
+    mock_build_comment_response,
+    client,
+    mock_db,
+):
+    asset_id = uuid.uuid4()
+    comment = MagicMock()
+    expected = {
+        "id": str(uuid.uuid4()),
+        "body": "Looks good",
+    }
+
+    link = MagicMock()
+    link.asset_id = asset_id
+    mock_validate.return_value = link
+    mock_db.order_by.return_value = mock_db
+    mock_db.all.return_value = [comment]
+    mock_build_comment_response.return_value = expected
+
+    response = client.get("/share/some-token/comments")
+
+    assert response.status_code == 200
+    assert response.json() == [expected]
+    mock_build_comment_response.assert_called_once_with(comment, mock_db)
+
+
+@patch("apps.api.routers.comments._build_comment_response")
+@patch("apps.api.routers.comments.validate_share_link")
+def test_share_comments_returns_array_for_folder_or_project_share_asset(
+    mock_validate,
+    mock_build_comment_response,
+    client,
+    mock_db,
+):
+    asset_id = uuid.uuid4()
+    comment = MagicMock()
+    expected = {
+        "id": str(uuid.uuid4()),
+        "body": "Needs one tweak",
+    }
+
+    link = MagicMock()
+    link.asset_id = None
+    mock_validate.return_value = link
+    mock_db.order_by.return_value = mock_db
+    mock_db.all.return_value = [comment]
+    mock_build_comment_response.return_value = expected
+
+    response = client.get(f"/share/some-token/comments?asset_id={asset_id}")
+
+    assert response.status_code == 200
+    assert response.json() == [expected]
+    mock_build_comment_response.assert_called_once_with(comment, mock_db)
+
+
+@patch("apps.api.routers.comments.validate_share_link")
+def test_share_comments_returns_empty_array_without_target_asset(
+    mock_validate,
+    client,
+):
+    link = MagicMock()
+    link.asset_id = None
+    mock_validate.return_value = link
+
+    response = client.get("/share/some-token/comments")
+
+    assert response.status_code == 200
+    assert response.json() == []

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -61,7 +61,7 @@ interface GuestComment {
   timecode_start?: number | null
 }
 
-type CommentsResponse = GuestComment[] | { comments?: GuestComment[] }
+type CommentsResponse = GuestComment[]
 
 // ─── Utility ──────────────────────────────────────────────────────────────────
 
@@ -198,8 +198,8 @@ function GuestCommentList({ token, refreshKey }: GuestCommentListProps) {
   React.useEffect(() => {
     setLoading(true)
     fetch(`${API_URL}/share/${token}/comments`)
-      .then((r) => (r.ok ? r.json() : Promise.resolve({ comments: [] })))
-      .then((data: CommentsResponse) => setComments(Array.isArray(data) ? data : (data.comments ?? [])))
+      .then((r) => (r.ok ? r.json() : Promise.resolve([])))
+      .then((data: CommentsResponse) => setComments(data))
       .catch(() => setComments([]))
       .finally(() => setLoading(false))
   }, [token, refreshKey])


### PR DESCRIPTION
## Summary
- Normalize `GET /share/{token}/comments` so the no-target fallback returns a bare array.
- Simplify the single-asset share page comments response type now that the endpoint returns a consistent array shape.
- Add backend regression coverage for asset-share, folder/project-share query asset, and no-target fallback paths.

Closes #72

## Testing
- `. .venv/bin/activate && pytest apps/api/tests/test_share_comments.py`
- `. .venv/bin/activate && pytest apps/api/tests/test_share_comments.py apps/api/tests/test_smoke.py`
- `git diff --check`

## Notes
- Installed API test dependencies in a local virtualenv.
- Frontend lint was not run because `npm ci --ignore-scripts` fails due package-lock/package.json drift, and `pnpm install --frozen-lockfile --ignore-scripts` fails because pnpm-lock.yaml is out of sync with package.json.