### PR TITLE
feat: add PATCH /auth/change-password endpoint

### DIFF
--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -10,6 +10,7 @@ from ..schemas.auth import (
     SendMagicCodeRequest, SendMagicCodeResponse,
     VerifyMagicCodeRequest, SetPasswordRequest,
     AcceptInviteRequest, InviteInfoResponse,
+    ChangePasswordRequest,
 )
 from ..services.auth_service import (
     hash_password, verify_password,
@@ -249,3 +250,17 @@ def update_preferences(
     db.commit()
     db.refresh(current_user)
     return current_user
+
+@router.patch("/change-password", status_code=status.HTTP_200_OK)
+def change_password(
+    body: ChangePasswordRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Change password for authenticated user."""
+    if not verify_password(body.current_password, current_user.password_hash):
+        raise HTTPException(status_code=400, detail="Current password is incorrect")
+
+    current_user.password_hash = hash_password(body.new_password)
+    db.commit()
+    return {"message": "Password changed successfully"}

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -258,6 +258,8 @@ def change_password(
     current_user: User = Depends(get_current_user),
 ):
     """Change password for authenticated user."""
+    if current_user.password_hash is None:
+        raise HTTPException(status_code=400, detail="No password set for this account; use set-password instead")
     if not verify_password(body.current_password, current_user.password_hash):
         raise HTTPException(status_code=400, detail="Current password is incorrect")
 

--- a/apps/api/schemas/auth.py
+++ b/apps/api/schemas/auth.py
@@ -62,6 +62,10 @@ class InviteInfoResponse(BaseModel):
     name: str
     org_name: str | None = None
 
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
 class UpdateProfileRequest(BaseModel):
     name: str | None = None
     avatar_url: str | None = None


### PR DESCRIPTION
## What this adds

`PATCH /auth/change-password` endpoint so authenticated users can change their own password. The frontend was already coded to call this endpoint but it did not exist.

## Changes

1. **`schemas/auth.py`** — Adds `ChangePasswordRequest` schema with `current_password` and `new_password` fields.

2. **`routers/auth.py`** — Adds `PATCH /auth/change-password` endpoint. Validates the current password, then hashes and stores the new one. Returns an error if the current password is incorrect.

## Files changed
- `apps/api/schemas/auth.py` — +4 lines
- `apps/api/routers/auth.py` — +15 lines