### PR TITLE
ci(web): gate vitest in CI + fix stale frontend test mocks; drop stray lib/ gitignore rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
         run: pnpm exec tsc --noEmit
         continue-on-error: true
 
+      - name: Run tests
+        run: pnpm test
+
       - name: Build
         run: pnpm build
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
 parts/
 sdist/
 var/

--- a/apps/web/lib/__tests__/api.test.ts
+++ b/apps/web/lib/__tests__/api.test.ts
@@ -23,6 +23,7 @@ describe('API client', () => {
         get: (key: string) => key === 'content-type' ? 'application/json' : null,
       },
       json: () => Promise.resolve(mockData),
+      text: () => Promise.resolve(JSON.stringify(mockData)),
     }))
 
     const result = await api.get('/test')
@@ -38,6 +39,7 @@ describe('API client', () => {
         get: (key: string) => key === 'content-type' ? 'application/json' : null,
       },
       json: () => Promise.resolve({}),
+      text: () => Promise.resolve(JSON.stringify({})),
     }))
 
     await api.get('/test')
@@ -89,6 +91,7 @@ describe('API client', () => {
           get: (key: string) => key === 'content-type' ? 'application/json' : null,
         },
         json: () => Promise.resolve({ success: true }),
+        text: () => Promise.resolve(JSON.stringify({ success: true })),
       })
 
     vi.stubGlobal('fetch', fetchMock)

--- a/apps/web/stores/__tests__/notification-store.test.ts
+++ b/apps/web/stores/__tests__/notification-store.test.ts
@@ -6,6 +6,7 @@ vi.mock('@/lib/api', () => ({
   api: {
     get: vi.fn(),
     patch: vi.fn(),
+    post: vi.fn(),
   },
 }))
 
@@ -80,7 +81,7 @@ describe('Notification store', () => {
   })
 
   it('markAllRead resets unread count to 0', async () => {
-    vi.mocked(api.patch).mockResolvedValue(undefined)
+    vi.mocked(api.post).mockResolvedValue(undefined)
     useNotificationStore.setState({
       notifications: mockNotifications,
       unreadCount: 1,
@@ -91,11 +92,11 @@ describe('Notification store', () => {
     const state = useNotificationStore.getState()
     expect(state.unreadCount).toBe(0)
     expect(state.notifications.every((n) => n.read)).toBe(true)
-    expect(api.patch).toHaveBeenCalledWith('/notifications/read-all', {})
+    expect(api.post).toHaveBeenCalledWith('/me/notifications/read-all')
   })
 
   it('markAsRead marks a specific notification as read', async () => {
-    vi.mocked(api.patch).mockResolvedValue(undefined)
+    vi.mocked(api.post).mockResolvedValue(undefined)
     useNotificationStore.setState({
       notifications: mockNotifications,
       unreadCount: 1,
@@ -106,6 +107,6 @@ describe('Notification store', () => {
     const state = useNotificationStore.getState()
     expect(state.notifications.find((n) => n.id === 'n1')?.read).toBe(true)
     expect(state.unreadCount).toBe(0)
-    expect(api.patch).toHaveBeenCalledWith('/notifications/n1/read', {})
+    expect(api.post).toHaveBeenCalledWith('/me/notifications/n1/read')
   })
 })


### PR DESCRIPTION
## What & why

The frontend `vitest` suite was **never run in CI** (only `tsc` + `next build`), so ~5 stale-mock failures sat red unnoticed. This gates the suite, fixes the failures, and removes a `.gitignore` rule that was silently ignoring `apps/web/lib/`.

## Changes

**CI gate** — add a blocking `Run tests` step (`pnpm test` = `vitest run`) to the **Frontend Build** job.

**Fix pre-existing failures** (source evolved, mocks didn't):
- `lib/__tests__/api.test.ts` — `request()` reads `response.text()`; mocks only had `.json()`. Added `.text()` to the 3 success mocks.
- `stores/__tests__/notification-store.test.ts` — store calls `api.post('/me/notifications/…')`; test mocked `api.patch` on old `/notifications/…` paths. Mock `post` + match the store.

**gitignore** — remove `lib/` / `lib64/` (Python-template leftovers) that matched `apps/web/lib/`.

## Verification
- `vitest run`: **13 files, 113 tests pass** (5 were failing).
- `git check-ignore apps/web/lib/*` now returns nothing; CI YAML validated.

No CHANGELOG entry — internal CI/test tooling, not user-facing.

## Merge order
Independent of the storage-cap stack (#98–#102) — recommend merging this **first**, then rebasing the stack onto the new `main` so its branches inherit the vitest gate + fixes.
