### PR TITLE
feat(gc): report-only-first S3 orphan sweeper (#110)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,3 +99,5 @@ EMAIL_CONCURRENCY=2            # Parallel email sending jobs
 TRANSCODER_ENGINE=ffmpeg
 MAX_UPLOAD_BYTES=0             # Max size (bytes) for one uploaded file; 0 = unlimited
 SOFT_DELETE_RETENTION_DAYS=30  # Hard-delete rows soft-deleted longer than N days (cascade + S3 reclaim); 0 = disabled
+ORPHAN_SWEEP_GRACE_HOURS=0    # S3 orphan sweeper: reclaim raw/+processed/ keys with no DB row; 0 = disabled; >0 = only keys older than N hours
+ORPHAN_SWEEP_DELETE=false     # false = report-only (log only); true = actually delete orphans

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -51,6 +51,13 @@ class Settings(BaseSettings):
     # S3 objects reclaimed. Days. 0 (or negative) DISABLES the sweep (matches the reaper convention).
     soft_delete_retention_days: int = 30
 
+    # Orphan S3 sweeper (issue #65 follow-up): reclaim bucket keys under raw/ + processed/ that no
+    # MediaFile row owns. 0 = disabled. When > 0, only keys whose S3 LastModified is older than this
+    # many hours are considered, so in-flight / just-committed uploads are never mistaken for orphans.
+    orphan_sweep_grace_hours: int = 0
+    # Report-only by default: when False the sweeper only LOGS what it would delete; set True to delete.
+    orphan_sweep_delete: bool = False
+
     # Worker concurrency settings
     transcoding_concurrency: int = 2  # Number of concurrent video transcoding jobs
     email_concurrency: int = 2  # Number of concurrent email sending jobs

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -250,6 +250,20 @@ def list_stale_multipart_uploads(cutoff):
     return stale
 
 
+def list_keys(prefix: str):
+    """Yield (key, last_modified, size) for every object under `prefix`, paginated."""
+    s3 = get_s3_client()
+    kwargs = {"Bucket": settings.s3_bucket, "Prefix": prefix}
+    while True:
+        resp = s3.list_objects_v2(**kwargs)
+        for o in resp.get("Contents", []):
+            yield o["Key"], o["LastModified"], o["Size"]
+        if resp.get("IsTruncated"):
+            kwargs["ContinuationToken"] = resp.get("NextContinuationToken")
+        else:
+            break
+
+
 def delete_prefix(prefix: str) -> None:
     """Delete every object whose key starts with `prefix` (works for a single key too —
     a key is its own prefix). Used to reclaim HLS folders and single processed keys."""

--- a/apps/api/tasks/celery_app.py
+++ b/apps/api/tasks/celery_app.py
@@ -70,6 +70,10 @@ celery_app.conf.beat_schedule = {
         "task": "cleanup_soft_deleted",
         "schedule": crontab(minute=0, hour=3),  # daily at 03:00 UTC
     },
+    "sweep-orphan-s3": {
+        "task": "sweep_orphan_s3",
+        "schedule": crontab(minute=0, hour=4, day_of_week=0),  # weekly, Sunday 04:00 UTC
+    },
 }
 
 

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -19,7 +19,7 @@ from ..models.metadata import MetadataField, AssetMetadata, Collection, Collecti
 from ..models.branding import ProjectBranding, WatermarkSettings
 from ..models.activity import Mention, ActivityLog, Notification
 from ..services.s3_service import (
-    list_stale_multipart_uploads, abort_multipart_upload, delete_object, delete_prefix,
+    list_stale_multipart_uploads, abort_multipart_upload, delete_object, delete_prefix, list_keys,
 )
 
 log = logging.getLogger("celery.cleanup")
@@ -354,5 +354,81 @@ def cleanup_soft_deleted():
         db.commit()
         log.info("cleanup: %s", asdict(counts))
         return asdict(counts)
+    finally:
+        db.close()
+
+
+_ORPHAN_SWEEP_PREFIXES = ("raw/", "processed/")
+
+
+@dataclass
+class OrphanSweepCounts:
+    grace_hours: int = 0
+    delete_enabled: bool = False
+    scanned: int = 0
+    orphans: int = 0
+    orphan_bytes: int = 0
+    deleted: int = 0
+
+
+def _sweep_orphan_s3(db) -> OrphanSweepCounts:
+    """Report (and optionally delete) S3 keys under raw/ and processed/ that no MediaFile row owns.
+    Report-only unless orphan_sweep_delete is True. Only keys older than orphan_sweep_grace_hours
+    (0 disables) are considered. Read-only on the DB (no commit). A key is LIVE if it is a
+    MediaFile.s3_key_raw / s3_key_thumbnail, or lives under processed/{project_id}/{asset_id}/{version_id}/
+    (= the transcode output_prefix) for some MediaFile — derived from the raw key
+    `raw/{project_id}/{asset_id}/{version_id}/...`. MediaFile is queried UNFILTERED on purpose: a
+    soft-deleted-but-not-yet-purged asset still owns its S3 and belongs to the retention GC, not here."""
+    grace = settings.orphan_sweep_grace_hours
+    counts = OrphanSweepCounts(grace_hours=grace, delete_enabled=settings.orphan_sweep_delete)
+    if grace <= 0:
+        log.info("orphan-sweep: disabled (orphan_sweep_grace_hours=%s)", grace)
+        return counts
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=grace)
+
+    exact_live: set = set()
+    processed_roots: set = set()
+    for raw, thumb in db.query(MediaFile.s3_key_raw, MediaFile.s3_key_thumbnail).all():
+        if raw:
+            exact_live.add(raw)
+            parts = raw.split("/")  # raw/{project_id}/{asset_id}/{version_id}/original.ext
+            if len(parts) >= 4 and parts[0] == "raw":
+                processed_roots.add("processed/" + "/".join(parts[1:4]) + "/")
+        if thumb:
+            exact_live.add(thumb)
+
+    def _is_live(key):
+        return key in exact_live or any(key.startswith(root) for root in processed_roots)
+
+    orphans = []
+    for prefix in _ORPHAN_SWEEP_PREFIXES:
+        for key, last_modified, size in list_keys(prefix):
+            counts.scanned += 1
+            if last_modified >= cutoff:
+                continue  # too recent — may be an in-flight / just-committed upload
+            if _is_live(key):
+                continue
+            orphans.append((key, size))
+
+    counts.orphans = len(orphans)
+    counts.orphan_bytes = sum(s for _, s in orphans)
+    if counts.delete_enabled:
+        for key, _ in orphans:
+            _safe(delete_object, key)
+            counts.deleted += 1
+        log.info("orphan-sweep: deleted %d/%d orphan key(s), %d bytes", counts.deleted, counts.orphans, counts.orphan_bytes)
+    else:
+        log.info("orphan-sweep: REPORT-ONLY — %d orphan key(s) under %s, %d bytes "
+                 "(set ORPHAN_SWEEP_DELETE=true to reclaim). sample=%s",
+                 counts.orphans, list(_ORPHAN_SWEEP_PREFIXES), counts.orphan_bytes, [k for k, _ in orphans[:10]])
+    return counts
+
+
+@celery_app.task(name="sweep_orphan_s3")
+def sweep_orphan_s3():
+    """Periodic beat task: report (or delete) orphaned S3 objects. Off until ORPHAN_SWEEP_GRACE_HOURS>0."""
+    db = SessionLocal()
+    try:
+        return asdict(_sweep_orphan_s3(db))
     finally:
         db.close()

--- a/apps/api/tests/test_orphan_sweep.py
+++ b/apps/api/tests/test_orphan_sweep.py
@@ -1,0 +1,70 @@
+"""Tests for the S3 orphan sweeper (issue #110)."""
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import apps.api.tasks.cleanup_tasks as ct
+from apps.api.config import settings
+from apps.api.models.user import User
+from apps.api.models.project import Project, ProjectType
+from apps.api.models.asset import Asset, AssetType, AssetVersion, MediaFile, FileType, ProcessingStatus
+
+
+def _seed_media(db):
+    u = User(email=f"orph-{uuid.uuid4()}@t.local", name="t"); db.add(u); db.flush()
+    p = Project(name="t", project_type=ProjectType.personal, created_by=u.id); db.add(p); db.flush()
+    a = Asset(project_id=p.id, name="t", asset_type=AssetType.video, created_by=u.id); db.add(a); db.flush()
+    v = AssetVersion(asset_id=a.id, version_number=1, processing_status=ProcessingStatus.ready, created_by=u.id); db.add(v); db.flush()
+    raw = f"raw/{p.id}/{a.id}/{v.id}/original.mp4"
+    mf = MediaFile(version_id=v.id, file_type=FileType.video, original_filename="f.mp4", mime_type="video/mp4",
+                   file_size_bytes=100, s3_key_raw=raw,
+                   s3_key_processed=f"processed/{p.id}/{a.id}/{v.id}",
+                   s3_key_thumbnail=f"processed/{p.id}/{a.id}/{v.id}/thumb0.jpg")
+    db.add(mf); db.flush()
+    return str(p.id), str(a.id), str(v.id), raw
+
+
+def _run(db, monkeypatch, all_keys, grace=24, delete=False):
+    monkeypatch.setattr(settings, "orphan_sweep_grace_hours", grace)
+    monkeypatch.setattr(settings, "orphan_sweep_delete", delete)
+    deleted = []
+    monkeypatch.setattr(ct, "delete_object", lambda k: deleted.append(k))
+    monkeypatch.setattr(ct, "list_keys", lambda prefix: [(k, lm, s) for (k, lm, s) in all_keys if k.startswith(prefix)])
+    counts = ct._sweep_orphan_s3(db)
+    return counts, deleted
+
+
+def test_orphan_sweep_reports_only_true_orphans(real_db, monkeypatch):
+    pid, aid, vid, raw = _seed_media(real_db)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    recent = datetime.now(timezone.utc) - timedelta(hours=1)
+    all_keys = [
+        (raw, old, 100),                                              # live raw -> not orphan
+        (f"processed/{pid}/{aid}/{vid}/720p/seg001.ts", old, 200),    # HLS segment under live prefix -> not orphan
+        (f"processed/{pid}/{aid}/{vid}/thumb0.jpg", old, 10),         # live thumbnail -> not orphan
+        ("raw/dead-proj/dead-asset/dead-ver/original.mp4", old, 500), # genuine orphan
+        ("processed/ghost/ghost/ghost/master.m3u8", recent, 300),     # unknown but RECENT -> skipped (grace)
+    ]
+    counts, deleted = _run(real_db, monkeypatch, all_keys, grace=24, delete=False)
+    assert counts.orphans == 1 and counts.orphan_bytes == 500
+    assert counts.deleted == 0 and deleted == []                      # report-only
+
+
+def test_orphan_sweep_deletes_only_orphan_when_enabled(real_db, monkeypatch):
+    pid, aid, vid, raw = _seed_media(real_db)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    all_keys = [
+        (raw, old, 100),
+        (f"processed/{pid}/{aid}/{vid}/720p/seg001.ts", old, 200),
+        ("raw/dead/dead/dead/original.mp4", old, 500),
+    ]
+    counts, deleted = _run(real_db, monkeypatch, all_keys, grace=24, delete=True)
+    assert counts.deleted == 1
+    assert deleted == ["raw/dead/dead/dead/original.mp4"]             # only the orphan; live keys untouched
+
+
+def test_orphan_sweep_disabled_when_grace_zero(mock_db, monkeypatch):
+    monkeypatch.setattr(settings, "orphan_sweep_grace_hours", 0)
+    called = []
+    monkeypatch.setattr(ct, "list_keys", lambda prefix: called.append(prefix) or [])
+    counts = ct._sweep_orphan_s3(mock_db)
+    assert counts.orphans == 0 and called == []                      # never listed the bucket


### PR DESCRIPTION
## Summary

Closes #110 (the S3 orphan sweeper deferred from #65). Reclaims bucket keys under `raw/` and `processed/` that no `MediaFile` row owns. **Top of the stack: base `chore/setup-guard-test-fixture` → #108 → #107 → #106** — merge those first.

Built **report-only-first**, because the one way this hurts is deleting a live object it wrongly thinks is orphaned:

- **Off by default** — `ORPHAN_SWEEP_GRACE_HOURS=0` disables it. When > 0, only keys whose S3 `LastModified` is older than the window are considered, so in-flight / just-committed uploads are never flagged.
- **Report-only by default** — `ORPHAN_SWEEP_DELETE=false` logs what it *would* delete; deletion happens only when an operator explicitly sets it `true`.

## Changes

- **`services/s3_service.py`** — `list_keys(prefix)`: paginated `list_objects_v2` yielding `(key, last_modified, size)`.
- **`tasks/cleanup_tasks.py`** — `_sweep_orphan_s3(db)` + a weekly `sweep_orphan_s3` beat task. Live-key logic (read-only on the DB): a key is live if it equals a `MediaFile.s3_key_raw`/`s3_key_thumbnail`, or lives under `processed/{project_id}/{asset_id}/{version_id}/` (the transcode `output_prefix`, under which *all* processed outputs — HLS incl. segments, mp3, webp, thumbnails, waveforms — are written), derived from the raw key. `MediaFile` is queried without any live/deleted filter, so soft-deleted-but-not-yet-purged media (owned by the retention GC) is never treated as an orphan.
- **`config.py` / `.env.example`** — the two flags above, documented.
- **`tasks/celery_app.py`** — `sweep-orphan-s3` beat entry (weekly, Sun 04:00 UTC).

## Testing

- [x] Backend tests pass — real-Postgres + faked `list_keys`: a live raw key, a live HLS segment reached only via the prefix match, and a live thumbnail are **never** flagged; only a genuine no-DB-row key is reported; a within-grace key is skipped; `delete=false` deletes nothing; `delete=true` deletes **only** the orphan; `grace_hours=0` disables (never lists the bucket). Full suite 126 passed.
- [ ] Frontend / manual — N/A (backend only)

Closes #110.
