### PR TITLE
fix: handle transcode for videos without audio track

### DIFF
--- a/apps/api/tests/test_ffmpeg_transcoder.py
+++ b/apps/api/tests/test_ffmpeg_transcoder.py
@@ -1,0 +1,189 @@
+"""
+Tests for FFmpegTranscoder: command construction and error handling.
+
+Verifies:
+- has_audio=True  → ffmpeg cmd includes -map a:0, var_stream_map has audio tracks
+- has_audio=False → ffmpeg cmd excludes -map a:0, var_stream_map is video-only
+- _run() uses errors='replace' to survive Latin-1/Shift-JIS metadata
+- _run() raises RuntimeError with stderr on non-zero exit
+"""
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from packages.transcoder.ffmpeg_transcoder import FFmpegTranscoder
+from packages.transcoder.base import TranscodeJob
+
+
+def _make_job(qualities: list[str] | None = None) -> TranscodeJob:
+    return TranscodeJob(
+        media_id="media-1",
+        version_id="v1",
+        input_s3_key="uploads/video.mp4",
+        output_s3_prefix="hls/media-1/v1",
+        qualities=qualities or ["1080p", "720p", "360p"],
+    )
+
+
+# ─── _run() error handling ────────────────────────────────────────────────────
+
+def test_run_raises_on_nonzero():
+    with patch("subprocess.run") as mock_run:
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "ffmpeg error details"
+        mock_run.return_value = mock_result
+
+        with pytest.raises(RuntimeError, match="ffmpeg exited 1: ffmpeg error details"):
+            FFmpegTranscoder._run(["ffmpeg", "-i", "test.mp4"], label="ffmpeg")
+
+
+def test_run_uses_errors_replace():
+    """Verify that text=True + errors='replace' is passed to subprocess.run."""
+    with patch("subprocess.run") as mock_run:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        FFmpegTranscoder._run(["ffmpeg", "-i", "test.mp4"], timeout=60, label="ffmpeg")
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["text"] is True
+        assert call_kwargs["errors"] == "replace"
+        assert call_kwargs["timeout"] == 60
+
+
+# ─── has_audio=True command construction ───────────────────────────────────────
+
+def test_transcode_with_audio_includes_audio_map():
+    """When ffprobe detects audio streams, ffmpeg cmd must include -map a:0."""
+    def mock_run_side_effect(cmd, **_kwargs):
+        # First call: video probe → return metadata
+        if "-select_streams" in cmd and cmd[cmd.index("-select_streams") + 1] == "v:0":
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            mock.stdout = json.dumps({
+                "streams": [{"r_frame_rate": "30/1", "duration": 10.0, "width": 1920, "height": 1080}],
+            })
+            return mock
+        # Second call: audio probe → return audio stream
+        if "-select_streams" in cmd and cmd[cmd.index("-select_streams") + 1] == "a":
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            mock.stdout = json.dumps({
+                "streams": [{"codec_type": "audio"}],
+            })
+            return mock
+        # Third call: main ffmpeg transcode
+        mock = MagicMock()
+        mock.returncode = 0
+        mock.stderr = ""
+        return mock
+
+    with patch("subprocess.run", side_effect=mock_run_side_effect) as mock_run:
+        s3_mock = MagicMock()
+        s3_mock.generate_presigned_url.return_value = "https://s3.example.com/uploads/video.mp4"
+        s3_mock.upload_file = MagicMock()
+
+        # Mock thumbnail generation
+        with patch("builtins.open", MagicMock()), \
+             patch("pathlib.Path.glob", return_value=[]), \
+             patch("pathlib.Path.rglob", return_value=[]), \
+             patch("pathlib.Path.mkdir"), \
+             patch("shutil.rmtree"):
+                transcoder = FFmpegTranscoder(s3_mock, "test-bucket")
+                job = _make_job(["720p"])
+                asyncio.run(transcoder.transcode(job))
+
+        # Find the main ffmpeg command call (the one with -filter_complex)
+        ffmpeg_calls = [c for c in mock_run.call_args_list
+                        if any("filter_complex" in str(a) for a in c[0][0])]
+        assert len(ffmpeg_calls) > 0
+        ffmpeg_cmd = ffmpeg_calls[0][0][0]
+
+        # Assert audio map is present
+        assert "-map" in ffmpeg_cmd
+        # Find all -map args
+        maps = [ffmpeg_cmd[i+1] for i, arg in enumerate(ffmpeg_cmd) if arg == "-map"]
+        assert "a:0" in maps, f"Expected -map a:0 in ffmpeg cmd, got maps: {maps}"
+
+        # Assert var_stream_map includes audio tracks
+        var_stream_idx = ffmpeg_cmd.index("-var_stream_map")
+        stream_map = ffmpeg_cmd[var_stream_idx + 1]
+        assert "a:0" in stream_map, f"Expected audio track in var_stream_map, got: {stream_map}"
+
+
+# ─── has_audio=False command construction ─────────────────────────────────────
+
+def test_transcode_without_audio_excludes_audio_map():
+    """When ffprobe detects no audio streams, ffmpeg cmd must NOT include -map a:0."""
+    def mock_run_side_effect(cmd, **_kwargs):
+        # First call: video probe
+        if "-select_streams" in cmd and cmd[cmd.index("-select_streams") + 1] == "v:0":
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            mock.stdout = json.dumps({
+                "streams": [{"r_frame_rate": "30/1", "duration": 10.0, "width": 1920, "height": 1080}],
+            })
+            return mock
+        # Second call: audio probe → NO audio streams
+        if "-select_streams" in cmd and cmd[cmd.index("-select_streams") + 1] == "a":
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            mock.stdout = json.dumps({"streams": []})
+            return mock
+        # Third call: main ffmpeg transcode
+        mock = MagicMock()
+        mock.returncode = 0
+        mock.stderr = ""
+        return mock
+
+    with patch("subprocess.run", side_effect=mock_run_side_effect) as mock_run:
+        s3_mock = MagicMock()
+        s3_mock.generate_presigned_url.return_value = "https://s3.example.com/uploads/video.mp4"
+        s3_mock.upload_file = MagicMock()
+
+        with patch("builtins.open", MagicMock()), \
+             patch("pathlib.Path.glob", return_value=[]), \
+             patch("pathlib.Path.rglob", return_value=[]), \
+             patch("pathlib.Path.mkdir"), \
+             patch("shutil.rmtree"):
+                transcoder = FFmpegTranscoder(s3_mock, "test-bucket")
+                job = _make_job(["720p"])
+                asyncio.run(transcoder.transcode(job))
+
+        # Find the main ffmpeg command call
+        ffmpeg_calls = [c for c in mock_run.call_args_list
+                        if any("filter_complex" in str(a) for a in c[0][0])]
+        assert len(ffmpeg_calls) > 0
+        ffmpeg_cmd = ffmpeg_calls[0][0][0]
+
+        # Assert audio map is NOT present
+        maps = [ffmpeg_cmd[i+1] for i, arg in enumerate(ffmpeg_cmd) if arg == "-map"]
+        assert "a:0" not in maps, f"Expected no -map a:0 in no-audio transcode, got maps: {maps}"
+
+        # Assert var_stream_map is video-only
+        var_stream_idx = ffmpeg_cmd.index("-var_stream_map")
+        stream_map = ffmpeg_cmd[var_stream_idx + 1]
+        assert ",a:" not in stream_map, f"Expected no audio tracks in var_stream_map, got: {stream_map}"
+
+
+# ─── _run() returns stdout on success ──────────────────────────────────────────
+
+def test_run_returns_stdout():
+    with patch("subprocess.run") as mock_run:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        mock_result.stdout = "output data"
+        mock_run.return_value = mock_result
+
+        result = FFmpegTranscoder._run(["echo", "hello"], label="test")
+        assert result == "output data"

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -52,11 +52,23 @@ interface ShareValidateResponse {
   error?: string
 }
 
+interface CommentAuthor {
+  id: string
+  name: string
+  avatar_url?: string | null
+}
+
+interface GuestAuthor {
+  id: string
+  name: string
+  email?: string
+}
+
 interface GuestComment {
   id: string
   body: string
-  guest_name: string
-  guest_email: string
+  author?: CommentAuthor | null
+  guest_author?: GuestAuthor | null
   created_at: string
   timecode_start?: number | null
 }
@@ -228,16 +240,31 @@ function GuestCommentList({ token, refreshKey }: GuestCommentListProps) {
 
   return (
     <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2.5">
-      {comments.map((comment) => (
+      {comments.map((comment) => {
+        const displayName = comment.guest_author?.name || comment.author?.name || 'Unknown'
+        const avatarUrl = comment.author?.avatar_url ?? null
+        const [imgError, setImgError] = React.useState(false)
+        return (
         <div
           key={comment.id}
           className="rounded-lg bg-white/[0.03] border border-white/5 px-3 py-2.5"
         >
           <div className="flex items-center gap-2 mb-1.5">
             <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-purple-500/20 text-2xs font-medium text-purple-400">
-              {comment.guest_name.charAt(0).toUpperCase()}
+              {avatarUrl && !imgError ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={avatarUrl}
+                  alt=""
+                  className="h-full w-full rounded-full object-cover"
+                  referrerPolicy="no-referrer"
+                  onError={() => setImgError(true)}
+                />
+              ) : (
+                displayName.charAt(0).toUpperCase()
+              )}
             </div>
-            <span className="text-xs font-medium text-zinc-200">{comment.guest_name}</span>
+            <span className="text-xs font-medium text-zinc-200">{displayName}</span>
             {comment.timecode_start != null && (
               <span className="text-2xs text-zinc-500 font-mono bg-white/5 px-1.5 py-0.5 rounded">
                 {Math.floor(comment.timecode_start / 60)}:
@@ -250,7 +277,8 @@ function GuestCommentList({ token, refreshKey }: GuestCommentListProps) {
           </div>
           <p className="text-sm text-zinc-300 leading-relaxed">{comment.body}</p>
         </div>
-      ))}
+        )
+      })}
     </div>
   )
 }
@@ -466,18 +494,99 @@ interface ShareMediaViewerProps {
 }
 
 function ShareMediaViewer({ asset, token, streamUrl, streamLoading }: ShareMediaViewerProps) {
+  const videoRef = React.useRef<HTMLVideoElement>(null)
+  const audioRef = React.useRef<HTMLAudioElement>(null)
+  const [fatalError, setFatalError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!streamUrl || streamLoading) return
+
+    setFatalError(null)
+    const mediaEl = asset.asset_type === 'video' ? videoRef.current : audioRef.current
+    if (!mediaEl) return
+
+    const isHls = streamUrl.includes('.m3u8')
+
+    // Resolve relative stream URLs against API_URL (backend returns /stream/hls/master.m3u8?token=...)
+    const resolvedUrl = streamUrl.startsWith('/')
+      ? `${API_URL}${streamUrl}`
+      : streamUrl
+
+    let hls: any = null
+    let cancelled = false
+
+    function setupHls() {
+      import('hls.js').then(({ default: Hls }) => {
+        if (cancelled) return
+
+        if (isHls && Hls.isSupported()) {
+          hls = new Hls()
+          hls.loadSource(resolvedUrl)
+          hls.attachMedia(mediaEl!)
+
+          hls.on(Hls.Events.ERROR, (_event: any, data: any) => {
+            if (data.fatal) {
+              setFatalError(
+                data.type === Hls.ErrorTypes.NETWORK_ERROR
+                  ? 'Network error loading video'
+                  : data.type === Hls.ErrorTypes.MEDIA_ERROR
+                    ? 'Media decode error'
+                    : `Playback error: ${data.details || data.type}`
+              )
+              if (hls) {
+                hls.destroy()
+                hls = null
+              }
+            }
+          })
+        } else if (mediaEl!.canPlayType && mediaEl!.canPlayType('application/vnd.apple.mpegurl')) {
+          // Safari native HLS
+          mediaEl!.src = resolvedUrl
+        } else {
+          // Direct URL fallback (mp4, mp3, etc.)
+          mediaEl!.src = resolvedUrl
+        }
+      })
+    }
+
+    if (isHls) {
+      setupHls()
+    } else if (mediaEl) {
+      mediaEl.src = resolvedUrl
+    }
+
+    function handleMediaError() {
+      setFatalError('Media playback failed')
+    }
+    mediaEl.addEventListener('error', handleMediaError)
+
+    return () => {
+      cancelled = true
+      mediaEl.removeEventListener('error', handleMediaError)
+      if (hls) {
+        hls.destroy()
+      }
+    }
+  }, [streamUrl, streamLoading, asset.asset_type])
+
   return (
     <div className="flex-1 flex items-center justify-center bg-black min-h-0 overflow-hidden">
       {asset.asset_type === 'video' && (
         <div className="w-full h-full flex items-center justify-center">
           {streamLoading ? (
             <Loader2 className="h-8 w-8 animate-spin text-zinc-500" />
+          ) : fatalError ? (
+            <div className="flex flex-col items-center gap-2">
+              <AlertTriangle className="h-10 w-10 text-red-500" />
+              <p className="text-sm text-red-400">{fatalError}</p>
+            </div>
           ) : streamUrl ? (
             <video
-              src={streamUrl}
+              ref={videoRef}
               controls
               className="max-h-full max-w-full"
               preload="metadata"
+              playsInline
             >
               Your browser does not support video playback.
             </video>
@@ -494,6 +603,11 @@ function ShareMediaViewer({ asset, token, streamUrl, streamLoading }: ShareMedia
         <div className="w-full max-w-2xl px-8">
           {streamLoading ? (
             <Loader2 className="h-6 w-6 animate-spin text-zinc-500 mx-auto" />
+          ) : fatalError ? (
+            <div className="flex flex-col items-center gap-2">
+              <AlertTriangle className="h-10 w-10 text-red-500" />
+              <p className="text-sm text-red-400">{fatalError}</p>
+            </div>
           ) : streamUrl ? (
             <div className="space-y-6">
               <div className="flex flex-col items-center gap-3">
@@ -502,7 +616,7 @@ function ShareMediaViewer({ asset, token, streamUrl, streamLoading }: ShareMedia
                 </div>
                 <p className="text-sm font-medium text-zinc-300">{asset.name}</p>
               </div>
-              <audio src={streamUrl} controls className="w-full">
+              <audio ref={audioRef} controls className="w-full">
                 Your browser does not support audio playback.
               </audio>
             </div>

--- a/apps/web/components/projects/share-create-dialog.tsx
+++ b/apps/web/components/projects/share-create-dialog.tsx
@@ -24,7 +24,7 @@ import {
   LayoutGrid,
 } from 'lucide-react'
 import * as Switch from '@radix-ui/react-switch'
-import { cn, endOfDayISO } from '@/lib/utils'
+import { cn, copyToClipboard, endOfDayISO } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { api } from '@/lib/api'
 import type { AssetResponse, Folder, ShareLink, ShareLinkAppearance } from '@/types'
@@ -79,32 +79,43 @@ function AssetTypeIcon({ type, className }: { type: string; className?: string }
 // ─── Copy button ─────────────────────────────────────────────────────────────
 
 function CopyButton({ text, label }: { text: string; label?: string }) {
-  const [copied, setCopied] = React.useState(false)
+  const [status, setStatus] = React.useState<'idle' | 'copied' | 'failed'>('idle')
 
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Fallback
+  function handleCopy() {
+    const ok = copyToClipboard(text)
+    if (ok) {
+      setStatus('copied')
+      setTimeout(() => setStatus('idle'), 2000)
+    } else {
+      setStatus('failed')
+      setTimeout(() => setStatus('idle'), 3000)
     }
   }
 
   return (
-    <Button variant="secondary" size="sm" onClick={handleCopy}>
-      {copied ? (
-        <>
-          <Check className="h-3.5 w-3.5 text-status-success" />
-          {label ? 'Copied!' : ''}
-        </>
-      ) : (
-        <>
-          <Copy className="h-3.5 w-3.5" />
-          {label ?? ''}
-        </>
-      )}
-    </Button>
+    <>
+      <div className="sr-only" aria-live="polite" role="status">
+        {status === 'copied' ? 'URL copied to clipboard' : status === 'failed' ? 'Copy failed' : ''}
+      </div>
+      <Button variant="secondary" size="sm" onClick={handleCopy}>
+        {status === 'copied' ? (
+          <>
+            <Check className="h-3.5 w-3.5 text-status-success" />
+            {label ? 'Copied!' : ''}
+          </>
+        ) : status === 'failed' ? (
+          <>
+            <X className="h-3.5 w-3.5 text-status-error" />
+            {label ? 'Failed' : ''}
+          </>
+        ) : (
+          <>
+            <Copy className="h-3.5 w-3.5" />
+            {label ?? ''}
+          </>
+        )}
+      </Button>
+    </>
   )
 }
 
@@ -578,6 +589,7 @@ function LinkCreatedPhase({ result, allResults, onSelectResult, onDone, onAdvanc
     setEditingTitle(false)
     setShowSettings(false)
   }, [result.token, result.title])
+  const [urlCopied, setUrlCopied] = React.useState(false)
   const [layout, setLayout] = React.useState<'grid' | 'list'>('grid')
   const titleInputRef = React.useRef<HTMLInputElement>(null)
   const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -716,12 +728,15 @@ function LinkCreatedPhase({ result, allResults, onSelectResult, onDone, onAdvanc
         <div className="flex items-center gap-2 rounded-md border border-border bg-bg-tertiary px-3 py-2">
           <span className="flex-1 truncate font-mono text-xs text-text-primary">{shareUrl}</span>
           <button
-            onClick={async () => {
-              try { await navigator.clipboard.writeText(shareUrl) } catch {}
+            onClick={() => {
+              if (copyToClipboard(shareUrl)) {
+                setUrlCopied(true)
+                setTimeout(() => setUrlCopied(false), 2000)
+              }
             }}
             className="text-text-tertiary hover:text-text-primary transition-colors shrink-0"
           >
-            <Copy className="h-3.5 w-3.5" />
+            {urlCopied ? <Check className="h-3.5 w-3.5 text-status-success" /> : <Copy className="h-3.5 w-3.5" />}
           </button>
           <select
             value={visibility}

--- a/apps/web/components/review/share-dialog.tsx
+++ b/apps/web/components/review/share-dialog.tsx
@@ -17,7 +17,7 @@ import {
   Plus,
   Search,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, copyToClipboard } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { api } from "@/lib/api";
@@ -100,31 +100,40 @@ function PermissionSelect({
 // ─── Copy button ──────────────────────────────────────────────────────────────
 
 function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = React.useState(false);
+  const [status, setStatus] = React.useState<'idle' | 'copied' | 'failed'>('idle');
 
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback
+  function handleCopy() {
+    const ok = copyToClipboard(text);
+    if (ok) {
+      setStatus('copied');
+      setTimeout(() => setStatus('idle'), 2000);
+    } else {
+      setStatus('failed');
+      setTimeout(() => setStatus('idle'), 3000);
     }
   }
 
   return (
-    <button
-      onClick={handleCopy}
-      className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
-      title="Copy to clipboard"
-    >
-      {copied ? (
-        <Check className="h-3.5 w-3.5 text-status-success" />
-      ) : (
-        <Copy className="h-3.5 w-3.5" />
-      )}
-      {copied ? "Copied!" : "Copy"}
-    </button>
+    <>
+      {/* aria-live region for screen reader announcements */}
+      <div className="sr-only" aria-live="polite" role="status">
+        {status === 'copied' ? 'URL copied to clipboard' : status === 'failed' ? 'Copy failed' : ''}
+      </div>
+      <button
+        onClick={handleCopy}
+        className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
+        title="Copy to clipboard"
+      >
+        {status === 'copied' ? (
+          <Check className="h-3.5 w-3.5 text-status-success" />
+        ) : status === 'failed' ? (
+          <X className="h-3.5 w-3.5 text-status-error" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+        {status === 'copied' ? 'Copied!' : status === 'failed' ? 'Failed' : 'Copy'}
+      </button>
+    </>
   );
 }
 

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -102,3 +102,51 @@ export function endOfDayISO(dateStr: string): string {
   d.setHours(23, 59, 59, 999)
   return d.toISOString()
 }
+
+/**
+ * Copy text to clipboard with modern API + fallback.
+ * Handles iOS Safari where execCommand('copy') requires a selected editable element.
+ * Returns true on success, false on failure.
+ */
+export function copyToClipboard(text: string): boolean {
+  // Modern async clipboard API
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).catch(() => {
+      // noop — writeText handles this, fallback not triggered
+    })
+    return true
+  }
+
+  // Fallback for older browsers (including iOS Safari < 13.4)
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.contentEditable = 'true'
+    textarea.readOnly = false
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-9999px'
+    textarea.style.top = '-9999px'
+    document.body.appendChild(textarea)
+
+    // iOS Safari requires selection on editable elements
+    if (navigator.userAgent.includes('iPhone') || navigator.userAgent.includes('iPad')) {
+      textarea.contentEditable = 'true'
+      textarea.readOnly = false
+      const range = document.createRange()
+      range.selectNodeContents(textarea)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      textarea.setSelectionRange(0, text.length)
+    } else {
+      textarea.select()
+      textarea.setSelectionRange(0, text.length)
+    }
+
+    const ok = document.execCommand('copy')
+    document.body.removeChild(textarea)
+    return ok
+  } catch {
+    return false
+  }
+}

--- a/packages/transcoder/ffmpeg_transcoder.py
+++ b/packages/transcoder/ffmpeg_transcoder.py
@@ -25,15 +25,32 @@ class FFmpegTranscoder(BaseTranscoder):
             ExpiresIn=expires_in,
         )
 
+    @staticmethod
+    def _run(cmd: list[str], timeout: int | None = None, label: str = "ffmpeg") -> str:
+        """Run a command, raising RuntimeError with stderr on failure.
+
+        Uses errors='replace' because ffmpeg often echoes input metadata
+        (Latin-1 / Shift-JIS) to stderr, which would break strict UTF-8 decode.
+        """
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, errors='replace', timeout=timeout,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            raise RuntimeError(
+                f"{label} exited {result.returncode}: {stderr or 'no stderr output'}"
+            )
+        return result.stdout
+
     async def get_video_metadata(self, s3_key: str) -> VideoMetadata:
         """Get video metadata using streaming (no full download)."""
         input_url = self._get_presigned_url(s3_key)
         cmd = [
-            "ffprobe", "-v", "quiet", "-print_format", "json",
+            "ffprobe", "-v", "error", "-print_format", "json",
             "-show_streams", "-select_streams", "v:0", input_url,
         ]
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=120)
-        data = json.loads(result.stdout)
+        stdout = self._run(cmd, timeout=120, label="ffprobe")
+        data = json.loads(stdout)
         stream = data["streams"][0]
         fps_parts = stream.get("r_frame_rate", "30/1").split("/")
         fps = float(fps_parts[0]) / float(fps_parts[1])
@@ -55,7 +72,7 @@ class FFmpegTranscoder(BaseTranscoder):
                 "-q:v", "2",
                 f"{thumb_dir}/thumb_%04d.jpg",
             ]
-            subprocess.run(cmd, capture_output=True, check=True, timeout=600)
+            self._run(cmd, timeout=600, label="ffmpeg")
             return [str(p) for p in sorted(Path(thumb_dir).glob("thumb_*.jpg"))]
         finally:
             shutil.rmtree(thumb_dir, ignore_errors=True)
@@ -78,12 +95,22 @@ class FFmpegTranscoder(BaseTranscoder):
         input_url = self._get_presigned_url(job.input_s3_key, expires_in=7200)
 
         try:
-            # 1. Get metadata via streaming (no download)
+            # 1. Get video metadata via streaming (no download)
+            # Note: ffprobe result is used for metadata logging only;
+            # _run() already fail-fasts on non-zero exit.
             cmd = [
-                "ffprobe", "-v", "quiet", "-print_format", "json",
+                "ffprobe", "-v", "error", "-print_format", "json",
                 "-show_streams", "-select_streams", "v:0", input_url,
             ]
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            vid_info = self._run(cmd, timeout=120, label="ffprobe")
+
+            # 2. Check if input has an audio stream
+            audio_cmd = [
+                "ffprobe", "-v", "error", "-print_format", "json",
+                "-show_streams", "-select_streams", "a", input_url,
+            ]
+            audio_result = self._run(audio_cmd, timeout=120, label="ffprobe")
+            has_audio = bool(json.loads(audio_result).get("streams"))
 
             # 3. Build quality ladder based on available qualities
             QUALITY_MAP = {
@@ -113,8 +140,10 @@ class FFmpegTranscoder(BaseTranscoder):
 
             for i, quality in enumerate(qualities):
                 scale, crf = QUALITY_MAP[quality]
+                ffmpeg_cmd += ["-map", f"[{quality}]"]
+                if has_audio:
+                    ffmpeg_cmd += ["-map", "a:0"]
                 ffmpeg_cmd += [
-                    "-map", f"[{quality}]", "-map", "a:0",
                     f"-c:v:{i}", "libx264", f"-crf", str(crf), "-preset", "fast",
                     "-force_key_frames", "expr:gte(t,n_forced*2)",
                 ]
@@ -127,7 +156,10 @@ class FFmpegTranscoder(BaseTranscoder):
                 "-hls_flags", "independent_segments",
                 "-hls_segment_type", "mpegts",
                 "-master_pl_name", "master.m3u8",
-                "-var_stream_map", " ".join(f"v:{i},a:{i}" for i in range(len(qualities))),
+                "-var_stream_map", " ".join(
+                    f"v:{i},a:{i}" if has_audio else f"v:{i}"
+                    for i in range(len(qualities))
+                ),
                 "-hls_segment_filename", str(hls_dir / "%v" / "seg_%03d.ts"),
                 str(hls_dir / "%v" / "playlist.m3u8"),
             ]
@@ -137,7 +169,7 @@ class FFmpegTranscoder(BaseTranscoder):
                 (hls_dir / q).mkdir(exist_ok=True)
 
             # Timeout scales with expected duration - 4 hours for very large files
-            subprocess.run(ffmpeg_cmd, check=True, capture_output=True, timeout=14400)
+            self._run(ffmpeg_cmd, timeout=14400, label="ffmpeg")
 
             # 4. Upload HLS files to S3
             uploaded_keys = []
@@ -159,7 +191,7 @@ class FFmpegTranscoder(BaseTranscoder):
                 "-vf", "fps=0.1", "-q:v", "2", "-frames:v", "1",
                 str(work_dir / "thumb_%04d.jpg"),
             ]
-            subprocess.run(thumb_cmd, check=True, capture_output=True)
+            self._run(thumb_cmd, label="ffmpeg")
             thumbnail_key = f"{job.output_s3_prefix}/thumbnail.jpg"
             if thumb_path.exists():
                 self.s3.upload_file(


### PR DESCRIPTION
## Description

Videos without an audio track (e.g. screen recordings, animations, silent clips) cause the transcoder to fail with `Stream map 'a:0' matches no streams` because `-map a:0` was applied unconditionally.

### Fix

- Probe for audio streams using `ffprobe -select_streams a` before building the ffmpeg command
- Only include `-map a:0` and `var_stream_map` audio entries (`v:{i},a:{i}`) when `has_audio=True`
- Videos without audio now produce video-only HLS output