### PR TITLE
feat: add support for skipping video transcoding during local QC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,5 @@ API_WORKERS=4                  # Gunicorn worker processes (prod only)
 TRANSCODING_CONCURRENCY=2     # Parallel video transcoding jobs (CPU intensive)
 EMAIL_CONCURRENCY=2            # Parallel email sending jobs
 TRANSCODER_ENGINE=ffmpeg
+# Skip FFmpeg transcoding and review uploaded videos as-is (local QC / dev)
+USE_ORIGINAL_VIDEOS=false

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -39,7 +39,9 @@ class Settings(BaseSettings):
     refresh_token_expire_days: int = 7
     frontend_url: str = "http://localhost:3000"
     transcoder_engine: str = "ffmpeg"
-    
+    # Skip FFmpeg HLS transcoding and serve uploaded videos as-is (useful for local QC)
+    use_original_videos: bool = False
+
     # Worker concurrency settings
     transcoding_concurrency: int = 2  # Number of concurrent video transcoding jobs
     email_concurrency: int = 2  # Number of concurrent email sending jobs

--- a/apps/api/routers/upload.py
+++ b/apps/api/routers/upload.py
@@ -20,6 +20,7 @@ from ..schemas.upload import (
     CompleteUploadRequest, CompleteUploadResponse, AbortUploadRequest,
     ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES, mime_to_asset_type,
 )
+from ..config import settings
 
 router = APIRouter(prefix="/upload", tags=["upload"])
 
@@ -144,6 +145,12 @@ def complete_upload(
 
     # Then complete S3 multipart
     complete_multipart_upload(body.s3_key, body.upload_id, [p.model_dump() for p in body.parts])
+
+    asset = db.query(Asset).filter(Asset.id == body.asset_id, Asset.deleted_at.is_(None)).first()
+    if settings.use_original_videos and asset and asset.asset_type == AssetType.video:
+        version.processing_status = ProcessingStatus.ready
+        db.commit()
+        return CompleteUploadResponse(status="ready", asset_id=body.asset_id, version_id=body.version_id)
 
     version.processing_status = ProcessingStatus.processing
     db.commit()

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -83,6 +83,9 @@ def process_asset(self, asset_id: str, version_id: str):
 
 
 def _process_video(db, asset, version, media_file, s3, output_prefix):
+    if settings.use_original_videos:
+        return
+
     from packages.transcoder.ffmpeg_transcoder import FFmpegTranscoder
     from packages.transcoder.base import TranscodeJob
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,6 +80,8 @@ services:
       S3_BUCKET: freeframe
       S3_REGION: us-east-1
       S3_PUBLIC_ENDPOINT: http://localhost:9000
+      # Set to "true" to skip video transcoding and QC the original upload directly
+      USE_ORIGINAL_VIDEOS: ${USE_ORIGINAL_VIDEOS:-false}
     depends_on:
       postgres:
         condition: service_healthy
@@ -108,6 +110,7 @@ services:
       S3_ENDPOINT: http://minio:9000
       S3_BUCKET: freeframe
       S3_REGION: us-east-1
+      USE_ORIGINAL_VIDEOS: ${USE_ORIGINAL_VIDEOS:-false}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Introduced a new configuration option `USE_ORIGINAL_VIDEOS` to allow skipping FFmpeg transcoding and serving uploaded videos as-is for local quality control. Updated relevant files to integrate this feature, including environment variables, Docker configuration, and API logic for handling uploads and processing assets.

## Summary

<!-- Brief description of the changes -->

## Changes

- 

## Testing

- [x] Backend tests pass (`python -m pytest apps/api/tests/ -v`)
- [x] Frontend builds (`pnpm --filter web build`)
- [x] Tested manually in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->
