### PR TITLE
fix: widen file_size_bytes to BigInteger (int4 -> bigint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configurable per-file upload limit** ([#64](https://github.com/Techiebutler/freeframe/issues/64)) — new `MAX_UPLOAD_BYTES` env var caps the size of a single uploaded file (`0` = unlimited, the new default). Replaces the hardcoded 10GB ceiling that self-hosters running their own S3/MinIO had no way to change or remove. Enforced at both upload-initiation points (`POST /upload/initiate` and new-version upload) with an error that reports the configured cap instead of a hardcoded "10GB". Effective size is still structurally bounded by S3 multipart (10,000 parts × 10MB chunk ≈ 97GB).
 
 ### Fixed
+- **Files larger than ~2.1 GB could not be recorded** ([#99](https://github.com/Techiebutler/freeframe/pull/99)) — `MediaFile.file_size_bytes` and `CommentAttachment.file_size_bytes` were `INTEGER` (int4, ~2.1 GB ceiling), so a file above that size overflowed on insert despite per-file uploads being nominally unlimited ([#64]). Both columns are now `BigInteger`.
 - **Misleading "Storage X / 10 GB" indicator on the project page** ([#64](https://github.com/Techiebutler/freeframe/issues/64)) — the project sidebar rendered a hardcoded 10 GB denominator with 80%/90% color warnings, implying a per-project quota that never existed as a real, configurable concept. It now shows only storage used — no fake denominator, no progress bar.
 
 ---

--- a/apps/api/alembic/versions/54b1ad156f8f_widen_file_size_bytes_to_bigint.py
+++ b/apps/api/alembic/versions/54b1ad156f8f_widen_file_size_bytes_to_bigint.py
@@ -20,7 +20,13 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Widen file_size_bytes from INTEGER (int4, ~2.1GB) to BIGINT so files larger
-    than ~2.1GB can be recorded (media files support up to 10GB+)."""
+    than ~2.1GB can be recorded (media files support up to 10GB+).
+
+    WARNING: int4->int8 is not binary-coercible in PostgreSQL, so each ALTER COLUMN
+    rewrites the entire table under an ACCESS EXCLUSIVE lock, blocking all reads/writes
+    to media_files (and comment_attachments) for the rewrite's duration. On a large
+    deployment run this in a maintenance window, or migrate zero-downtime via a
+    nullable new column + backfill + rename."""
     op.alter_column("media_files", "file_size_bytes",
                     existing_type=sa.Integer(), type_=sa.BigInteger(), existing_nullable=False)
     op.alter_column("comment_attachments", "file_size_bytes",

--- a/apps/api/alembic/versions/54b1ad156f8f_widen_file_size_bytes_to_bigint.py
+++ b/apps/api/alembic/versions/54b1ad156f8f_widen_file_size_bytes_to_bigint.py
@@ -1,0 +1,36 @@
+"""widen file_size_bytes to bigint
+
+Revision ID: 54b1ad156f8f
+Revises: dfcdaa30f89e
+Create Date: 2026-07-06 19:36:42.295309
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '54b1ad156f8f'
+down_revision: Union[str, Sequence[str], None] = 'dfcdaa30f89e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Widen file_size_bytes from INTEGER (int4, ~2.1GB) to BIGINT so files larger
+    than ~2.1GB can be recorded (media files support up to 10GB+)."""
+    op.alter_column("media_files", "file_size_bytes",
+                    existing_type=sa.Integer(), type_=sa.BigInteger(), existing_nullable=False)
+    op.alter_column("comment_attachments", "file_size_bytes",
+                    existing_type=sa.Integer(), type_=sa.BigInteger(), existing_nullable=False)
+
+
+def downgrade() -> None:
+    """Revert to INTEGER. NOTE: rows with file_size_bytes > 2^31-1 would overflow and
+    fail this downgrade — acceptable, since such values could not have existed before."""
+    op.alter_column("comment_attachments", "file_size_bytes",
+                    existing_type=sa.BigInteger(), type_=sa.Integer(), existing_nullable=False)
+    op.alter_column("media_files", "file_size_bytes",
+                    existing_type=sa.BigInteger(), type_=sa.Integer(), existing_nullable=False)

--- a/apps/api/models/asset.py
+++ b/apps/api/models/asset.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from enum import Enum as PyEnum
 from typing import Optional
-from sqlalchemy import String, Enum, DateTime, ForeignKey, Integer, Float, func, UniqueConstraint, Index
+from sqlalchemy import String, Enum, DateTime, ForeignKey, Integer, BigInteger, Float, func, UniqueConstraint, Index
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 try:
@@ -74,7 +74,7 @@ class MediaFile(Base):
     file_type: Mapped[FileType] = mapped_column(Enum(FileType), nullable=False)
     original_filename: Mapped[str] = mapped_column(String(500), nullable=False)
     mime_type: Mapped[str] = mapped_column(String(100), nullable=False)
-    file_size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    file_size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
     s3_key_raw: Mapped[str] = mapped_column(String(1000), nullable=False)
     s3_key_processed: Mapped[Optional[str]] = mapped_column(String(1000), nullable=True)
     s3_key_thumbnail: Mapped[Optional[str]] = mapped_column(String(1000), nullable=True)

--- a/apps/api/models/comment.py
+++ b/apps/api/models/comment.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from enum import Enum as PyEnum
 from typing import Optional
-from sqlalchemy import String, Boolean, DateTime, Enum, ForeignKey, Float, Integer, func, Text, UniqueConstraint
+from sqlalchemy import String, Boolean, DateTime, Enum, ForeignKey, Float, Integer, BigInteger, func, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 try:
@@ -46,7 +46,7 @@ class CommentAttachment(Base):
     file_type: Mapped[str] = mapped_column(String(50), nullable=False)
     s3_key: Mapped[str] = mapped_column(String(1000), nullable=False)
     original_filename: Mapped[str] = mapped_column(String(500), nullable=False)
-    file_size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    file_size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 class CommentReaction(Base):

--- a/apps/api/tests/test_filesize_bigint.py
+++ b/apps/api/tests/test_filesize_bigint.py
@@ -1,0 +1,18 @@
+"""file_size_bytes columns must be BigInteger.
+
+Postgres INTEGER (int4) tops out at ~2.147 GB, so a file larger than that cannot be
+recorded at all — which silently breaks large-media support (and the storage cap that
+sums these values). Both file_size_bytes columns must be BigInteger.
+"""
+from sqlalchemy import BigInteger
+
+from apps.api.models.asset import MediaFile
+from apps.api.models.comment import CommentAttachment
+
+
+def test_media_file_size_bytes_is_bigint():
+    assert isinstance(MediaFile.__table__.columns["file_size_bytes"].type, BigInteger)
+
+
+def test_comment_attachment_file_size_bytes_is_bigint():
+    assert isinstance(CommentAttachment.__table__.columns["file_size_bytes"].type, BigInteger)


### PR DESCRIPTION
## Summary

`MediaFile.file_size_bytes` and `CommentAttachment.file_size_bytes` were `INTEGER`
(int4, ~2.1 GB ceiling) — so any file larger than ~2.1 GB could not be recorded at
all. This undermines #64 (per-file uploads are now nominally unlimited) and #98
(instance storage accounting sums these values). Widen both to `BigInteger`.

**Stacked on #98** (`feature/instance-settings-storage-cap`) — this PR's diff is only
the column change, and its migration chains off #98's. Retarget to `main` once #98 merges.

## Changes

- `MediaFile.file_size_bytes` and `CommentAttachment.file_size_bytes` → `BigInteger`.
- Alembic migration `54b1ad156f8f` (`ALTER COLUMN … TYPE BIGINT`), chained off `dfcdaa30f89e`.
- Structural tests (`apps/api/tests/test_filesize_bigint.py`).

## Testing

- Full backend suite: **88 passed**.
- Migration applied to the dev DB; verified both columns are now `BIGINT` via the
  SQLAlchemy inspector (a wrong type would have shown here).
