### PR TITLE
Add NAS/MinIO storage docs and NLE comment export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,21 @@ S3_ENDPOINT=http://localhost:9000
 # S3_REGION=us-east-1
 # S3_ENDPOINT=                 # Set for non-AWS (e.g., https://acct.r2.cloudflarestorage.com)
 
+# ─── NAS storage via MinIO (Synology / QNAP / TrueNAS / Unraid) ─────
+# Run MinIO on your NAS (see docs/nas-storage.md) so media lives on NAS
+# disks while FreeFrame keeps talking S3. Keep S3_STORAGE=minio so the
+# app sends requests to your endpoint instead of AWS.
+#   S3_STORAGE=minio
+#   S3_BUCKET=freeframe
+#   S3_ACCESS_KEY=<MinIO access key you create on the NAS>
+#   S3_SECRET_KEY=<MinIO secret key you create on the NAS>
+#   S3_REGION=us-east-1
+#   S3_ENDPOINT=http://<nas-ip-or-host>:9000          # reached by the API/worker
+#   S3_PUBLIC_ENDPOINT=http://<nas-ip-or-host>:9000   # reached by the browser
+# If the browser and the API reach the NAS at the same address (typical on a
+# LAN), S3_ENDPOINT and S3_PUBLIC_ENDPOINT are identical. Use https:// URLs if
+# you put MinIO behind TLS.
+
 # ─── Auth ───────────────────────────────────────────────────
 # Prod: generate a strong secret →  openssl rand -hex 64
 JWT_SECRET=change-me-to-a-secure-random-string

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ For the full guide including **SSL setup**, **bring-your-own infrastructure** (e
 | Guide | Description |
 |-------|-------------|
 | [Production Deployment](docs/deployment.md) | SSL, bring-your-own infra, scaling, troubleshooting |
+| [NAS Storage](docs/nas-storage.md) | Store media on a NAS (Synology/QNAP/TrueNAS/Unraid) via MinIO |
 | [Architecture](docs/architecture.md) | System design, data flow, media pipeline, permissions |
 | [Contributing](docs/contributing.md) | Dev setup, testing, code style, PR process |
 | [Environment Variables](.env.example) | Full config reference with comments |

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -5,13 +5,14 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from ..config import settings
 from ..database import get_db
 from ..middleware.auth import get_current_user, get_optional_user
 from ..middleware.share_auth import get_share_link
-from ..models.asset import Asset
+from ..models.asset import Asset, AssetVersion, MediaFile, ProcessingStatus
 from ..models.project import ProjectMember, ProjectRole
 from ..models.comment import Annotation, Comment, CommentAttachment, CommentReaction
 from ..models.activity import Mention, Notification, NotificationType, ActivityLog, ActivityAction
@@ -32,6 +33,7 @@ from ..schemas.comment import (
     ReactionResponse,
 )
 from ..services import s3_service
+from ..services import comment_export
 from ..services.permissions import require_asset_access, validate_share_link
 from ..tasks.email_tasks import send_mention_email, send_comment_email
 from ..tasks.celery_app import send_task_safe
@@ -214,6 +216,107 @@ def list_comments(
         query = query.filter(Comment.visibility == visibility)
     top_level = query.order_by(Comment.created_at).all()
     return [_build_comment_response(c, db, current_user_id=current_user.id) for c in top_level]
+
+
+def _resolve_export_version(db: Session, asset: Asset, version_id: Optional[uuid.UUID]) -> AssetVersion:
+    """Return the requested version, or the latest ready version for the asset."""
+    if version_id:
+        version = db.query(AssetVersion).filter(
+            AssetVersion.id == version_id,
+            AssetVersion.asset_id == asset.id,
+            AssetVersion.deleted_at.is_(None),
+        ).first()
+        if not version:
+            raise HTTPException(status_code=404, detail="Version not found")
+        return version
+    version = db.query(AssetVersion).filter(
+        AssetVersion.asset_id == asset.id,
+        AssetVersion.deleted_at.is_(None),
+        AssetVersion.processing_status == ProcessingStatus.ready,
+    ).order_by(AssetVersion.version_number.desc()).first()
+    if not version:
+        raise HTTPException(status_code=404, detail="No ready version found for this asset")
+    return version
+
+
+def _author_name(db: Session, comment: Comment) -> str:
+    if comment.author_id:
+        user = db.query(User).filter(User.id == comment.author_id).first()
+        if user:
+            return user.name
+    if comment.guest_author_id:
+        guest = db.query(GuestUser).filter(GuestUser.id == comment.guest_author_id).first()
+        if guest:
+            return guest.name
+    return "Reviewer"
+
+
+@router.get("/assets/{asset_id}/comments/export")
+def export_comments(
+    asset_id: uuid.UUID,
+    format: str = "csv",
+    version_id: Optional[uuid.UUID] = None,
+    fps: Optional[float] = None,
+    include_resolved: bool = True,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Export timecoded comments as an NLE marker file.
+
+    `format` is one of: csv, edl, fcpxml, avid. Timecodes are frame-accurate,
+    derived from the media's frame rate (override with `fps` if the source is
+    unknown). Only top-level comments carrying a timecode are exported.
+    """
+    fmt = format.lower()
+    if fmt not in comment_export.FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported format '{format}'. Use one of: {', '.join(comment_export.FORMATS)}",
+        )
+
+    asset = _get_asset(db, asset_id)
+    require_asset_access(db, asset, current_user)
+    version = _resolve_export_version(db, asset, version_id)
+
+    media_file = db.query(MediaFile).filter(MediaFile.version_id == version.id).first()
+    effective_fps = fps or (media_file.fps if media_file and media_file.fps else None) or 30.0
+    width = (media_file.width if media_file else None) or 1920
+    height = (media_file.height if media_file else None) or 1080
+    duration = (media_file.duration_seconds if media_file else None) or 0.0
+
+    query = db.query(Comment).filter(
+        Comment.asset_id == asset_id,
+        Comment.version_id == version.id,
+        Comment.parent_id.is_(None),
+        Comment.deleted_at.is_(None),
+        Comment.timecode_start.isnot(None),
+    )
+    if not include_resolved:
+        query = query.filter(Comment.resolved.is_(False))
+    comments = query.order_by(Comment.timecode_start).all()
+
+    markers = [
+        comment_export.Marker(
+            seconds=c.timecode_start,
+            end_seconds=c.timecode_end,
+            author=_author_name(db, c),
+            body=c.body,
+            resolved=c.resolved,
+            created_at=c.created_at,
+        )
+        for c in comments
+    ]
+
+    content, media_type, filename = comment_export.export(
+        fmt, markers, asset.name, effective_fps,
+        width=width, height=height, duration_seconds=duration,
+    )
+
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.post("/assets/{asset_id}/comments", response_model=CommentResponse, status_code=status.HTTP_201_CREATED)

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -1,0 +1,230 @@
+"""Export timecoded comments as NLE marker files.
+
+Produces marker/locator files that import into the major editors:
+
+- ``csv``     Generic spreadsheet-friendly CSV (also handy for Premiere/Resolve).
+- ``edl``     CMX3600 EDL with ``*LOC:`` marker lines — DaVinci Resolve, Avid,
+              Premiere all read markers from these.
+- ``fcpxml``  Final Cut Pro X FCPXML markers (also imported by Resolve/Premiere).
+- ``avid``    Avid Media Composer tab-delimited locator (.txt) file.
+
+Timecodes are non-drop-frame (SMPTE ``HH:MM:SS:FF``) computed from the media's
+frame rate. Comment times are stored in seconds, so a frame rate is required for
+frame accuracy — the caller supplies it from the media file (defaulting to 30).
+"""
+
+import csv as _csv
+import io
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from xml.sax.saxutils import escape, quoteattr
+
+
+@dataclass
+class Marker:
+    """A single exportable comment marker."""
+    seconds: float
+    end_seconds: Optional[float]
+    author: str
+    body: str
+    resolved: bool
+    created_at: Optional[datetime]
+
+
+# ── Timecode helpers ────────────────────────────────────────────────────────
+
+def nominal_fps(fps: float) -> int:
+    """Integer frame count per second used for SMPTE timecodes (e.g. 30 for 29.97)."""
+    return max(1, round(fps))
+
+
+def seconds_to_tc(seconds: float, fps: float) -> str:
+    """Convert seconds to non-drop-frame SMPTE timecode ``HH:MM:SS:FF``."""
+    n = nominal_fps(fps)
+    total_frames = int(round(max(0.0, seconds) * fps))
+    frames = total_frames % n
+    total_seconds = total_frames // n
+    ss = total_seconds % 60
+    mm = (total_seconds // 60) % 60
+    hh = total_seconds // 3600
+    return f"{hh:02d}:{mm:02d}:{ss:02d}:{frames:02d}"
+
+
+def _frame_duration(fps: float) -> tuple[int, int]:
+    """Return (numerator, denominator) seconds-per-frame for FCPXML rational time.
+
+    Integer rates -> 1/fps. NTSC rates (23.976, 29.97, 59.94) -> 1001/(nominal*1000).
+    """
+    n = nominal_fps(fps)
+    if abs(fps - n) < 0.01:
+        return (1, n)
+    # NTSC fractional rate check: nominal * 1000 / 1001
+    if abs(fps - (n * 1000.0 / 1001.0)) < 0.1:
+        return (1001, n * 1000)
+    # Fallback: microsecond-resolution rational
+    return (max(1, round(1_000_000 / fps)), 1_000_000)
+
+
+def _to_frames(seconds: float, fps: float) -> int:
+    return int(round(max(0.0, seconds) * fps))
+
+
+def _one_line(text: str) -> str:
+    """Flatten a comment body to a single line for line-oriented formats."""
+    return " ".join((text or "").split())
+
+
+# ── CSV ─────────────────────────────────────────────────────────────────────
+
+def build_csv(markers: list[Marker], asset_name: str, fps: float) -> str:
+    buf = io.StringIO()
+    w = _csv.writer(buf)
+    w.writerow(["Timecode In", "Timecode Out", "Seconds", "Frame", "Author",
+                "Comment", "Resolved", "Created At"])
+    for m in markers:
+        tc_in = seconds_to_tc(m.seconds, fps)
+        tc_out = seconds_to_tc(m.end_seconds, fps) if m.end_seconds is not None else ""
+        w.writerow([
+            tc_in,
+            tc_out,
+            f"{m.seconds:.3f}",
+            _to_frames(m.seconds, fps),
+            m.author,
+            _one_line(m.body),
+            "yes" if m.resolved else "no",
+            m.created_at.isoformat() if m.created_at else "",
+        ])
+    return buf.getvalue()
+
+
+# ── EDL (CMX3600) ───────────────────────────────────────────────────────────
+
+def build_edl(markers: list[Marker], asset_name: str, fps: float) -> str:
+    """CMX3600 EDL with one 1-frame event + ``*LOC:`` marker line per comment."""
+    n = nominal_fps(fps)
+    lines = [f"TITLE: {_one_line(asset_name)[:70]}", "FCM: NON-DROP FRAME", ""]
+    for i, m in enumerate(markers, start=1):
+        start_f = _to_frames(m.seconds, fps)
+        if m.end_seconds is not None:
+            end_f = max(_to_frames(m.end_seconds, fps), start_f + 1)
+        else:
+            end_f = start_f + 1
+        tc_in = seconds_to_tc(start_f / fps, fps)
+        tc_out = seconds_to_tc(end_f / fps, fps)
+        event = f"{i:03d}"
+        lines.append(f"{event}  AX       V     C        {tc_in} {tc_out} {tc_in} {tc_out}")
+        # Marker color/name/comment. Resolve/Avid read the *LOC line as a marker.
+        note = _one_line(f"{m.body} ({m.author})")
+        lines.append(f"*LOC: {tc_in} WHITE  {note}")
+        lines.append(f"* FROM CLIP NAME: {_one_line(asset_name)}")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+# ── Avid locator (.txt) ─────────────────────────────────────────────────────
+
+def build_avid(markers: list[Marker], fps: float, track: str = "V1",
+               color: str = "red") -> str:
+    """Avid Media Composer tab-delimited locator file.
+
+    Columns: Name(author)  Timecode  Track  Color  Comment
+    """
+    rows = []
+    for m in markers:
+        tc = seconds_to_tc(m.seconds, fps)
+        comment = _one_line(m.body)
+        rows.append("\t".join([m.author or "Reviewer", tc, track, color, comment]))
+    return "\n".join(rows) + "\n"
+
+
+# ── FCPXML ──────────────────────────────────────────────────────────────────
+
+def build_fcpxml(markers: list[Marker], asset_name: str, fps: float,
+                 width: int, height: int, duration_seconds: float) -> str:
+    fd_num, fd_den = _frame_duration(fps)
+    frame_dur = f"{fd_num}/{fd_den}s"
+
+    def rational(seconds: float) -> str:
+        frames = _to_frames(seconds, fps)
+        num = frames * fd_num
+        return f"{num}/{fd_den}s" if num else "0s"
+
+    total_frames = max(1, _to_frames(duration_seconds or 0, fps))
+    seq_duration = f"{total_frames * fd_num}/{fd_den}s"
+    w = width or 1920
+    h = height or 1080
+    name = _one_line(asset_name) or "FreeFrame Asset"
+
+    marker_xml = []
+    for m in markers:
+        start = rational(m.seconds)
+        if m.end_seconds is not None and m.end_seconds > m.seconds:
+            dur_frames = max(1, _to_frames(m.end_seconds, fps) - _to_frames(m.seconds, fps))
+        else:
+            dur_frames = 1
+        dur = f"{dur_frames * fd_num}/{fd_den}s"
+        value = _one_line(f"{m.body} - {m.author}") if m.author else _one_line(m.body)
+        completed = ' completed="1"' if m.resolved else ""
+        # Resolved comments export as to-do markers so their state survives.
+        tag = "marker"
+        marker_xml.append(
+            f'          <{tag} start={quoteattr(start)} duration={quoteattr(dur)} '
+            f'value={quoteattr(value or "Comment")}{completed}/>'
+        )
+    markers_block = "\n".join(marker_xml)
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fcpxml>
+<fcpxml version="1.9">
+  <resources>
+    <format id="r1" name="FFExportFormat" frameDuration="{frame_dur}" width="{w}" height="{h}"/>
+    <asset id="r2" name={quoteattr(name)} start="0s" duration="{seq_duration}" hasVideo="1" format="r1" videoSources="1"/>
+  </resources>
+  <library>
+    <event name="FreeFrame Export">
+      <project name={quoteattr(name + " - Comments")}>
+        <sequence format="r1" duration="{seq_duration}" tcStart="0s" tcFormat="NDF">
+          <spine>
+            <asset-clip ref="r2" name={quoteattr(name)} offset="0s" start="0s" duration="{seq_duration}" format="r1">
+{markers_block}
+            </asset-clip>
+          </spine>
+        </sequence>
+      </project>
+    </event>
+  </library>
+</fcpxml>
+"""
+
+
+# ── Dispatcher ──────────────────────────────────────────────────────────────
+
+FORMATS = {
+    "csv":    ("text/csv", "csv"),
+    "edl":    ("application/octet-stream", "edl"),
+    "avid":   ("text/plain", "txt"),
+    "fcpxml": ("application/xml", "fcpxml"),
+}
+
+
+def export(fmt: str, markers: list[Marker], asset_name: str, fps: float,
+           width: int = 1920, height: int = 1080,
+           duration_seconds: float = 0.0) -> tuple[str, str, str]:
+    """Build the export. Returns (content, media_type, filename)."""
+    if fmt not in FORMATS:
+        raise ValueError(f"Unsupported format: {fmt}")
+    media_type, ext = FORMATS[fmt]
+
+    if fmt == "csv":
+        content = build_csv(markers, asset_name, fps)
+    elif fmt == "edl":
+        content = build_edl(markers, asset_name, fps)
+    elif fmt == "avid":
+        content = build_avid(markers, fps)
+    else:  # fcpxml
+        content = build_fcpxml(markers, asset_name, fps, width, height, duration_seconds)
+
+    safe = "".join(c if c.isalnum() or c in "-_ " else "_" for c in (asset_name or "comments")).strip() or "comments"
+    filename = f"{safe}_comments.{ext}"
+    return content, media_type, filename

--- a/apps/api/tests/test_comment_export.py
+++ b/apps/api/tests/test_comment_export.py
@@ -1,0 +1,119 @@
+"""Unit tests for NLE comment export (pure — no DB/S3 required)."""
+
+import datetime
+import xml.dom.minidom as minidom
+
+from apps.api.services import comment_export as ce
+
+
+def _markers():
+    return [
+        ce.Marker(
+            seconds=2.0,
+            end_seconds=4.5,
+            author="Thoryn Smit",
+            body="Fix the color grade here, too warm",
+            resolved=False,
+            created_at=datetime.datetime(2026, 7, 6, 12, 0, 0),
+        ),
+        ce.Marker(
+            seconds=61.53,
+            end_seconds=None,
+            author="Guest Reviewer",
+            body="Audio pop at this cut & <clip>",
+            resolved=True,
+            created_at=datetime.datetime(2026, 7, 6, 12, 5, 0),
+        ),
+    ]
+
+
+# ── Timecode math ────────────────────────────────────────────────────────────
+
+def test_seconds_to_tc_integer_fps():
+    assert ce.seconds_to_tc(0, 25) == "00:00:00:00"
+    assert ce.seconds_to_tc(1, 25) == "00:00:01:00"
+    # 1 hour + 1 minute + 1 second + 12 frames at 24fps
+    assert ce.seconds_to_tc(3661 + 12 / 24, 24) == "01:01:01:12"
+
+
+def test_seconds_to_tc_ntsc():
+    # 29.97 non-drop rolls frame count with a nominal 30-frame second
+    assert ce.seconds_to_tc(1, 29.97) == "00:00:01:00"
+    assert ce.seconds_to_tc(0, 29.97) == "00:00:00:00"
+
+
+def test_frame_duration_rationals():
+    assert ce._frame_duration(25) == (1, 25)
+    assert ce._frame_duration(30) == (1, 30)
+    assert ce._frame_duration(29.97) == (1001, 30000)
+    assert ce._frame_duration(23.976) == (1001, 24000)
+
+
+# ── Formats ──────────────────────────────────────────────────────────────────
+
+def test_csv_has_header_and_rows():
+    content, media_type, filename = ce.export("csv", _markers(), "Hero Spot v3", 30)
+    assert media_type == "text/csv"
+    assert filename.endswith(".csv")
+    lines = content.strip().splitlines()
+    assert lines[0].startswith("Timecode In,Timecode Out")
+    assert len(lines) == 3  # header + 2 markers
+    assert "Thoryn Smit" in content
+    assert "yes" in content  # resolved marker
+
+
+def test_edl_structure():
+    content, _, filename = ce.export("edl", _markers(), "Hero Spot v3", 29.97)
+    assert filename.endswith(".edl")
+    assert "TITLE: Hero Spot v3" in content
+    assert "FCM: NON-DROP FRAME" in content
+    assert "*LOC:" in content
+    # One event line per marker (events numbered 001, 002)
+    assert "001  AX" in content
+    assert "002  AX" in content
+
+
+def test_avid_is_tab_delimited():
+    content, media_type, filename = ce.export("avid", _markers(), "Hero Spot v3", 25)
+    assert filename.endswith(".txt")
+    first = content.splitlines()[0].split("\t")
+    # Name, Timecode, Track, Color, Comment
+    assert len(first) == 5
+    assert first[0] == "Thoryn Smit"
+    assert first[2] == "V1"
+
+
+def test_fcpxml_is_wellformed_and_escapes():
+    content, media_type, filename = ce.export(
+        "fcpxml", _markers(), "Spot & <Test>", 29.97, 1920, 1080, 90.0
+    )
+    assert filename.endswith(".fcpxml")
+    # Parses as valid XML even with & and < in names/bodies
+    doc = minidom.parseString(content)
+    markers = doc.getElementsByTagName("marker")
+    assert len(markers) == 2
+    # Resolved comment exports as a completed to-do marker
+    completed = [m for m in markers if m.getAttribute("completed") == "1"]
+    assert len(completed) == 1
+    # Marker start values land on exact frame boundaries (multiples of frameDuration)
+    for m in markers:
+        start = m.getAttribute("start")  # e.g. "60060/30000s"
+        num = int(start.split("/")[0])
+        assert num % 1001 == 0
+
+
+def test_unsupported_format_raises():
+    try:
+        ce.export("srt", _markers(), "x", 30)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for unsupported format")
+
+
+def test_empty_markers_still_produces_valid_output():
+    for fmt in ("csv", "edl", "avid", "fcpxml"):
+        content, _, _ = ce.export(fmt, [], "Empty", 30, duration_seconds=10.0)
+        assert isinstance(content, str) and content
+        if fmt == "fcpxml":
+            minidom.parseString(content)  # must remain well-formed

--- a/apps/web/app/(dashboard)/projects/[id]/assets/[assetId]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/assets/[assetId]/page.tsx
@@ -445,6 +445,7 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
                   <CommentPanel
                     comments={comments as any}
                     currentUserId={user?.id}
+                    assetId={asset.id}
                     onResolve={resolveComment}
                     onDelete={deleteComment}
                     onAddReaction={addReaction}

--- a/apps/web/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/page.tsx
@@ -997,6 +997,7 @@ export default function ProjectDetailPage() {
                       <CommentPanel
                         comments={comments as any}
                         currentUserId={user?.id}
+                        assetId={selectedAsset.id}
                         onResolve={resolveComment}
                         onDelete={deleteComment}
                         onAddReaction={addReaction}

--- a/apps/web/components/review/comment-panel.tsx
+++ b/apps/web/components/review/comment-panel.tsx
@@ -26,8 +26,10 @@ import {
   Check,
   Send,
   Lock,
+  Download,
 } from "lucide-react";
 import { cn, formatTime, formatRelativeTime } from "@/lib/utils";
+import { downloadToDisk } from "@/lib/api";
 import { useReviewStore } from "@/stores/review-store";
 import type { CommentWithReplies } from "@/hooks/use-comments";
 
@@ -37,6 +39,8 @@ interface CommentPanelProps {
   comments: CommentWithReplies[];
   isLoading?: boolean;
   currentUserId?: string;
+  /** When set, shows the "Export comments" button (NLE marker download). */
+  assetId?: string;
   onResolve: (commentId: string) => Promise<void>;
   onDelete: (commentId: string) => Promise<void>;
   onAddReaction: (commentId: string, emoji: string) => Promise<void>;
@@ -215,6 +219,87 @@ function CommentMenu({
           <Trash2 className="h-3.5 w-3.5" />
           Delete
         </button>
+      </Dropdown>
+    </div>
+  );
+}
+
+// ─── Export menu (download comments for NLE import) ──────────────────────────
+
+const EXPORT_FORMATS: { id: string; label: string; hint: string }[] = [
+  { id: "csv", label: "Spreadsheet", hint: "CSV" },
+  { id: "edl", label: "EDL", hint: "Resolve / Avid / Premiere" },
+  { id: "fcpxml", label: "Final Cut Pro", hint: "FCPXML" },
+  { id: "avid", label: "Avid markers", hint: ".txt locators" },
+];
+
+function ExportMenu({
+  assetId,
+  versionId,
+}: {
+  assetId: string;
+  versionId?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [busy, setBusy] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function handleExport(fmt: string) {
+    setBusy(fmt);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ format: fmt });
+      if (versionId) params.set("version_id", versionId);
+      await downloadToDisk(
+        `/assets/${assetId}/comments/export?${params.toString()}`,
+      );
+      setOpen(false);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Export failed. Please try again.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        className={cn(
+          "h-7 w-7 flex items-center justify-center rounded-md transition-colors",
+          open
+            ? "text-accent bg-accent/10"
+            : "text-text-tertiary hover:text-text-secondary hover:bg-bg-tertiary",
+        )}
+        title="Export comments"
+        onClick={() => setOpen((p) => !p)}
+      >
+        <Download className="h-4 w-4" />
+      </button>
+      <Dropdown open={open} onClose={() => setOpen(false)} align="right" className="w-60">
+        <div className="px-3 py-2 text-[11px] text-text-tertiary uppercase tracking-wider font-medium">
+          Export comments as...
+        </div>
+        {EXPORT_FORMATS.map((f) => (
+          <button
+            key={f.id}
+            disabled={busy !== null}
+            className="flex w-full items-center justify-between gap-2 px-3 py-2 text-[13px] text-text-secondary hover:bg-bg-tertiary transition-colors disabled:opacity-50"
+            onClick={() => handleExport(f.id)}
+          >
+            <span className="font-medium text-text-primary">{f.label}</span>
+            <span className="text-[11px] text-text-tertiary">
+              {busy === f.id ? "Preparing…" : f.hint}
+            </span>
+          </button>
+        ))}
+        <div className="border-t border-border mt-1 pt-1.5 px-3 pb-1.5 text-[11px] text-text-tertiary leading-snug">
+          Frame-accurate timecoded comments for the current version.
+        </div>
+        {error && (
+          <div className="px-3 pb-2 text-[11px] text-red-400">{error}</div>
+        )}
       </Dropdown>
     </div>
   );
@@ -750,6 +835,7 @@ export function CommentPanel({
   comments,
   isLoading,
   currentUserId,
+  assetId,
   onResolve,
   onDelete,
   onAddReaction,
@@ -761,6 +847,7 @@ export function CommentPanel({
   const focusedCommentId = useReviewStore((s) => s.focusedCommentId);
   const setFocusedCommentId = useReviewStore((s) => s.setFocusedCommentId);
   const setActiveAnnotation = useReviewStore((s) => s.setActiveAnnotation);
+  const currentVersion = useReviewStore((s) => s.currentVersion);
 
   // Toolbar state
   const [visibility, setVisibility] = React.useState<CommentVisibility>("all");
@@ -1113,6 +1200,11 @@ export function CommentPanel({
           >
             <Search className="h-4 w-4" />
           </button>
+
+          {/* Export comments for NLE import */}
+          {assetId && (
+            <ExportMenu assetId={assetId} versionId={currentVersion?.id} />
+          )}
 
         </div>
       </div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -131,6 +131,55 @@ async function uploadRequest<T>(path: string, formData: FormData): Promise<T> {
   return text ? (JSON.parse(text) as T) : (undefined as unknown as T)
 }
 
+async function downloadFile(path: string): Promise<{ blob: Blob; filename: string }> {
+  const buildHeaders = (token: string | null): Record<string, string> => {
+    const headers: Record<string, string> = {}
+    if (token) headers['Authorization'] = `Bearer ${token}`
+    return headers
+  }
+
+  const execute = async (token: string | null): Promise<Response> =>
+    fetch(`${API_URL}${path}`, { headers: buildHeaders(token) })
+
+  let token = getAccessToken()
+  let response = await execute(token)
+
+  if (response.status === 401) {
+    const newToken = await refreshAccessToken()
+    if (newToken) response = await execute(newToken)
+  }
+
+  if (!response.ok) {
+    let detail = response.statusText
+    try {
+      const errorBody = await response.json()
+      if (errorBody?.detail) detail = typeof errorBody.detail === 'string' ? errorBody.detail : JSON.stringify(errorBody.detail)
+    } catch {
+      // ignore
+    }
+    throw new ApiError(response.status, detail)
+  }
+
+  const blob = await response.blob()
+  const cd = response.headers.get('content-disposition') || ''
+  const match = cd.match(/filename\*?=(?:UTF-8'')?"?([^";]+)"?/i)
+  const filename = match ? decodeURIComponent(match[1]) : 'download'
+  return { blob, filename }
+}
+
+/** Fetch an authenticated file and trigger a browser download. */
+export async function downloadToDisk(path: string, fallbackName?: string): Promise<void> {
+  const { blob, filename } = await downloadFile(path)
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename || fallbackName || 'download'
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
 export const api = {
   get: <T>(path: string, options?: RequestOptions) =>
     request<T>('GET', path, undefined, options),

--- a/docs/nas-storage.md
+++ b/docs/nas-storage.md
@@ -1,0 +1,154 @@
+# NAS Storage (MinIO)
+
+FreeFrame stores all media (uploads, transcoded HLS, thumbnails) through the **S3
+API**. To keep your media physically on a NAS, run **MinIO** — a small
+open-source S3-compatible server — on the NAS and point it at a folder on your
+NAS volumes. FreeFrame then talks S3 to the NAS, so uploads, video streaming and
+thumbnails keep working exactly as designed, **with no application code changes**.
+
+```
+Browser ──uploads/streams──►  MinIO (on the NAS)  ──stores files──►  NAS disks
+FreeFrame API/worker ─S3 API─►  http://<nas-ip>:9000
+```
+
+---
+
+## 1. Run MinIO on the NAS
+
+Pick the path for your NAS. In all cases you are creating a **data folder** on the
+NAS and exposing it on **port 9000** (S3 API) and **9001** (web console).
+
+### Synology (DSM 7+)
+
+1. Open **Container Manager** → **Registry**, search `minio/minio`, download the
+   `latest` tag.
+2. Create a shared folder for the data, e.g. `/volume1/freeframe`.
+3. **Container Manager → Container → Create**, image `minio/minio`:
+   - **Volume:** map `/volume1/freeframe` → `/data`.
+   - **Port:** `9000 → 9000` and `9001 → 9001`.
+   - **Environment:**
+     - `MINIO_ROOT_USER` = a username you choose (this becomes `S3_ACCESS_KEY`)
+     - `MINIO_ROOT_PASSWORD` = a strong password (this becomes `S3_SECRET_KEY`)
+   - **Command / Execution:** `server /data --console-address ":9001"`
+
+### QNAP
+
+Use **Container Station** → **Create Application** with the Compose snippet in
+§2 below (Container Station accepts Docker Compose YAML directly).
+
+### TrueNAS SCALE
+
+**Apps → Discover Apps → Custom App** (or the community MinIO chart). Set the data
+storage to a dataset on your pool, the credentials as above, and expose ports
+9000/9001.
+
+### Unraid
+
+**Apps (Community Applications)** → search **MinIO** → install the template. Set
+the appdata/data path to a share on the array, set the root user/password, and
+map ports 9000/9001.
+
+### Any NAS with Docker / Portainer
+
+```yaml
+# minio-compose.yml — run on the NAS
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"   # S3 API — FreeFrame connects here
+      - "9001:9001"   # Web console — for you to manage buckets
+    environment:
+      MINIO_ROOT_USER: freeframe          # becomes S3_ACCESS_KEY
+      MINIO_ROOT_PASSWORD: change-me-long  # becomes S3_SECRET_KEY
+    volumes:
+      - /path/on/nas/freeframe:/data       # media lives here on the NAS
+    restart: unless-stopped
+```
+
+```bash
+docker compose -f minio-compose.yml up -d
+```
+
+> If your NAS cannot run Docker at all, MinIO also ships as a single binary
+> (`minio server /path/on/nas`), but Docker is the supported, low-maintenance
+> route. If Docker is impossible on your NAS, use the native filesystem backend
+> instead (out of scope here) or mount the NAS share into the FreeFrame host and
+> run MinIO there against the mount.
+
+---
+
+## 2. Create the bucket
+
+Open the MinIO console at `http://<nas-ip>:9001`, log in with the root
+user/password, and **create a bucket** named `freeframe` (or whatever you set in
+`S3_BUCKET`). FreeFrame also tries to create the bucket on startup, but making it
+yourself avoids permission surprises.
+
+---
+
+## 3. Point FreeFrame at the NAS
+
+In your `.env.prod` (or `.env` for dev), set:
+
+```bash
+S3_STORAGE=minio        # keep "minio" — NOT "s3". This tells FreeFrame to use S3_ENDPOINT.
+S3_BUCKET=freeframe
+S3_ACCESS_KEY=freeframe            # = MINIO_ROOT_USER
+S3_SECRET_KEY=change-me-long       # = MINIO_ROOT_PASSWORD
+S3_REGION=us-east-1
+S3_ENDPOINT=http://<nas-ip>:9000        # how the API/worker reaches the NAS
+S3_PUBLIC_ENDPOINT=http://<nas-ip>:9000  # how the browser reaches the NAS
+```
+
+- **`S3_STORAGE` must stay `minio`.** Setting it to `s3` makes FreeFrame ignore
+  `S3_ENDPOINT` and talk to real AWS.
+- **`S3_ENDPOINT`** is used server-side (API + transcoding worker) to read/write
+  objects. Use the address those containers can reach — usually the NAS LAN IP.
+- **`S3_PUBLIC_ENDPOINT`** is baked into presigned URLs the **browser** uses for
+  direct uploads and HLS segment downloads. It must be reachable from users'
+  machines. On a LAN this is the same NAS IP; if FreeFrame is exposed over the
+  internet, this must be a publicly reachable MinIO address (see §5).
+
+If both FreeFrame and the browser reach the NAS at the same address, the two
+endpoints are identical.
+
+Restart FreeFrame:
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+```
+
+---
+
+## 4. Verify
+
+1. Upload a video in FreeFrame. In the MinIO console you should see objects appear
+   under `raw/...` immediately, then `processed/...` once transcoding finishes.
+2. Play the video — HLS segments stream from the NAS.
+3. Confirm the files are on the NAS volume you mapped to `/data`.
+
+If uploads start but stall, or playback 403s, it's almost always
+`S3_PUBLIC_ENDPOINT` pointing somewhere the browser can't reach — see below.
+
+---
+
+## 5. Notes & gotchas
+
+- **Two endpoints, one cause of 90% of issues.** Server-side traffic uses
+  `S3_ENDPOINT`; browser traffic uses `S3_PUBLIC_ENDPOINT`. If the browser can't
+  reach the NAS address in `S3_PUBLIC_ENDPOINT`, uploads/streaming fail even
+  though the server side is fine.
+- **CORS is handled automatically.** On startup FreeFrame sets a CORS policy and a
+  public-read policy on the `processed/` prefix of the bucket (for MinIO
+  endpoints). The MinIO root credentials have permission to do this.
+- **Exposing over the internet / HTTPS.** For remote reviewers, put MinIO behind a
+  reverse proxy with TLS (e.g. Traefik or your NAS's built-in reverse proxy) and
+  set `S3_PUBLIC_ENDPOINT=https://media.yourdomain.com`. Keep `S3_ENDPOINT` on the
+  internal address for speed.
+- **Backups.** Your media now lives in the MinIO data folder on the NAS — include
+  that folder (and your Postgres volume) in the NAS backup/snapshot schedule.
+- **Performance.** Transcoding streams the source from MinIO over the network;
+  wired gigabit (or better) between the FreeFrame host and the NAS is recommended
+  for large 4K files.


### PR DESCRIPTION
Two customizations:

1. NAS storage via MinIO — no app code change needed since FreeFrame already talks S3. Adds docs/nas-storage.md (Synology/QNAP/TrueNAS/ Unraid setup) and a NAS config block in .env.example.

2. Comment export for NLEs — download timecoded comments as markers for Avid, DaVinci Resolve, Premiere, and Final Cut. New pure service comment_export.py produces CSV, EDL (CMX3600), FCPXML, and Avid tab-delimited locator files with frame-accurate non-drop timecodes derived from MediaFile.fps. Endpoint: GET /assets/{asset_id}/comments/export?format=&version_id=&fps= UI adds an export dropdown to the comment panel toolbar, backed by a new downloadToDisk() authed-blob helper in lib/api.ts. Unit tests in test_comment_export.py.

## Summary

<!-- Brief description of the changes -->

## Changes

- 

## Testing

- [ ] Backend tests pass (`python -m pytest apps/api/tests/ -v`)
- [ ] Frontend builds (`pnpm --filter web build`)
- [ ] Tested manually in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->
