### PR TITLE
docs: add v1.1.6 to CHANGELOG (share comments + HLS playback fixes, dep bumps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to FreeFrame are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2026-07-06
+
+### Fixed
+- **HLS video playback on the public share page in Chrome/Firefox** ([#68](https://github.com/Techiebutler/freeframe/issues/68)) — `ShareMediaViewer` used a plain `<video src={streamUrl}>`, which only plays HLS (`.m3u8`) natively in Safari and failed in Chrome/Firefox. It now uses hls.js (already a project dependency) for MediaSource-capable browsers, falling back to native playback for Safari and direct media files; the same pattern was applied to the audio branch. ([#76](https://github.com/Techiebutler/freeframe/pull/76))
+- **Public share comments response shape** ([#67](https://github.com/Techiebutler/freeframe/issues/67), [#72](https://github.com/Techiebutler/freeframe/issues/72)) — `GET /share/{token}/comments` now returns a consistent bare array on the no-target fallback path, and the single-asset share page handles the response robustly (aligned with the folder share viewer). Adds backend regression coverage for asset-share, folder/project-share, and no-target fallback paths. ([#70](https://github.com/Techiebutler/freeframe/pull/70), [#73](https://github.com/Techiebutler/freeframe/pull/73))
+
+### Dependencies
+- Bump `redis` (apps/api) from 5.1.0 to 5.3.1 ([#30](https://github.com/Techiebutler/freeframe/pull/30))
+- Bump `pnpm/action-setup` from 5 to 6 (CI) ([#58](https://github.com/Techiebutler/freeframe/pull/58))
+
+---
+
 ## [1.1.5] - 2026-04-14
 
 ### Security


### PR DESCRIPTION
## Summary

Release catch-up. Since **v1.1.4**, `main` had drifted: the `[1.1.5]` entry was written into the CHANGELOG but **never tagged**, and five PRs merged afterward with no CHANGELOG entries. This documents those five as **v1.1.6**.

- `v1.1.5` has now been tagged on its commit (`ad3907ad`) — see the CHANGELOG entry that already existed for it.
- This PR adds the `[1.1.6]` section for the undocumented merges below.
- After merge, `v1.1.6` will be tagged on the merge commit (matching the repo's manual, CHANGELOG-driven release convention).

## Changes documented in [1.1.6]

### Fixed
- HLS video playback on the public share page in Chrome/Firefox (#68 / #76)
- Public share comments response shape (#67, #72 / #70, #73)

### Dependencies
- `redis` 5.1.0 → 5.3.1 (#30)
- `pnpm/action-setup` 5 → 6, CI (#58)

## Notes

Docs-only change — no code touched. This does not include the in-flight #64 upload-limit fix (PR #91), which keeps its own `[Unreleased]` entry and will be rebased above `[1.1.6]` when it merges.
