### PR TITLE
fix: make per-file upload limit configurable, drop hardcoded 10GB cap (#64)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,4 @@ API_WORKERS=4                  # Gunicorn worker processes (prod only)
 TRANSCODING_CONCURRENCY=2     # Parallel video transcoding jobs (CPU intensive)
 EMAIL_CONCURRENCY=2            # Parallel email sending jobs
 TRANSCODER_ENGINE=ffmpeg
+MAX_UPLOAD_BYTES=0             # Max size (bytes) for one uploaded file; 0 = unlimited

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to FreeFrame are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Configurable per-file upload limit** ([#64](https://github.com/Techiebutler/freeframe/issues/64)) — new `MAX_UPLOAD_BYTES` env var caps the size of a single uploaded file (`0` = unlimited, the new default). Replaces the hardcoded 10GB ceiling that self-hosters running their own S3/MinIO had no way to change or remove. Enforced at both upload-initiation points (`POST /upload/initiate` and new-version upload) with an error that reports the configured cap instead of a hardcoded "10GB". Effective size is still structurally bounded by S3 multipart (10,000 parts × 10MB chunk ≈ 97GB).
+
+### Fixed
+- **Misleading "Storage X / 10 GB" indicator on the project page** ([#64](https://github.com/Techiebutler/freeframe/issues/64)) — the project sidebar rendered a hardcoded 10 GB denominator with 80%/90% color warnings, implying a per-project quota that never existed as a real, configurable concept. It now shows only storage used — no fake denominator, no progress bar.
+
+---
+
 ## [1.1.6] - 2026-07-06
 
 ### Fixed

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -11,3 +11,6 @@ ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=7
 FRONTEND_URL=http://localhost:3000
 TRANSCODER_ENGINE=ffmpeg
+
+# Max size (bytes) for a single uploaded file. 0 = unlimited (no per-file cap).
+MAX_UPLOAD_BYTES=0

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -39,7 +39,11 @@ class Settings(BaseSettings):
     refresh_token_expire_days: int = 7
     frontend_url: str = "http://localhost:3000"
     transcoder_engine: str = "ffmpeg"
-    
+
+    # Maximum size (bytes) for a single uploaded file. 0 = unlimited (no per-file cap).
+    # Note: S3 multipart still caps effective size at ~10,000 parts x chunk size.
+    max_upload_bytes: int = 0
+
     # Worker concurrency settings
     transcoding_concurrency: int = 2  # Number of concurrent video transcoding jobs
     email_concurrency: int = 2  # Number of concurrent email sending jobs

--- a/apps/api/routers/assets.py
+++ b/apps/api/routers/assets.py
@@ -17,7 +17,7 @@ from ..schemas.notification import AssignmentUpdate
 from ..services.permissions import require_project_role, require_asset_access, can_access_asset, is_public_project, get_project_member
 from ..services.s3_service import generate_presigned_get_url, build_download_filename
 from .hls_proxy import create_hls_token
-from ..schemas.upload import InitiateUploadRequest, InitiateUploadResponse, ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES, mime_to_asset_type
+from ..schemas.upload import InitiateUploadRequest, InitiateUploadResponse, ALLOWED_MIME_TYPES, upload_size_error, mime_to_asset_type
 from ..services.s3_service import create_multipart_upload
 
 router = APIRouter(tags=["assets"])
@@ -301,8 +301,9 @@ def initiate_new_version(
 
     if body.mime_type not in ALLOWED_MIME_TYPES:
         raise HTTPException(status_code=400, detail="Unsupported file type")
-    if body.file_size_bytes > MAX_FILE_SIZE_BYTES:
-        raise HTTPException(status_code=400, detail="File exceeds 10GB limit")
+    size_error = upload_size_error(body.file_size_bytes)
+    if size_error:
+        raise HTTPException(status_code=400, detail=size_error)
 
     last_version = db.query(AssetVersion).filter(
         AssetVersion.asset_id == asset_id,

--- a/apps/api/routers/upload.py
+++ b/apps/api/routers/upload.py
@@ -18,7 +18,7 @@ from ..schemas.upload import (
     InitiateUploadRequest, InitiateUploadResponse,
     PresignPartRequest, PresignPartResponse,
     CompleteUploadRequest, CompleteUploadResponse, AbortUploadRequest,
-    ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES, mime_to_asset_type,
+    ALLOWED_MIME_TYPES, upload_size_error, mime_to_asset_type,
 )
 
 router = APIRouter(prefix="/upload", tags=["upload"])
@@ -32,8 +32,9 @@ def initiate_upload(
     # Validate mime type
     if body.mime_type not in ALLOWED_MIME_TYPES:
         raise HTTPException(status_code=400, detail=f"Unsupported file type: {body.mime_type}")
-    if body.file_size_bytes > MAX_FILE_SIZE_BYTES:
-        raise HTTPException(status_code=400, detail="File exceeds 10GB limit")
+    size_error = upload_size_error(body.file_size_bytes)
+    if size_error:
+        raise HTTPException(status_code=400, detail=size_error)
 
     # Verify project access (editor or above)
     project = db.query(Project).filter(Project.id == body.project_id, Project.deleted_at.is_(None)).first()

--- a/apps/api/schemas/upload.py
+++ b/apps/api/schemas/upload.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 import uuid
 from ..models.asset import AssetType
+from ..config import settings
 
 ALLOWED_MIME_TYPES = {
     # Images
@@ -12,8 +13,26 @@ ALLOWED_MIME_TYPES = {
     "video/webm", "video/mpeg", "video/x-ms-wmv",
 }
 
-MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024 * 1024  # 10 GB
 CHUNK_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+def _format_bytes(num_bytes: int) -> str:
+    """Human-readable size for error messages, e.g. '10 GB'."""
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return f"{int(value)} {unit}" if value == int(value) else f"{value:.1f} {unit}"
+        value /= 1024
+
+def upload_size_error(file_size_bytes: int) -> str | None:
+    """Return an error detail if the file exceeds the configured per-file cap, else None.
+
+    ``settings.max_upload_bytes == 0`` disables the cap (unlimited). Read at call time
+    so the limit stays configurable via the ``MAX_UPLOAD_BYTES`` env var.
+    """
+    limit = settings.max_upload_bytes
+    if limit and file_size_bytes > limit:
+        return f"File exceeds {_format_bytes(limit)} limit"
+    return None
 
 def mime_to_asset_type(mime_type: str) -> AssetType:
     if mime_type.startswith("image/"):

--- a/apps/api/tests/test_upload_size_limit.py
+++ b/apps/api/tests/test_upload_size_limit.py
@@ -1,0 +1,26 @@
+"""Tests for the configurable per-file upload size limit (issue #64).
+
+The 10 GB per-file cap used to be hardcoded. It is now driven by
+`settings.max_upload_bytes`, where 0 means unlimited (no per-file cap).
+"""
+from apps.api.config import settings
+from apps.api.schemas.upload import upload_size_error
+
+
+def test_unlimited_when_zero(monkeypatch):
+    """max_upload_bytes == 0 disables the cap — no error even for huge files."""
+    monkeypatch.setattr(settings, "max_upload_bytes", 0)
+    assert upload_size_error(50 * 1024 * 1024 * 1024) is None  # 50 GB
+
+
+def test_rejects_file_over_limit(monkeypatch):
+    monkeypatch.setattr(settings, "max_upload_bytes", 2 * 1024 * 1024 * 1024)  # 2 GB cap
+    err = upload_size_error(3 * 1024 * 1024 * 1024)  # 3 GB
+    assert err is not None
+    assert "2 GB" in err  # message reports the configured cap, not a hardcoded 10 GB
+
+
+def test_allows_file_at_or_under_limit(monkeypatch):
+    monkeypatch.setattr(settings, "max_upload_bytes", 2 * 1024 * 1024 * 1024)  # 2 GB cap
+    assert upload_size_error(2 * 1024 * 1024 * 1024) is None  # exactly at the cap
+    assert upload_size_error(1 * 1024 * 1024 * 1024) is None  # under the cap

--- a/apps/web/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/page.tsx
@@ -586,39 +586,17 @@ export default function ProjectDetailPage() {
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Storage indicator — matches global sidebar bottom section (p-2 + space-y-1) */}
-        {(() => {
-          const used = project?.storage_bytes ?? 0;
-          const limit = 10 * 1024 * 1024 * 1024; // 10 GB default limit
-          const pct = limit > 0 ? Math.min((used / limit) * 100, 100) : 0;
-          const isCritical = pct >= 90;
-          const isWarning = pct >= 80;
-          return (
-            <div className="border-t border-border shrink-0 p-2 space-y-1">
-              <div className="flex flex-col gap-1 px-2.5 py-1.5">
-                <div className="flex items-center justify-between">
-                  <span className="text-[11px] font-medium text-text-secondary">Storage</span>
-                  <span className={cn(
-                    "text-[10px] tabular-nums",
-                    isCritical ? "text-status-error font-medium" : isWarning ? "text-amber-400 font-medium" : "text-text-tertiary",
-                  )}>
-                    {formatBytes(used)} / {formatBytes(limit)}
-                  </span>
-                </div>
-                <div className="h-1 w-full rounded-full bg-bg-hover overflow-hidden">
-                  <div
-                    className={cn(
-                      "h-full rounded-full transition-all duration-300",
-                      isCritical ? "bg-status-error" : isWarning ? "bg-amber-400" : "bg-accent",
-                    )}
-                    style={{ width: `${Math.max(pct, 1)}%` }}
-                  />
-                </div>
-              </div>
-              <div className="h-5" />
-            </div>
-          );
-        })()}
+        {/* Storage indicator — matches global sidebar bottom section (p-2 + space-y-1).
+            Shows storage used; no quota denominator (FreeFrame has no fixed cap). */}
+        <div className="border-t border-border shrink-0 p-2 space-y-1">
+          <div className="flex items-center justify-between px-2.5 py-1.5">
+            <span className="text-[11px] font-medium text-text-secondary">Storage used</span>
+            <span className="text-[10px] tabular-nums text-text-tertiary">
+              {formatBytes(project?.storage_bytes ?? 0)}
+            </span>
+          </div>
+          <div className="h-5" />
+        </div>
       </div>
 
       {/* ─── Main Content ───────────────────────────────────────────────── */}


### PR DESCRIPTION
## Summary

Fixes #64. The 10 GB per-file upload cap and the "Storage X / 10 GB" project
indicator were both hardcoded, with no configurable quota concept — self-hosters
running their own S3/MinIO had no way to change or remove them, and the UI implied
a quota that never actually existed. This makes the per-file cap configurable via
`MAX_UPLOAD_BYTES` (unlimited by default) and drops the misleading UI denominator.

Scope is intentionally "config + UI only" — no DB migration or per-project quota column.

## Changes

- Add `MAX_UPLOAD_BYTES` env setting (`0` = unlimited, new default) in `config.py`
- Replace hardcoded `MAX_FILE_SIZE_BYTES` with an `upload_size_error()` helper that
  reads the setting at call time and reports the configured cap in the error message
- Enforce at both upload-initiation points (`routers/upload.py`, `routers/assets.py`)
- Drop the fake "/ 10 GB" storage denominator + progress bar in the project sidebar;
  show only storage used
- Document `MAX_UPLOAD_BYTES` in both `.env.example` files
- Add unit tests for the size-limit logic
- CHANGELOG: entry added under `[Unreleased]` (no version cut — release drift handled separately)

Effective size is still structurally bounded by S3 multipart (10,000 parts × 10 MB chunk ≈ 97 GB).

## Testing

- [x] Backend tests pass (`python -m pytest apps/api/tests/` — **69 passed**)
- [ ] Frontend builds (`pnpm --filter web build`) — not run
- [ ] Tested manually in browser — backend behavior verified in-container; UI change is presentational

## Screenshots

Storage indicator — before: `Storage  {used} / 10 GB` + colored progress bar → after: `Storage used  {used}` (no denominator/bar).
