### PR TITLE
feat: instance settings + instance-wide storage cap (backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Instance settings + instance-wide storage cap** ([#98](https://github.com/Techiebutler/freeframe/pull/98)) — new admin-editable `instance_settings` singleton table (the home for deployment-level settings on this single-tenant instance), with an instance-wide total-storage cap as its first setting. `GET /instance/settings` (any member) returns `storage_limit_bytes` + current `storage_used_bytes`; `PUT /instance/settings` (admin) sets the limit (`0` = unlimited). The cap is enforced at upload initiate alongside the per-file `MAX_UPLOAD_BYTES` check; usage counts committed (processing/ready), non-deleted media. Backend only — admin UI + storage indicator to follow.
 - **Configurable per-file upload limit** ([#64](https://github.com/Techiebutler/freeframe/issues/64)) — new `MAX_UPLOAD_BYTES` env var caps the size of a single uploaded file (`0` = unlimited, the new default). Replaces the hardcoded 10GB ceiling that self-hosters running their own S3/MinIO had no way to change or remove. Enforced at both upload-initiation points (`POST /upload/initiate` and new-version upload) with an error that reports the configured cap instead of a hardcoded "10GB". Effective size is still structurally bounded by S3 multipart (10,000 parts × 10MB chunk ≈ 97GB).
 
 ### Fixed

--- a/apps/api/alembic/versions/dfcdaa30f89e_add_instance_settings_table.py
+++ b/apps/api/alembic/versions/dfcdaa30f89e_add_instance_settings_table.py
@@ -1,0 +1,31 @@
+"""add_instance_settings_table
+
+Revision ID: dfcdaa30f89e
+Revises: 8ca3dffea55f
+Create Date: 2026-07-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'dfcdaa30f89e'
+down_revision: Union[str, Sequence[str], None] = '8ca3dffea55f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "instance_settings",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("storage_limit_bytes", sa.BigInteger(), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("instance_settings")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
-from .routers import auth, users, projects, upload, events, assets, me, comments, approvals, share, metadata, branding, notifications, admin, setup, folders, hls_proxy
+from .routers import auth, users, projects, upload, events, assets, me, comments, approvals, share, metadata, branding, notifications, admin, setup, folders, hls_proxy, instance_settings
 from .services.s3_service import ensure_bucket_exists
 from .middleware.global_rate_limit import GlobalRateLimitMiddleware
 from .middleware.setup_guard import SetupGuardMiddleware
@@ -58,6 +58,7 @@ app.include_router(admin.router)
 app.include_router(setup.router)
 app.include_router(folders.router)
 app.include_router(hls_proxy.router)
+app.include_router(instance_settings.router)
 
 @app.get("/health")
 def health():

--- a/apps/api/models/__init__.py
+++ b/apps/api/models/__init__.py
@@ -7,4 +7,5 @@ from .approval import Approval
 from .share import ShareLink, AssetShare, ShareLinkActivity, ShareActivityAction, ShareVisibility
 from .metadata import MetadataField, AssetMetadata, Collection, CollectionShare
 from .branding import ProjectBranding, WatermarkSettings
+from .instance_settings import InstanceSettings
 from .activity import Mention, ActivityLog, Notification

--- a/apps/api/models/instance_settings.py
+++ b/apps/api/models/instance_settings.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+from sqlalchemy import BigInteger, DateTime, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+try:
+    from ..database import Base
+except ImportError:
+    from database import Base
+
+
+class InstanceSettings(Base):
+    """Single-row table holding instance-wide (deployment-level) settings.
+
+    Singleton: exactly one row, created lazily via get_or_create in the router.
+    storage_limit_bytes == 0 means unlimited (matches MAX_UPLOAD_BYTES).
+    """
+    __tablename__ = "instance_settings"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    storage_limit_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/apps/api/routers/assets.py
+++ b/apps/api/routers/assets.py
@@ -17,7 +17,8 @@ from ..schemas.notification import AssignmentUpdate
 from ..services.permissions import require_project_role, require_asset_access, can_access_asset, is_public_project, get_project_member
 from ..services.s3_service import generate_presigned_get_url, build_download_filename
 from .hls_proxy import create_hls_token
-from ..schemas.upload import InitiateUploadRequest, InitiateUploadResponse, ALLOWED_MIME_TYPES, upload_size_error, mime_to_asset_type
+from ..schemas.upload import InitiateUploadRequest, InitiateUploadResponse, ALLOWED_MIME_TYPES, mime_to_asset_type
+from ..services.storage import upload_guard_error
 from ..services.s3_service import create_multipart_upload
 
 router = APIRouter(tags=["assets"])
@@ -301,9 +302,9 @@ def initiate_new_version(
 
     if body.mime_type not in ALLOWED_MIME_TYPES:
         raise HTTPException(status_code=400, detail="Unsupported file type")
-    size_error = upload_size_error(body.file_size_bytes)
-    if size_error:
-        raise HTTPException(status_code=400, detail=size_error)
+    guard_error = upload_guard_error(db, body.file_size_bytes)
+    if guard_error:
+        raise HTTPException(status_code=400, detail=guard_error)
 
     last_version = db.query(AssetVersion).filter(
         AssetVersion.asset_id == asset_id,

--- a/apps/api/routers/instance_settings.py
+++ b/apps/api/routers/instance_settings.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..middleware.auth import get_current_user
+from ..models.user import User
+from ..models.instance_settings import InstanceSettings
+from ..routers.users import require_admin
+from ..schemas.instance_settings import InstanceSettingsUpdate, InstanceSettingsResponse
+from ..services import storage as storage_service
+
+router = APIRouter(tags=["instance_settings"])
+
+
+def get_or_create_instance_settings(db: Session) -> InstanceSettings:
+    row = db.query(InstanceSettings).first()
+    if not row:
+        row = InstanceSettings()
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+    return row
+
+
+def _build_response(db: Session, row: InstanceSettings) -> InstanceSettingsResponse:
+    return InstanceSettingsResponse(
+        storage_limit_bytes=row.storage_limit_bytes,
+        storage_used_bytes=storage_service.instance_storage_used_bytes(db),
+    )
+
+
+@router.get("/instance/settings", response_model=InstanceSettingsResponse)
+def get_instance_settings(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Any authenticated member: instance storage limit + current usage."""
+    row = get_or_create_instance_settings(db)
+    return _build_response(db, row)
+
+
+@router.put("/instance/settings", response_model=InstanceSettingsResponse)
+def update_instance_settings(
+    body: InstanceSettingsUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """Admin only: update instance settings."""
+    row = get_or_create_instance_settings(db)
+    if body.storage_limit_bytes is not None:
+        row.storage_limit_bytes = body.storage_limit_bytes
+    db.commit()
+    db.refresh(row)
+    return _build_response(db, row)

--- a/apps/api/routers/instance_settings.py
+++ b/apps/api/routers/instance_settings.py
@@ -1,4 +1,7 @@
+import uuid
+
 from fastapi import APIRouter, Depends
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..database import get_db
@@ -11,14 +14,23 @@ from ..services import storage as storage_service
 
 router = APIRouter(tags=["instance_settings"])
 
+# Fixed sentinel PK: instance_settings is a singleton. Concurrent first-time creates
+# collide on this PK (IntegrityError) instead of producing duplicate rows.
+_SINGLETON_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
 
 def get_or_create_instance_settings(db: Session) -> InstanceSettings:
     row = db.query(InstanceSettings).first()
-    if not row:
-        row = InstanceSettings()
-        db.add(row)
+    if row:
+        return row
+    row = InstanceSettings(id=_SINGLETON_ID)
+    db.add(row)
+    try:
         db.commit()
-        db.refresh(row)
+    except IntegrityError:
+        db.rollback()
+        return db.query(InstanceSettings).first()
+    db.refresh(row)
     return row
 
 
@@ -34,9 +46,16 @@ def get_instance_settings(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Any authenticated member: instance storage limit + current usage."""
-    row = get_or_create_instance_settings(db)
-    return _build_response(db, row)
+    """Any authenticated member: instance storage limit + current usage.
+
+    Read-only: does not create the settings row. Defaults to unlimited (0)
+    when no row exists yet — only PUT creates the singleton row.
+    """
+    row = db.query(InstanceSettings).first()
+    return InstanceSettingsResponse(
+        storage_limit_bytes=row.storage_limit_bytes if row else 0,
+        storage_used_bytes=storage_service.instance_storage_used_bytes(db),
+    )
 
 
 @router.put("/instance/settings", response_model=InstanceSettingsResponse)

--- a/apps/api/routers/upload.py
+++ b/apps/api/routers/upload.py
@@ -18,8 +18,9 @@ from ..schemas.upload import (
     InitiateUploadRequest, InitiateUploadResponse,
     PresignPartRequest, PresignPartResponse,
     CompleteUploadRequest, CompleteUploadResponse, AbortUploadRequest,
-    ALLOWED_MIME_TYPES, upload_size_error, mime_to_asset_type,
+    ALLOWED_MIME_TYPES, mime_to_asset_type,
 )
+from ..services.storage import upload_guard_error
 
 router = APIRouter(prefix="/upload", tags=["upload"])
 
@@ -32,9 +33,9 @@ def initiate_upload(
     # Validate mime type
     if body.mime_type not in ALLOWED_MIME_TYPES:
         raise HTTPException(status_code=400, detail=f"Unsupported file type: {body.mime_type}")
-    size_error = upload_size_error(body.file_size_bytes)
-    if size_error:
-        raise HTTPException(status_code=400, detail=size_error)
+    guard_error = upload_guard_error(db, body.file_size_bytes)
+    if guard_error:
+        raise HTTPException(status_code=400, detail=guard_error)
 
     # Verify project access (editor or above)
     project = db.query(Project).filter(Project.id == body.project_id, Project.deleted_at.is_(None)).first()

--- a/apps/api/schemas/instance_settings.py
+++ b/apps/api/schemas/instance_settings.py
@@ -2,7 +2,8 @@ from pydantic import BaseModel, Field
 
 
 class InstanceSettingsUpdate(BaseModel):
-    storage_limit_bytes: int | None = Field(default=None, ge=0)
+    # Upper bound = PostgreSQL BigInteger max (2**63 - 1); rejects overflow with 422 instead of a 500.
+    storage_limit_bytes: int | None = Field(default=None, ge=0, le=9223372036854775807)
 
 
 class InstanceSettingsResponse(BaseModel):

--- a/apps/api/schemas/instance_settings.py
+++ b/apps/api/schemas/instance_settings.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, Field
+
+
+class InstanceSettingsUpdate(BaseModel):
+    storage_limit_bytes: int | None = Field(default=None, ge=0)
+
+
+class InstanceSettingsResponse(BaseModel):
+    # Curated per role. Today member and admin see the same fields; future admin-only
+    # fields must be excluded from the member response rather than dumping the row.
+    storage_limit_bytes: int
+    storage_used_bytes: int

--- a/apps/api/services/storage.py
+++ b/apps/api/services/storage.py
@@ -1,0 +1,51 @@
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..models.asset import Asset, AssetVersion, MediaFile, ProcessingStatus
+from ..models.instance_settings import InstanceSettings
+from ..schemas.upload import _format_bytes, upload_size_error
+
+
+def get_storage_limit(db: Session) -> int:
+    """Non-creating read of the instance storage cap. 0 (or no row) == unlimited."""
+    row = db.query(InstanceSettings).first()
+    return row.storage_limit_bytes if row else 0
+
+
+def instance_storage_used_bytes(db: Session) -> int:
+    """Instance-wide committed storage in bytes — the single source of truth for both
+    the member GET indicator and cap enforcement.
+
+    Counts only bytes actually in S3: versions in `processing`/`ready`, excluding
+    soft-deleted assets/versions. MediaFile has no deleted_at, so soft-delete is
+    excluded via the Asset/AssetVersion join filters.
+    """
+    return db.query(func.coalesce(func.sum(MediaFile.file_size_bytes), 0)) \
+        .join(AssetVersion, MediaFile.version_id == AssetVersion.id) \
+        .join(Asset, AssetVersion.asset_id == Asset.id) \
+        .filter(
+            Asset.deleted_at.is_(None),
+            AssetVersion.deleted_at.is_(None),
+            AssetVersion.processing_status.in_(
+                [ProcessingStatus.processing, ProcessingStatus.ready]
+            ),
+        ).scalar() or 0
+
+
+def storage_cap_error(db: Session, incoming_bytes: int) -> str | None:
+    """Return an error detail if accepting `incoming_bytes` would exceed the instance
+    storage cap, else None. Limit 0 (unlimited) short-circuits before any usage query.
+    """
+    limit = get_storage_limit(db)
+    if not limit:
+        return None
+    used = instance_storage_used_bytes(db)
+    if used + incoming_bytes > limit:
+        return f"Storage limit reached — {_format_bytes(used)} of {_format_bytes(limit)} used"
+    return None
+
+
+def upload_guard_error(db: Session, file_size_bytes: int) -> str | None:
+    """Combined pre-upload guard: the per-file cap (env `MAX_UPLOAD_BYTES`) first, then the
+    instance-wide storage cap (DB). Returns the first error message, or None if both pass."""
+    return upload_size_error(file_size_bytes) or storage_cap_error(db, file_size_bytes)

--- a/apps/api/tests/test_instance_settings.py
+++ b/apps/api/tests/test_instance_settings.py
@@ -9,3 +9,63 @@ def test_instance_settings_table_shape():
     # 0 = unlimited default
     assert cols["storage_limit_bytes"].server_default.arg == "0"
     assert cols["storage_limit_bytes"].nullable is False
+
+
+from unittest.mock import MagicMock
+from apps.api.services import storage as storage_service
+
+
+def test_get_storage_limit_no_row_is_unlimited(mock_db):
+    mock_db.first.return_value = None
+    assert storage_service.get_storage_limit(mock_db) == 0
+
+
+def test_get_storage_limit_reads_row(mock_db):
+    mock_db.first.return_value = MagicMock(storage_limit_bytes=5_000)
+    assert storage_service.get_storage_limit(mock_db) == 5_000
+
+
+def test_storage_cap_error_unlimited_returns_none(mock_db, monkeypatch):
+    monkeypatch.setattr(storage_service, "get_storage_limit", lambda db: 0)
+    # usage must not even be queried when unlimited
+    monkeypatch.setattr(storage_service, "instance_storage_used_bytes",
+                        lambda db: (_ for _ in ()).throw(AssertionError("should not run")))
+    assert storage_service.storage_cap_error(mock_db, 10_000) is None
+
+
+def test_storage_cap_error_under_limit_returns_none(mock_db, monkeypatch):
+    monkeypatch.setattr(storage_service, "get_storage_limit", lambda db: 1_000)
+    monkeypatch.setattr(storage_service, "instance_storage_used_bytes", lambda db: 400)
+    assert storage_service.storage_cap_error(mock_db, 500) is None       # 900 <= 1000
+
+
+def test_storage_cap_error_at_limit_returns_none(mock_db, monkeypatch):
+    monkeypatch.setattr(storage_service, "get_storage_limit", lambda db: 1_000)
+    monkeypatch.setattr(storage_service, "instance_storage_used_bytes", lambda db: 600)
+    assert storage_service.storage_cap_error(mock_db, 400) is None       # exactly 1000, not over
+
+
+def test_storage_cap_error_over_limit_returns_message(mock_db, monkeypatch):
+    monkeypatch.setattr(storage_service, "get_storage_limit", lambda db: 1_000)
+    monkeypatch.setattr(storage_service, "instance_storage_used_bytes", lambda db: 800)
+    err = storage_service.storage_cap_error(mock_db, 400)               # 1200 > 1000
+    assert err is not None
+    assert "Storage limit reached" in err
+
+
+def test_upload_guard_error_size_wins(mock_db, monkeypatch):
+    monkeypatch.setattr(storage_service, "upload_size_error", lambda n: "too big")
+    monkeypatch.setattr(storage_service, "storage_cap_error", lambda db, n: "cap!")
+    assert storage_service.upload_guard_error(mock_db, 123) == "too big"   # per-file checked first
+
+
+def test_upload_guard_error_falls_through_to_cap(mock_db, monkeypatch):
+    monkeypatch.setattr(storage_service, "upload_size_error", lambda n: None)
+    monkeypatch.setattr(storage_service, "storage_cap_error", lambda db, n: "cap!")
+    assert storage_service.upload_guard_error(mock_db, 123) == "cap!"
+
+
+def test_upload_guard_error_both_pass(mock_db, monkeypatch):
+    monkeypatch.setattr(storage_service, "upload_size_error", lambda n: None)
+    monkeypatch.setattr(storage_service, "storage_cap_error", lambda db, n: None)
+    assert storage_service.upload_guard_error(mock_db, 123) is None

--- a/apps/api/tests/test_instance_settings.py
+++ b/apps/api/tests/test_instance_settings.py
@@ -111,6 +111,18 @@ def test_get_settings_member(client, auth_headers, mock_db, test_user, monkeypat
     assert r.json() == {"storage_limit_bytes": 8000, "storage_used_bytes": 100}
 
 
+def test_get_settings_no_row_is_read_only_and_unlimited(client, auth_headers, mock_db, test_user, monkeypatch):
+    # No row exists yet — GET must NOT create one; it should default to unlimited (0).
+    test_user.is_superadmin = False
+    mock_db.first.return_value = None
+    monkeypatch.setattr(storage_service, "instance_storage_used_bytes", lambda db: 100)
+    r = client.get("/instance/settings", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json() == {"storage_limit_bytes": 0, "storage_used_bytes": 100}
+    mock_db.add.assert_not_called()
+    mock_db.commit.assert_not_called()
+
+
 import uuid
 from apps.api.routers import upload as upload_router
 

--- a/apps/api/tests/test_instance_settings.py
+++ b/apps/api/tests/test_instance_settings.py
@@ -102,6 +102,13 @@ def test_put_settings_rejects_negative(client, auth_headers, mock_db, test_user)
     assert r.status_code == 422
 
 
+def test_put_settings_rejects_over_bigint_max(client, auth_headers, mock_db, test_user):
+    test_user.is_superadmin = True
+    # 2**63 exceeds PostgreSQL BigInteger; reject at validation (422), never overflow into a 500.
+    r = client.put("/instance/settings", headers=auth_headers, json={"storage_limit_bytes": 9223372036854775808})
+    assert r.status_code == 422
+
+
 def test_get_settings_member(client, auth_headers, mock_db, test_user, monkeypatch):
     test_user.is_superadmin = False
     mock_db.first.return_value = MagicMock(storage_limit_bytes=8000)

--- a/apps/api/tests/test_instance_settings.py
+++ b/apps/api/tests/test_instance_settings.py
@@ -1,0 +1,11 @@
+"""Tests for instance_settings model, storage service, router, and cap enforcement."""
+from apps.api.models.instance_settings import InstanceSettings
+
+
+def test_instance_settings_table_shape():
+    cols = InstanceSettings.__table__.columns
+    assert InstanceSettings.__tablename__ == "instance_settings"
+    assert "storage_limit_bytes" in cols
+    # 0 = unlimited default
+    assert cols["storage_limit_bytes"].server_default.arg == "0"
+    assert cols["storage_limit_bytes"].nullable is False

--- a/apps/api/tests/test_instance_settings.py
+++ b/apps/api/tests/test_instance_settings.py
@@ -109,3 +109,38 @@ def test_get_settings_member(client, auth_headers, mock_db, test_user, monkeypat
     r = client.get("/instance/settings", headers=auth_headers)
     assert r.status_code == 200
     assert r.json() == {"storage_limit_bytes": 8000, "storage_used_bytes": 100}
+
+
+import uuid
+from apps.api.routers import upload as upload_router
+
+
+def test_initiate_upload_rejected_when_over_cap(client, auth_headers, mock_db, test_user, monkeypatch):
+    # Force the upload guard to trip regardless of DB state
+    monkeypatch.setattr(upload_router, "upload_guard_error", lambda db, n: "Storage limit reached — 9 GB of 10 GB used")
+    body = {
+        "project_id": str(uuid.uuid4()),
+        "asset_name": "big.mp4",
+        "original_filename": "big.mp4",
+        "mime_type": "video/mp4",
+        "file_size_bytes": 2_000_000_000,
+    }
+    r = client.post("/upload/initiate", headers=auth_headers, json=body)
+    assert r.status_code == 400
+    assert "Storage limit reached" in r.json()["detail"]
+
+
+def test_initiate_upload_allowed_when_guard_passes(client, auth_headers, mock_db, test_user, monkeypatch):
+    # guard returns None; expect to pass the gate and fail later on project lookup (404)
+    # — proving the guard did NOT block it.
+    monkeypatch.setattr(upload_router, "upload_guard_error", lambda db, n: None)
+    mock_db.first.return_value = None                    # project not found → 404 after the gate
+    body = {
+        "project_id": str(uuid.uuid4()),
+        "asset_name": "ok.mp4",
+        "original_filename": "ok.mp4",
+        "mime_type": "video/mp4",
+        "file_size_bytes": 1_000,
+    }
+    r = client.post("/upload/initiate", headers=auth_headers, json=body)
+    assert r.status_code == 404                          # got past the guard gate

--- a/apps/api/tests/test_instance_settings.py
+++ b/apps/api/tests/test_instance_settings.py
@@ -69,3 +69,43 @@ def test_upload_guard_error_both_pass(mock_db, monkeypatch):
     monkeypatch.setattr(storage_service, "upload_size_error", lambda n: None)
     monkeypatch.setattr(storage_service, "storage_cap_error", lambda db, n: None)
     assert storage_service.upload_guard_error(mock_db, 123) is None
+
+
+from apps.api.services import storage as storage_service
+
+
+def test_put_settings_requires_admin(client, auth_headers, mock_db, test_user):
+    test_user.is_superadmin = False
+    r = client.put("/instance/settings", headers=auth_headers, json={"storage_limit_bytes": 1000})
+    assert r.status_code == 403
+
+
+def test_put_settings_admin_updates(client, auth_headers, mock_db, test_user, monkeypatch):
+    test_user.is_superadmin = True
+    mock_db.first.return_value = None                     # get_or_create → creates row
+    monkeypatch.setattr(storage_service, "instance_storage_used_bytes", lambda db: 42)
+
+    def _refresh(obj):
+        obj.storage_limit_bytes = getattr(obj, "storage_limit_bytes", 0)
+    mock_db.refresh.side_effect = _refresh
+
+    r = client.put("/instance/settings", headers=auth_headers, json={"storage_limit_bytes": 9000})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["storage_limit_bytes"] == 9000
+    assert body["storage_used_bytes"] == 42
+
+
+def test_put_settings_rejects_negative(client, auth_headers, mock_db, test_user):
+    test_user.is_superadmin = True
+    r = client.put("/instance/settings", headers=auth_headers, json={"storage_limit_bytes": -1})
+    assert r.status_code == 422
+
+
+def test_get_settings_member(client, auth_headers, mock_db, test_user, monkeypatch):
+    test_user.is_superadmin = False
+    mock_db.first.return_value = MagicMock(storage_limit_bytes=8000)
+    monkeypatch.setattr(storage_service, "instance_storage_used_bytes", lambda db: 100)
+    r = client.get("/instance/settings", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json() == {"storage_limit_bytes": 8000, "storage_used_bytes": 100}


### PR DESCRIPTION
## Summary

Adds an admin-editable `instance_settings` singleton table — the foundation for
instance-level settings on this single-tenant, self-hosted deployment — with an
instance-wide total-storage cap as its first setting, enforced at upload time.
Backend only; the admin UI and a real storage indicator are a separate follow-up.

Context: emerged from #64 (configurable per-file cap + removal of a fake per-project
"10 GB" indicator). FreeFrame is single-tenant — one implicit org == the instance —
so an "org-level" cap is really an instance-level cap.

## What's added

- **`InstanceSettings` model + migration** — single-row table (fixed sentinel PK →
  true singleton), `storage_limit_bytes` BigInteger (`0` = unlimited). Sibling to
  #90's `instance_branding`, kept separate by concern.
- **`services/storage.py`** — `instance_storage_used_bytes` (committed-only usage:
  processing/ready, non-deleted), `get_storage_limit`, `storage_cap_error`, and
  `upload_guard_error` (per-file `MAX_UPLOAD_BYTES` first, then the instance cap).
- **`GET /instance/settings`** (any member → `{storage_limit_bytes, storage_used_bytes}`,
  read-only) and **`PUT /instance/settings`** (admin). Per-role curated response;
  storage numbers never exposed to unauthenticated callers.
- **Enforcement** at both upload-initiate handlers via the shared guard, before the
  MediaFile row is created. Initiate-only (concurrent-burst race documented).
  Per-file env cap unchanged.

## Design decisions

- `0` = unlimited everywhere (consistent with `MAX_UPLOAD_BYTES`).
- One committed-only usage query feeds both the GET indicator and the cap check.
- True singleton via sentinel PK + IntegrityError handling (fails **closed** under
  concurrent first access).

## Testing

- Full backend suite: **86 passed**.
- New `apps/api/tests/test_instance_settings.py` (model, service, router auth/shape,
  enforcement, singleton no-row default).
- **Real-Postgres smoke** (the mock harness can't execute the SUM):
  `instance_storage_used_bytes` ran against the dev DB → 13.2 MB; over-cap and
  unlimited branches verified.

## Follow-ups (out of scope)

- Frontend: admin settings field + real "used / limit" indicator (replaces the fake
  one removed in #64).
- Automated real-DB integration test for the usage query (test harness is fully mocked).
- Pre-existing: `MediaFile.file_size_bytes` is `Integer` (int4, ~2.1 GB/row ceiling) →
  should become `BigInteger`.
- Align `routers/projects.py` per-project storage sum to committed-only semantics.
- Alembic heads: this migration and #90's branding both chain off `8ca3dffea55f` —
  whichever merges second needs an `alembic merge`.
