### PR TITLE
test(ci): SetupGuard bypass fixture so client tests pass in CI + zero-failure gate (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,10 @@ jobs:
 
       - name: Run tests
         run: |
+          set -o pipefail
           python -m pytest apps/api/tests/ -v --tb=short 2>&1 | tee test-output.txt
-          # Extract passed count and enforce minimum
+          # pipefail above makes this step fail on ANY test failure (zero-failure gate).
+          # The floor below additionally guards against tests being deleted or gutted.
           PASSED=$(grep -oP '\d+ passed' test-output.txt | grep -oP '\d+')
           echo "Tests passed: $PASSED"
           if [ -z "$PASSED" ] || [ "$PASSED" -lt 40 ]; then

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -124,6 +124,16 @@ def auth_headers(client, mock_db, test_user):
     app.dependency_overrides.pop(get_current_user, None)
 
 
+@pytest.fixture(autouse=True)
+def _bypass_setup_guard(monkeypatch):
+    """Mark initial setup complete so SetupGuardMiddleware doesn't 503 auth-gated client tests.
+    The middleware caches a module-level `_setup_complete` flag checked against the REAL DB (its own
+    SessionLocal, ignoring the get_db override); a fresh CI DB has no superadmin, so without this every
+    client request 503s (masked only by the >=40 floor). No test asserts the needs_setup/503 path, so a
+    blanket bypass is safe; monkeypatch restores the flag after each test."""
+    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
+
+
 @pytest.fixture
 def real_db():
     """Real-Postgres session inside a transaction that is always rolled back (no writes persist).

--- a/apps/api/tests/test_admin_purge.py
+++ b/apps/api/tests/test_admin_purge.py
@@ -2,15 +2,13 @@
 import apps.api.routers.admin as admin_module
 
 
-def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
+def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user):
     test_user.is_superadmin = False
     resp = client.post("/admin/purge", headers=auth_headers)
     assert resp.status_code == 403
 
 
 def test_purge_enqueues_task_for_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     test_user.is_superadmin = True
     calls = []
     monkeypatch.setattr(admin_module, "send_task_safe", lambda task, *a, **k: calls.append(task))

--- a/apps/api/tests/test_upload_folder_validation.py
+++ b/apps/api/tests/test_upload_folder_validation.py
@@ -30,7 +30,6 @@ def _valid_body(**overrides):
 def test_initiate_upload_rejects_soft_deleted_or_foreign_folder(
     client, auth_headers, mock_db, test_user, monkeypatch
 ):
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     # Bypass the upstream gates so we isolate the folder-validation path.
     monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
     monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
@@ -51,7 +50,6 @@ def test_initiate_upload_allows_valid_folder(
     client, auth_headers, mock_db, test_user, monkeypatch
 ):
     """Sanity check: a real, project-owned, non-deleted folder is accepted."""
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
     monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
     monkeypatch.setattr(
@@ -85,7 +83,6 @@ def test_initiate_upload_new_version_ignores_bad_folder(
     (e.g. now-trashed) folder_id must not cause a spurious 404 -- there is no
     data-loss risk in this branch.
     """
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
     monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Fixes #108. `SetupGuardMiddleware` 503s every auth-gated route until a superadmin exists in the real DB — so on a fresh CI DB the ~26 `client`-based tests were failing, masked only by the CI gate being a `>= 40 passed` floor. This centralizes the bypass and turns the gate into a real zero-failure check. **Stacked on #107 → #106.**

## Changes

- **Autouse `conftest.py` fixture** `_bypass_setup_guard` sets `apps.api.middleware.setup_guard._setup_complete = True` per test (auto-restored). No test asserts the `needs_setup`/503 path (verified — no `test_setup.py`, no such assertions), so a blanket bypass is safe.
- Removed the now-redundant per-test `_setup_complete` monkeypatches in `test_admin_purge.py` / `test_upload_folder_validation.py` (and the newly-unused `monkeypatch` param on one test).
- **`.github/workflows/ci.yml`**: added `set -o pipefail` before the `pytest | tee` pipeline so **any** test failure now fails the job (zero-failure gate); kept the `>= 40 passed` floor as a secondary "tests deleted/gutted" guard.

## Testing

- [x] Backend tests pass — full suite now **123 passed, 0 failed** against real Postgres (was ~89 passed / 26 SetupGuard-503 failed before this change).
- [ ] Frontend builds — N/A
- [ ] Tested manually in browser — N/A

Closes #108.
