### PR TITLE
feat: garbage collection for #65 — retention GC + orphan sweeper + data-safety fixes (release candidate)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,3 +98,4 @@ TRANSCODING_CONCURRENCY=2     # Parallel video transcoding jobs (CPU intensive)
 EMAIL_CONCURRENCY=2            # Parallel email sending jobs
 TRANSCODER_ENGINE=ffmpeg
 MAX_UPLOAD_BYTES=0             # Max size (bytes) for one uploaded file; 0 = unlimited
+SOFT_DELETE_RETENTION_DAYS=30  # Hard-delete rows soft-deleted longer than N days (cascade + S3 reclaim); 0 = disabled

--- a/.env.example
+++ b/.env.example
@@ -99,3 +99,5 @@ EMAIL_CONCURRENCY=2            # Parallel email sending jobs
 TRANSCODER_ENGINE=ffmpeg
 MAX_UPLOAD_BYTES=0             # Max size (bytes) for one uploaded file; 0 = unlimited
 SOFT_DELETE_RETENTION_DAYS=30  # Hard-delete rows soft-deleted longer than N days (cascade + S3 reclaim); 0 = disabled
+ORPHAN_SWEEP_GRACE_HOURS=0    # S3 orphan sweeper: reclaim raw/+processed/ keys with no DB row; 0 = disabled; >0 = only keys older than N hours
+ORPHAN_SWEEP_DELETE=false     # false = report-only (log only); true = actually delete orphans

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,10 @@ jobs:
 
       - name: Run tests
         run: |
+          set -o pipefail
           python -m pytest apps/api/tests/ -v --tb=short 2>&1 | tee test-output.txt
-          # Extract passed count and enforce minimum
+          # pipefail above makes this step fail on ANY test failure (zero-failure gate).
+          # The floor below additionally guards against tests being deleted or gutted.
           PASSED=$(grep -oP '\d+ passed' test-output.txt | grep -oP '\d+')
           echo "Tests passed: $PASSED"
           if [ -z "$PASSED" ] || [ "$PASSED" -lt 40 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Retention-window garbage collection** ([#65](https://github.com/Techiebutler/freeframe/issues/65)) — a daily `cleanup_soft_deleted` job hard-deletes rows soft-deleted longer than `SOFT_DELETE_RETENTION_DAYS` (default 30, `0` disables) and reclaims their S3 objects, cascading through projects, folders, assets, versions, media, comments, approvals, and share links. Long-expired share links are swept into soft-delete first. No effect unless you run `celery beat`.
-- **Manual `POST /admin/purge` endpoint** — superadmin-only; runs the retention collector on demand and returns the reclaimed counts.
+- **Manual `POST /admin/purge` endpoint** — superadmin-only; triggers the retention collector to run in the background (returns `202`); reclaimed counts are logged by the worker.
 
 ## [1.2.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Retention-window garbage collection** ([#65](https://github.com/Techiebutler/freeframe/issues/65)) — a daily `cleanup_soft_deleted` job hard-deletes rows soft-deleted longer than `SOFT_DELETE_RETENTION_DAYS` (default 30, `0` disables) and reclaims their S3 objects, cascading through projects, folders, assets, versions, media, comments, approvals, and share links. Long-expired share links are swept into soft-delete first. No effect unless you run `celery beat`.
+- **Manual `POST /admin/purge` endpoint** — superadmin-only; runs the retention collector on demand and returns the reclaimed counts.
+
 ## [1.2.0] - 2026-07-07
 
 ### Upgrade notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Retention-window garbage collection** ([#65](https://github.com/Techiebutler/freeframe/issues/65)) — a daily `cleanup_soft_deleted` job hard-deletes rows soft-deleted longer than `SOFT_DELETE_RETENTION_DAYS` (default 30, `0` disables) and reclaims their S3 objects, cascading through projects, folders, assets, versions, media, comments, approvals, and share links. Long-expired share links are swept into soft-delete first. No effect unless you run `celery beat`.
+- **S3 orphan sweeper** ([#65](https://github.com/Techiebutler/freeframe/issues/65)) — an opt-in weekly `sweep_orphan_s3` job reclaims bucket objects under `raw/`/`processed/` that no `MediaFile` row references. **Off and report-only by default**: set `ORPHAN_SWEEP_GRACE_HOURS` > 0 to enable (only keys older than that window are considered, so active uploads are never touched) and `ORPHAN_SWEEP_DELETE=true` to actually delete (otherwise it just logs what it would reclaim). No effect unless you run `celery beat`.
 - **Manual `POST /admin/purge` endpoint** — superadmin-only; triggers the retention collector to run in the background (returns `202`); reclaimed counts are logged by the worker.
+
+### Changed
+- **`POST /assets/{id}/restore` and `/folders/{id}/restore` now return `409`** when the item's project has been deleted — a deleted project has no restore path, so there is nothing to restore into.
 
 ## [1.2.0] - 2026-07-07
 

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -51,6 +51,13 @@ class Settings(BaseSettings):
     # S3 objects reclaimed. Days. 0 (or negative) DISABLES the sweep (matches the reaper convention).
     soft_delete_retention_days: int = 30
 
+    # Orphan S3 sweeper (issue #65 follow-up): reclaim bucket keys under raw/ + processed/ that no
+    # MediaFile row owns. 0 = disabled. When > 0, only keys whose S3 LastModified is older than this
+    # many hours are considered, so in-flight / just-committed uploads are never mistaken for orphans.
+    orphan_sweep_grace_hours: int = 0
+    # Report-only by default: when False the sweeper only LOGS what it would delete; set True to delete.
+    orphan_sweep_delete: bool = False
+
     # Worker concurrency settings
     transcoding_concurrency: int = 2  # Number of concurrent video transcoding jobs
     email_concurrency: int = 2  # Number of concurrent email sending jobs

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -47,6 +47,10 @@ class Settings(BaseSettings):
     # Reaper: uploads stuck in `uploading`/`failed` longer than this are reclaimed. Hours.
     stale_upload_timeout_hours: int = 24
 
+    # Retention GC: rows soft-deleted (deleted_at) longer than this are hard-deleted and their
+    # S3 objects reclaimed. Days. 0 (or negative) DISABLES the sweep (matches the reaper convention).
+    soft_delete_retention_days: int = 30
+
     # Worker concurrency settings
     transcoding_concurrency: int = 2  # Number of concurrent video transcoding jobs
     email_concurrency: int = 2  # Number of concurrent email sending jobs

--- a/apps/api/routers/admin.py
+++ b/apps/api/routers/admin.py
@@ -120,7 +120,9 @@ def purge_now(current_user: User = Depends(require_admin)):
 
     Superadmin only. Enqueues the same `cleanup_soft_deleted` task the daily beat runs, so the
     request returns immediately instead of blocking on a potentially long cascade + S3 deletes.
-    Reclaimed counts are logged by the worker.
+    Reclaimed counts are logged by the worker. If a purge is already running (e.g. the daily beat),
+    the advisory lock serializes purges and this enqueued run is skipped rather than double-cascading,
+    so a 202 here means "enqueued", not "a fresh run happened".
     """
     send_task_safe(cleanup_soft_deleted)
     return PurgeStartResponse(

--- a/apps/api/routers/admin.py
+++ b/apps/api/routers/admin.py
@@ -4,10 +4,15 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 import uuid
 
+from dataclasses import asdict
+
 from ..database import get_db
 from ..middleware.auth import get_current_user
 from ..models.user import User, UserStatus
 from ..schemas.auth import UserResponse, UpdateUserRoleRequest
+from .users import require_admin
+from ..tasks.cleanup_tasks import _run_cleanup
+from ..schemas.admin import PurgeResult
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -109,3 +114,17 @@ def update_user_role(
     db.commit()
     db.refresh(user)
     return user
+
+@router.post("/purge", response_model=PurgeResult)
+def purge_now(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """Run the retention-window garbage collector now and return what was reclaimed.
+
+    Superadmin only. Runs synchronously; typical self-hosted installs finish quickly. Large
+    installs should rely on the daily `cleanup_soft_deleted` beat task instead.
+    """
+    counts = _run_cleanup(db)
+    db.commit()
+    return PurgeResult(**asdict(counts))

--- a/apps/api/routers/admin.py
+++ b/apps/api/routers/admin.py
@@ -4,15 +4,14 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 import uuid
 
-from dataclasses import asdict
-
 from ..database import get_db
 from ..middleware.auth import get_current_user
 from ..models.user import User, UserStatus
 from ..schemas.auth import UserResponse, UpdateUserRoleRequest
 from .users import require_admin
-from ..tasks.cleanup_tasks import _run_cleanup
-from ..schemas.admin import PurgeResult
+from ..tasks.celery_app import send_task_safe
+from ..tasks.cleanup_tasks import cleanup_soft_deleted
+from ..schemas.admin import PurgeStartResponse
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -115,16 +114,16 @@ def update_user_role(
     db.refresh(user)
     return user
 
-@router.post("/purge", response_model=PurgeResult)
-def purge_now(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_admin),
-):
-    """Run the retention-window garbage collector now and return what was reclaimed.
+@router.post("/purge", response_model=PurgeStartResponse, status_code=status.HTTP_202_ACCEPTED)
+def purge_now(current_user: User = Depends(require_admin)):
+    """Trigger the retention-window garbage collector to run now, in the background.
 
-    Superadmin only. Runs synchronously; typical self-hosted installs finish quickly. Large
-    installs should rely on the daily `cleanup_soft_deleted` beat task instead.
+    Superadmin only. Enqueues the same `cleanup_soft_deleted` task the daily beat runs, so the
+    request returns immediately instead of blocking on a potentially long cascade + S3 deletes.
+    Reclaimed counts are logged by the worker.
     """
-    counts = _run_cleanup(db)
-    db.commit()
-    return PurgeResult(**asdict(counts))
+    send_task_safe(cleanup_soft_deleted)
+    return PurgeStartResponse(
+        status="started",
+        detail="Retention garbage collection is running in the background; see worker logs for reclaimed counts.",
+    )

--- a/apps/api/routers/folders.py
+++ b/apps/api/routers/folders.py
@@ -10,7 +10,7 @@ from ..database import get_db
 from ..middleware.auth import get_current_user
 from ..models.asset import Asset
 from ..models.folder import Folder
-from ..models.project import ProjectRole
+from ..models.project import Project, ProjectRole
 from ..models.user import User
 from ..schemas.folder import (
     AssetMoveRequest,
@@ -467,6 +467,12 @@ def restore_asset(
 
     require_project_role(db, asset.project_id, current_user, ProjectRole.editor)
 
+    # A deleted project has no restore path, so restoring an asset into a soft-deleted project would be
+    # a false success — the retention GC's project cascade would silently hard-delete it. Refuse.
+    project = db.query(Project).filter(Project.id == asset.project_id).first()
+    if project is None or project.deleted_at is not None:
+        raise HTTPException(status_code=409, detail="Cannot restore: the project has been deleted")
+
     # If parent folder is deleted, move to root
     if asset.folder_id:
         parent_folder = (
@@ -493,6 +499,10 @@ def restore_folder(
         raise HTTPException(status_code=404, detail="Deleted folder not found")
 
     require_project_role(db, folder.project_id, current_user, ProjectRole.editor)
+
+    project = db.query(Project).filter(Project.id == folder.project_id).first()
+    if project is None or project.deleted_at is not None:
+        raise HTTPException(status_code=409, detail="Cannot restore: the project has been deleted")
 
     # If parent folder is deleted, restore to root
     if folder.parent_id:

--- a/apps/api/routers/upload.py
+++ b/apps/api/routers/upload.py
@@ -44,18 +44,6 @@ def initiate_upload(
         raise HTTPException(status_code=404, detail="Project not found")
     require_project_role(db, body.project_id, current_user, ProjectRole.editor)
 
-    # Validate the target folder (if any): it must exist, belong to this project, and not be
-    # soft-deleted. Without this, a live asset could be created under a trashed folder and then
-    # hard-deleted by the retention GC's folder cascade (mirrors move_asset/bulk_move's _get_folder).
-    if body.folder_id is not None:
-        folder = db.query(Folder).filter(
-            Folder.id == body.folder_id,
-            Folder.project_id == body.project_id,
-            Folder.deleted_at.is_(None),
-        ).first()
-        if not folder:
-            raise HTTPException(status_code=404, detail="Folder not found")
-
     # Get or create asset
     if body.asset_id:
         asset = db.query(Asset).filter(Asset.id == body.asset_id, Asset.deleted_at.is_(None)).first()
@@ -64,6 +52,19 @@ def initiate_upload(
         if asset.project_id != body.project_id:
             raise HTTPException(status_code=400, detail="Asset does not belong to the specified project")
     else:
+        # Validate the target folder for a new asset: it must exist, belong to this project, and not
+        # be soft-deleted -- otherwise a live asset could be placed under a trashed folder and later
+        # hard-deleted by the retention GC's folder cascade. folder_id is only persisted here (new
+        # asset); the new-version path above ignores it, so it must not be validated there.
+        if body.folder_id is not None:
+            folder = db.query(Folder).filter(
+                Folder.id == body.folder_id,
+                Folder.project_id == body.project_id,
+                Folder.deleted_at.is_(None),
+            ).first()
+            if not folder:
+                raise HTTPException(status_code=404, detail="Folder not found")
+
         asset_type = mime_to_asset_type(body.mime_type)
         asset = Asset(
             project_id=body.project_id,

--- a/apps/api/routers/upload.py
+++ b/apps/api/routers/upload.py
@@ -7,6 +7,7 @@ from ..database import get_db
 from ..middleware.auth import get_current_user
 from ..models.user import User
 from ..models.asset import Asset, AssetVersion, MediaFile, AssetType, ProcessingStatus, FileType
+from ..models.folder import Folder
 from ..models.project import Project
 from ..services.s3_service import (
     create_multipart_upload, presign_upload_part,
@@ -42,6 +43,18 @@ def initiate_upload(
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
     require_project_role(db, body.project_id, current_user, ProjectRole.editor)
+
+    # Validate the target folder (if any): it must exist, belong to this project, and not be
+    # soft-deleted. Without this, a live asset could be created under a trashed folder and then
+    # hard-deleted by the retention GC's folder cascade (mirrors move_asset/bulk_move's _get_folder).
+    if body.folder_id is not None:
+        folder = db.query(Folder).filter(
+            Folder.id == body.folder_id,
+            Folder.project_id == body.project_id,
+            Folder.deleted_at.is_(None),
+        ).first()
+        if not folder:
+            raise HTTPException(status_code=404, detail="Folder not found")
 
     # Get or create asset
     if body.asset_id:

--- a/apps/api/schemas/admin.py
+++ b/apps/api/schemas/admin.py
@@ -1,15 +1,7 @@
 from pydantic import BaseModel
 
 
-class PurgeResult(BaseModel):
-    """Counts reclaimed by a manual/scheduled purge run."""
-    retention_days: int
-    projects: int
-    folders: int
-    assets: int
-    versions: int
-    media_files: int
-    comments: int
-    share_links: int
-    share_links_expired: int
-    s3_deletes: int
+class PurgeStartResponse(BaseModel):
+    """Response for the async manual purge trigger."""
+    status: str
+    detail: str

--- a/apps/api/schemas/admin.py
+++ b/apps/api/schemas/admin.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class PurgeResult(BaseModel):
+    """Counts reclaimed by a manual/scheduled purge run."""
+    retention_days: int
+    projects: int
+    folders: int
+    assets: int
+    versions: int
+    media_files: int
+    comments: int
+    share_links: int
+    share_links_expired: int
+    s3_deletes: int

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -250,6 +250,20 @@ def list_stale_multipart_uploads(cutoff):
     return stale
 
 
+def list_keys(prefix: str):
+    """Yield (key, last_modified, size) for every object under `prefix`, paginated."""
+    s3 = get_s3_client()
+    kwargs = {"Bucket": settings.s3_bucket, "Prefix": prefix}
+    while True:
+        resp = s3.list_objects_v2(**kwargs)
+        for o in resp.get("Contents", []):
+            yield o["Key"], o["LastModified"], o["Size"]
+        if resp.get("IsTruncated"):
+            kwargs["ContinuationToken"] = resp.get("NextContinuationToken")
+        else:
+            break
+
+
 def delete_prefix(prefix: str) -> None:
     """Delete every object whose key starts with `prefix` (works for a single key too —
     a key is its own prefix). Used to reclaim HLS folders and single processed keys."""

--- a/apps/api/tasks/celery_app.py
+++ b/apps/api/tasks/celery_app.py
@@ -66,6 +66,10 @@ celery_app.conf.beat_schedule = {
         "task": "reap_stale_uploads",
         "schedule": crontab(minute="0"),  # every hour
     },
+    "cleanup-soft-deleted": {
+        "task": "cleanup_soft_deleted",
+        "schedule": crontab(minute=0, hour=3),  # daily at 03:00 UTC
+    },
 }
 
 

--- a/apps/api/tasks/celery_app.py
+++ b/apps/api/tasks/celery_app.py
@@ -70,6 +70,10 @@ celery_app.conf.beat_schedule = {
         "task": "cleanup_soft_deleted",
         "schedule": crontab(minute=0, hour=3),  # daily at 03:00 UTC
     },
+    "sweep-orphan-s3": {
+        "task": "sweep_orphan_s3",
+        "schedule": crontab(minute=0, hour=4, day_of_week=0),  # weekly, Sunday 04:00 UTC
+    },
 }
 
 

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -113,6 +113,30 @@ def _purge_share_link(db, share_link_id, counts: PurgeCounts) -> None:
     db.flush()
 
 
+def _purge_asset(db, asset_id, counts: PurgeCounts) -> None:
+    """Hard-delete an asset and everything hanging off it."""
+    a = db.query(Asset).filter(Asset.id == asset_id).first()
+    if a is None:
+        return
+    for v in db.query(AssetVersion).filter(AssetVersion.asset_id == asset_id).all():
+        _purge_version(db, v.id, counts)
+    # defensive: comments not removed via a version (all comments have a version_id, so usually none)
+    for c in db.query(Comment).filter(Comment.asset_id == asset_id).all():
+        _purge_comment(db, c.id, counts)
+    db.query(Approval).filter(Approval.asset_id == asset_id).delete(synchronize_session=False)
+    db.query(AssetMetadata).filter(AssetMetadata.asset_id == asset_id).delete(synchronize_session=False)
+    for link in db.query(ShareLink).filter(ShareLink.asset_id == asset_id).all():
+        _purge_share_link(db, link.id, counts)
+    # share-link items in OTHER (multi-asset) links that reference this asset
+    db.query(ShareLinkItem).filter(ShareLinkItem.asset_id == asset_id).delete(synchronize_session=False)
+    db.query(AssetShare).filter(AssetShare.asset_id == asset_id).delete(synchronize_session=False)
+    db.query(ActivityLog).filter(ActivityLog.asset_id == asset_id).delete(synchronize_session=False)
+    db.query(Notification).filter(Notification.asset_id == asset_id).delete(synchronize_session=False)
+    db.query(Asset).filter(Asset.id == asset_id).delete(synchronize_session=False)
+    counts.assets += 1
+    db.flush()
+
+
 def _reap_stale_uploads(db) -> int:
     """Reclaim upload orphans. Mutates `db` (soft-deletes versions) but does NOT commit —
     the caller owns the transaction. Returns the number of versions soft-deleted."""

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -137,6 +137,24 @@ def _purge_asset(db, asset_id, counts: PurgeCounts) -> None:
     db.flush()
 
 
+def _purge_folder(db, folder_id, counts: PurgeCounts) -> None:
+    """Hard-delete a folder, its nested folders, its assets, and folder-scoped shares."""
+    f = db.query(Folder).filter(Folder.id == folder_id).first()
+    if f is None:
+        return
+    for child in db.query(Folder).filter(Folder.parent_id == folder_id).all():
+        _purge_folder(db, child.id, counts)
+    for a in db.query(Asset).filter(Asset.folder_id == folder_id).all():
+        _purge_asset(db, a.id, counts)
+    for link in db.query(ShareLink).filter(ShareLink.folder_id == folder_id).all():
+        _purge_share_link(db, link.id, counts)
+    db.query(ShareLinkItem).filter(ShareLinkItem.folder_id == folder_id).delete(synchronize_session=False)
+    db.query(AssetShare).filter(AssetShare.folder_id == folder_id).delete(synchronize_session=False)
+    db.query(Folder).filter(Folder.id == folder_id).delete(synchronize_session=False)
+    counts.folders += 1
+    db.flush()
+
+
 def _reap_stale_uploads(db) -> int:
     """Reclaim upload orphans. Mutates `db` (soft-deletes versions) but does NOT commit —
     the caller owns the transaction. Returns the number of versions soft-deleted."""

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from datetime import datetime, timezone, timedelta
 
 from .celery_app import celery_app
@@ -286,5 +286,27 @@ def reap_stale_uploads():
         n = _reap_stale_uploads(db)
         db.commit()
         return n
+    finally:
+        db.close()
+
+
+def _run_cleanup(db) -> PurgeCounts:
+    """Full cleanup pass: expire long-dead share links, then hard-delete aged soft-deletes.
+    Mutates db; the caller (task wrapper or admin endpoint) owns the commit."""
+    counts = PurgeCounts(retention_days=settings.soft_delete_retention_days)
+    _expire_share_links(db, counts)
+    _purge_soft_deleted(db, counts)
+    return counts
+
+
+@celery_app.task(name="cleanup_soft_deleted")
+def cleanup_soft_deleted():
+    """Daily beat task: retention-window GC + expired-share sweep."""
+    db = SessionLocal()
+    try:
+        counts = _run_cleanup(db)
+        db.commit()
+        log.info("cleanup: %s", asdict(counts))
+        return asdict(counts)
     finally:
         db.close()

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -19,7 +19,7 @@ from ..models.metadata import MetadataField, AssetMetadata, Collection, Collecti
 from ..models.branding import ProjectBranding, WatermarkSettings
 from ..models.activity import Mention, ActivityLog, Notification
 from ..services.s3_service import (
-    list_stale_multipart_uploads, abort_multipart_upload, delete_object, delete_prefix,
+    list_stale_multipart_uploads, abort_multipart_upload, delete_object, delete_prefix, list_keys,
 )
 
 log = logging.getLogger("celery.cleanup")
@@ -354,5 +354,81 @@ def cleanup_soft_deleted():
         db.commit()
         log.info("cleanup: %s", asdict(counts))
         return asdict(counts)
+    finally:
+        db.close()
+
+
+_ORPHAN_SWEEP_PREFIXES = ("raw/", "processed/")
+
+
+@dataclass
+class OrphanSweepCounts:
+    grace_hours: int = 0
+    delete_enabled: bool = False
+    scanned: int = 0
+    orphans: int = 0
+    orphan_bytes: int = 0
+    deleted: int = 0
+
+
+def _sweep_orphan_s3(db) -> OrphanSweepCounts:
+    """Report (and optionally delete) S3 keys under raw/ and processed/ that no MediaFile row owns.
+    Report-only unless orphan_sweep_delete is True. Only keys older than orphan_sweep_grace_hours
+    (0 disables) are considered. Read-only on the DB (no commit). A key is LIVE if it is a
+    MediaFile.s3_key_raw / s3_key_thumbnail, or lives under processed/{project_id}/{asset_id}/{version_id}/
+    (= the transcode output_prefix) for some MediaFile — derived from the raw key
+    `raw/{project_id}/{asset_id}/{version_id}/...`. MediaFile is queried UNFILTERED on purpose: a
+    soft-deleted-but-not-yet-purged asset still owns its S3 and belongs to the retention GC, not here."""
+    grace = settings.orphan_sweep_grace_hours
+    counts = OrphanSweepCounts(grace_hours=grace, delete_enabled=settings.orphan_sweep_delete)
+    if grace <= 0:
+        log.info("orphan-sweep: disabled (orphan_sweep_grace_hours=%s)", grace)
+        return counts
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=grace)
+
+    exact_live: set = set()
+    processed_roots: set = set()
+    for raw, thumb in db.query(MediaFile.s3_key_raw, MediaFile.s3_key_thumbnail).all():
+        if raw:
+            exact_live.add(raw)
+            parts = raw.split("/")  # raw/{project_id}/{asset_id}/{version_id}/original.ext
+            if len(parts) >= 4 and parts[0] == "raw":
+                processed_roots.add("processed/" + "/".join(parts[1:4]) + "/")
+        if thumb:
+            exact_live.add(thumb)
+
+    def _is_live(key):
+        return key in exact_live or any(key.startswith(root) for root in processed_roots)
+
+    orphans = []
+    for prefix in _ORPHAN_SWEEP_PREFIXES:
+        for key, last_modified, size in list_keys(prefix):
+            counts.scanned += 1
+            if last_modified >= cutoff:
+                continue  # too recent — may be an in-flight / just-committed upload
+            if _is_live(key):
+                continue
+            orphans.append((key, size))
+
+    counts.orphans = len(orphans)
+    counts.orphan_bytes = sum(s for _, s in orphans)
+    if counts.delete_enabled:
+        for key, _ in orphans:
+            _safe(delete_object, key)
+            counts.deleted += 1
+        log.info("orphan-sweep: deleted %d/%d orphan key(s), %d bytes", counts.deleted, counts.orphans, counts.orphan_bytes)
+    else:
+        log.info("orphan-sweep: REPORT-ONLY — %d orphan key(s) under %s, %d bytes "
+                 "(set ORPHAN_SWEEP_DELETE=true to reclaim). sample=%s",
+                 counts.orphans, list(_ORPHAN_SWEEP_PREFIXES), counts.orphan_bytes, [k for k, _ in orphans[:10]])
+    return counts
+
+
+@celery_app.task(name="sweep_orphan_s3")
+def sweep_orphan_s3():
+    """Periodic beat task: report (or delete) orphaned S3 objects. Off until ORPHAN_SWEEP_GRACE_HOURS>0."""
+    db = SessionLocal()
+    try:
+        return asdict(_sweep_orphan_s3(db))
     finally:
         db.close()

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -158,10 +158,18 @@ def _purge_folder(db, folder_id, counts: PurgeCounts) -> None:
     f = db.query(Folder).filter(Folder.id == folder_id).first()
     if f is None:
         return
-    for child in db.query(Folder).filter(Folder.parent_id == folder_id).all():
-        _purge_folder(db, child.id, counts)
-    for a in db.query(Asset).filter(Asset.folder_id == folder_id).all():
-        _purge_asset(db, a.id, counts)
+    child_ids = [c.id for c in db.query(Folder.id).filter(Folder.parent_id == folder_id).all()]
+    for cid in child_ids:
+        # re-check under lock: skip a child folder reparented out (e.g. restored to root) since the scan
+        if db.query(Folder).filter(Folder.id == cid, Folder.parent_id == folder_id).with_for_update().first() is None:
+            continue
+        _purge_folder(db, cid, counts)
+    asset_ids = [a.id for a in db.query(Asset.id).filter(Asset.folder_id == folder_id).all()]
+    for aid in asset_ids:
+        # re-check under lock: skip an asset reparented out (restored to root) since the scan
+        if db.query(Asset).filter(Asset.id == aid, Asset.folder_id == folder_id).with_for_update().first() is None:
+            continue
+        _purge_asset(db, aid, counts)
     for link in db.query(ShareLink).filter(ShareLink.folder_id == folder_id).all():
         _purge_share_link(db, link.id, counts)
     db.query(ShareLinkItem).filter(ShareLinkItem.folder_id == folder_id).delete(synchronize_session=False)
@@ -412,7 +420,14 @@ def _sweep_orphan_s3(db) -> OrphanSweepCounts:
 
     counts.orphans = len(orphans)
     counts.orphan_bytes = sum(s for _, s in orphans)
-    if counts.delete_enabled:
+
+    # Safety floor: a degenerate (empty) live-set — e.g. DATABASE_URL pointed at the wrong/empty DB —
+    # must never be allowed to mass-delete every scanned key as "orphaned". Report-only in that case.
+    live_set_empty = not exact_live and not processed_roots
+    if counts.delete_enabled and live_set_empty and orphans:
+        log.error("orphan-sweep: SAFETY ABORT — live-set is EMPTY (0 MediaFile rows) but %d key(s) scanned; "
+                  "refusing to delete (likely a wrong/empty DATABASE_URL). Reporting only.", counts.orphans)
+    if counts.delete_enabled and not (live_set_empty and orphans):
         for key, _ in orphans:
             _safe(delete_object, key)
             counts.deleted += 1

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -228,6 +228,27 @@ def _reap_stale_uploads(db) -> int:
     return len(versions)
 
 
+def _expire_share_links(db, counts: PurgeCounts) -> None:
+    """Soft-delete share links that expired BEYOND the retention window. Recently-expired links are
+    left alone so owners can still re-enable them (expiry is already 410-enforced at read time);
+    once aged past the window they flow into the normal purge. Mutates db; does NOT commit."""
+    days = settings.soft_delete_retention_days
+    if days <= 0:
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    links = db.query(ShareLink).filter(
+        ShareLink.deleted_at.is_(None),
+        ShareLink.expires_at.isnot(None),
+        ShareLink.expires_at < cutoff,
+    ).all()
+    now = datetime.now(timezone.utc)
+    for link in links:
+        link.deleted_at = now
+        counts.share_links_expired += 1
+    if links:
+        log.info("cleanup: soft-deleted %d long-expired share link(s)", len(links))
+
+
 def _purge_soft_deleted(db, counts: PurgeCounts) -> None:
     """Hard-delete every root soft-deleted longer than the retention window, cascading its subtree.
     Roots are processed top-down so a parent removes its children before a later pass queries them;

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -67,6 +67,39 @@ def _purge_comment(db, comment_id, counts: PurgeCounts) -> None:
     db.flush()
 
 
+def _reclaim_media_s3(mf, counts: PurgeCounts) -> None:
+    """Best-effort delete of a MediaFile's S3 objects. processed is a prefix (HLS or single key)."""
+    _safe(delete_object, mf.s3_key_raw)
+    counts.s3_deletes += 1
+    if mf.s3_key_processed:
+        _safe(delete_prefix, mf.s3_key_processed)
+        counts.s3_deletes += 1
+    if mf.s3_key_thumbnail:
+        _safe(delete_object, mf.s3_key_thumbnail)
+        counts.s3_deletes += 1
+
+
+def _purge_version(db, version_id, counts: PurgeCounts) -> None:
+    """Hard-delete a version's media (+S3), carousel items, comments and approvals, then the row."""
+    v = db.query(AssetVersion).filter(AssetVersion.id == version_id).first()
+    if v is None:
+        return
+    # carousel items reference media_file_id + version_id — remove before media files
+    db.query(CarouselItem).filter(CarouselItem.version_id == version_id).delete(synchronize_session=False)
+    media = db.query(MediaFile).filter(MediaFile.version_id == version_id).all()
+    for mf in media:
+        _reclaim_media_s3(mf, counts)
+    counts.media_files += len(media)
+    db.query(MediaFile).filter(MediaFile.version_id == version_id).delete(synchronize_session=False)
+    # comments on this version (recurse each; every comment has a version_id, NOT NULL)
+    for c in db.query(Comment).filter(Comment.version_id == version_id).all():
+        _purge_comment(db, c.id, counts)
+    db.query(Approval).filter(Approval.version_id == version_id).delete(synchronize_session=False)
+    db.query(AssetVersion).filter(AssetVersion.id == version_id).delete(synchronize_session=False)
+    counts.versions += 1
+    db.flush()
+
+
 def _reap_stale_uploads(db) -> int:
     """Reclaim upload orphans. Mutates `db` (soft-deletes versions) but does NOT commit —
     the caller owns the transaction. Returns the number of versions soft-deleted."""

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -100,6 +100,19 @@ def _purge_version(db, version_id, counts: PurgeCounts) -> None:
     db.flush()
 
 
+def _purge_share_link(db, share_link_id, counts: PurgeCounts) -> None:
+    """Hard-delete a share link and its items, activity, and watermark override."""
+    link = db.query(ShareLink).filter(ShareLink.id == share_link_id).first()
+    if link is None:
+        return
+    db.query(ShareLinkItem).filter(ShareLinkItem.share_link_id == share_link_id).delete(synchronize_session=False)
+    db.query(ShareLinkActivity).filter(ShareLinkActivity.share_link_id == share_link_id).delete(synchronize_session=False)
+    db.query(WatermarkSettings).filter(WatermarkSettings.share_link_id == share_link_id).delete(synchronize_session=False)
+    db.query(ShareLink).filter(ShareLink.id == share_link_id).delete(synchronize_session=False)
+    counts.share_links += 1
+    db.flush()
+
+
 def _reap_stale_uploads(db) -> int:
     """Reclaim upload orphans. Mutates `db` (soft-deletes versions) but does NOT commit —
     the caller owns the transaction. Returns the number of versions soft-deleted."""

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -22,6 +22,18 @@ from ..services.s3_service import (
 
 log = logging.getLogger("celery.cleanup")
 
+_MAX_RETENTION_DAYS = 36500  # 100 years; guards timedelta OverflowError on absurd misconfig (e.g. seconds mistaken for days)
+
+
+def _retention_days() -> int:
+    """Effective retention window in days, clamped to a sane max so a misconfigured huge value can't
+    raise OverflowError and silently kill the GC. `<= 0` (disabled) is handled by callers and passes through."""
+    days = settings.soft_delete_retention_days
+    if days > _MAX_RETENTION_DAYS:
+        log.warning("cleanup: soft_delete_retention_days=%s exceeds max %s; clamping", days, _MAX_RETENTION_DAYS)
+        return _MAX_RETENTION_DAYS
+    return days
+
 
 def _safe(fn, *args):
     """Run a best-effort S3 op; log and swallow any error so the sweep never aborts."""
@@ -234,7 +246,7 @@ def _expire_share_links(db, counts: PurgeCounts) -> None:
     """Soft-delete share links that expired BEYOND the retention window. Recently-expired links are
     left alone so owners can still re-enable them (expiry is already 410-enforced at read time);
     once aged past the window they flow into the normal purge. Mutates db; does NOT commit."""
-    days = settings.soft_delete_retention_days
+    days = _retention_days()
     if days <= 0:
         return
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
@@ -255,7 +267,7 @@ def _purge_soft_deleted(db, counts: PurgeCounts) -> None:
     """Hard-delete every root soft-deleted longer than the retention window, cascading its subtree.
     Roots are processed top-down so a parent removes its children before a later pass queries them;
     each pass re-queries the DB, and every helper guards against a row already removed."""
-    days = settings.soft_delete_retention_days
+    days = _retention_days()
     if days <= 0:
         # 0/negative DISABLES the purge — guard BEFORE computing a cutoff so a misconfigured 0
         # can never make cutoff == now() and hard-delete every soft-deleted row.

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -123,6 +123,7 @@ def _purge_asset(db, asset_id, counts: PurgeCounts) -> None:
     # defensive: comments not removed via a version (all comments have a version_id, so usually none)
     for c in db.query(Comment).filter(Comment.asset_id == asset_id).all():
         _purge_comment(db, c.id, counts)
+    # defensive: Approval.version_id is NOT NULL, so _purge_version already removed these
     db.query(Approval).filter(Approval.asset_id == asset_id).delete(synchronize_session=False)
     db.query(AssetMetadata).filter(AssetMetadata.asset_id == asset_id).delete(synchronize_session=False)
     for link in db.query(ShareLink).filter(ShareLink.asset_id == asset_id).all():
@@ -165,7 +166,8 @@ def _purge_project(db, project_id, counts: PurgeCounts) -> None:
         _purge_asset(db, a.id, counts)
     for f in db.query(Folder).filter(Folder.project_id == project_id, Folder.parent_id.is_(None)).all():
         _purge_folder(db, f.id, counts)
-    for f in db.query(Folder).filter(Folder.project_id == project_id).all():  # defensive leftovers
+    # catch orphaned folders (folders.parent_id has no same-project constraint) not reachable from the project's root folders
+    for f in db.query(Folder).filter(Folder.project_id == project_id).all():
         _purge_folder(db, f.id, counts)
     for link in db.query(ShareLink).filter(ShareLink.project_id == project_id).all():
         _purge_share_link(db, link.id, counts)

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -155,6 +155,45 @@ def _purge_folder(db, folder_id, counts: PurgeCounts) -> None:
     db.flush()
 
 
+def _purge_project(db, project_id, counts: PurgeCounts) -> None:
+    """Hard-delete a project and its entire contents."""
+    p = db.query(Project).filter(Project.id == project_id).first()
+    if p is None:
+        return
+    # assets first (covers foldered + loose); folder loops below are then empty
+    for a in db.query(Asset).filter(Asset.project_id == project_id).all():
+        _purge_asset(db, a.id, counts)
+    for f in db.query(Folder).filter(Folder.project_id == project_id, Folder.parent_id.is_(None)).all():
+        _purge_folder(db, f.id, counts)
+    for f in db.query(Folder).filter(Folder.project_id == project_id).all():  # defensive leftovers
+        _purge_folder(db, f.id, counts)
+    for link in db.query(ShareLink).filter(ShareLink.project_id == project_id).all():
+        _purge_share_link(db, link.id, counts)
+    field_ids = [mf.id for mf in db.query(MetadataField).filter(MetadataField.project_id == project_id).all()]
+    if field_ids:
+        db.query(AssetMetadata).filter(AssetMetadata.field_id.in_(field_ids)).delete(synchronize_session=False)
+    db.query(MetadataField).filter(MetadataField.project_id == project_id).delete(synchronize_session=False)
+    coll_ids = [c.id for c in db.query(Collection).filter(Collection.project_id == project_id).all()]
+    if coll_ids:
+        db.query(CollectionShare).filter(CollectionShare.collection_id.in_(coll_ids)).delete(synchronize_session=False)
+    db.query(Collection).filter(Collection.project_id == project_id).delete(synchronize_session=False)
+    branding = db.query(ProjectBranding).filter(ProjectBranding.project_id == project_id).first()
+    if branding is not None:
+        if branding.logo_s3_key:
+            _safe(delete_object, branding.logo_s3_key)
+            counts.s3_deletes += 1
+        db.query(ProjectBranding).filter(ProjectBranding.project_id == project_id).delete(synchronize_session=False)
+    db.query(WatermarkSettings).filter(WatermarkSettings.project_id == project_id).delete(synchronize_session=False)
+    db.query(ProjectMember).filter(ProjectMember.project_id == project_id).delete(synchronize_session=False)
+    db.query(ActivityLog).filter(ActivityLog.project_id == project_id).delete(synchronize_session=False)
+    if p.poster_s3_key:
+        _safe(delete_object, p.poster_s3_key)
+        counts.s3_deletes += 1
+    db.query(Project).filter(Project.id == project_id).delete(synchronize_session=False)
+    counts.projects += 1
+    db.flush()
+
+
 def _reap_stale_uploads(db) -> int:
     """Reclaim upload orphans. Mutates `db` (soft-deletes versions) but does NOT commit —
     the caller owns the transaction. Returns the number of versions soft-deleted."""

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -2,6 +2,8 @@ import logging
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone, timedelta
 
+from sqlalchemy import text
+
 from .celery_app import celery_app
 from ..database import SessionLocal
 from ..config import settings
@@ -23,6 +25,7 @@ from ..services.s3_service import (
 log = logging.getLogger("celery.cleanup")
 
 _MAX_RETENTION_DAYS = 36500  # 100 years; guards timedelta OverflowError on absurd misconfig (e.g. seconds mistaken for days)
+_PURGE_ADVISORY_LOCK_KEY = 5477651  # identifies the retention GC purge (pg advisory lock space)
 
 
 def _retention_days() -> int:
@@ -263,10 +266,26 @@ def _expire_share_links(db, counts: PurgeCounts) -> None:
         log.info("cleanup: soft-deleted %d long-expired share link(s)", len(links))
 
 
+def _lock_if_still_purgeable(db, model, obj_id, cutoff):
+    """Re-fetch a root row under SELECT ... FOR UPDATE, re-checking it is still soft-deleted and
+    aged past the cutoff. Returns the locked row, or None if it was restored (deleted_at cleared),
+    is no longer aged, or is already gone — in which case the caller must skip it. This closes the
+    purge-vs-restore TOCTOU: a restore that commits before this runs is filtered out; a restore
+    in-flight blocks on the lock and is then seen as deleted_at IS NULL; a restore after this locks
+    the row blocks until the purge deletes+commits (the restore then no-ops)."""
+    return db.query(model).filter(
+        model.id == obj_id,
+        model.deleted_at.isnot(None),
+        model.deleted_at < cutoff,
+    ).with_for_update().first()
+
+
 def _purge_soft_deleted(db, counts: PurgeCounts) -> None:
     """Hard-delete every root soft-deleted longer than the retention window, cascading its subtree.
     Roots are processed top-down so a parent removes its children before a later pass queries them;
-    each pass re-queries the DB, and every helper guards against a row already removed."""
+    each pass re-queries the DB, and every helper guards against a row already removed. Each root is
+    re-checked+locked (`_lock_if_still_purgeable`) right before cascading, so a restore that races
+    the scan can never be purged (see #107)."""
     days = _retention_days()
     if days <= 0:
         # 0/negative DISABLES the purge — guard BEFORE computing a cutoff so a misconfigured 0
@@ -275,18 +294,22 @@ def _purge_soft_deleted(db, counts: PurgeCounts) -> None:
         return
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
-    for p in db.query(Project).filter(Project.deleted_at.isnot(None), Project.deleted_at < cutoff).all():
-        _purge_project(db, p.id, counts)
-    for f in db.query(Folder).filter(Folder.deleted_at.isnot(None), Folder.deleted_at < cutoff).all():
-        _purge_folder(db, f.id, counts)
-    for a in db.query(Asset).filter(Asset.deleted_at.isnot(None), Asset.deleted_at < cutoff).all():
-        _purge_asset(db, a.id, counts)
-    for v in db.query(AssetVersion).filter(AssetVersion.deleted_at.isnot(None), AssetVersion.deleted_at < cutoff).all():
-        _purge_version(db, v.id, counts)
-    for c in db.query(Comment).filter(Comment.deleted_at.isnot(None), Comment.deleted_at < cutoff).all():
-        _purge_comment(db, c.id, counts)
-    for link in db.query(ShareLink).filter(ShareLink.deleted_at.isnot(None), ShareLink.deleted_at < cutoff).all():
-        _purge_share_link(db, link.id, counts)
+    for model, purge in (
+        (Project, _purge_project),
+        (Folder, _purge_folder),
+        (Asset, _purge_asset),
+        (AssetVersion, _purge_version),
+        (Comment, _purge_comment),
+        (ShareLink, _purge_share_link),
+    ):
+        ids = [r.id for r in db.query(model.id).filter(
+            model.deleted_at.isnot(None), model.deleted_at < cutoff,
+        ).all()]
+        for obj_id in ids:
+            if _lock_if_still_purgeable(db, model, obj_id, cutoff) is None:
+                continue  # restored or already removed since the scan
+            purge(db, obj_id, counts)
+
     db.query(Approval).filter(Approval.deleted_at.isnot(None), Approval.deleted_at < cutoff).delete(synchronize_session=False)
     db.query(AssetShare).filter(AssetShare.deleted_at.isnot(None), AssetShare.deleted_at < cutoff).delete(synchronize_session=False)
     db.flush()
@@ -306,8 +329,17 @@ def reap_stale_uploads():
 
 def _run_cleanup(db) -> PurgeCounts:
     """Full cleanup pass: expire long-dead share links, then hard-delete aged soft-deletes.
-    Mutates db; the caller (task wrapper or admin endpoint) owns the commit."""
-    counts = PurgeCounts(retention_days=_retention_days())  # report the clamped window actually used
+    Mutates db; the caller (task wrapper or admin endpoint) owns the commit. Guarded by a
+    Postgres advisory xact lock so an overlapping purge (daily beat racing a manual
+    `/admin/purge` enqueue) is skipped rather than double-cascading (see #107)."""
+    days = _retention_days()
+    counts = PurgeCounts(retention_days=days)  # report the clamped window actually used
+    if days <= 0:
+        return counts  # disabled; skip the advisory lock and all work
+    got_lock = db.execute(text("SELECT pg_try_advisory_xact_lock(:k)"), {"k": _PURGE_ADVISORY_LOCK_KEY}).scalar()
+    if not got_lock:
+        log.info("cleanup: another purge holds the advisory lock; skipping this run")
+        return counts
     _expire_share_links(db, counts)
     _purge_soft_deleted(db, counts)
     return counts

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -307,7 +307,7 @@ def reap_stale_uploads():
 def _run_cleanup(db) -> PurgeCounts:
     """Full cleanup pass: expire long-dead share links, then hard-delete aged soft-deletes.
     Mutates db; the caller (task wrapper or admin endpoint) owns the commit."""
-    counts = PurgeCounts(retention_days=settings.soft_delete_retention_days)
+    counts = PurgeCounts(retention_days=_retention_days())  # report the clamped window actually used
     _expire_share_links(db, counts)
     _purge_soft_deleted(db, counts)
     return counts

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -228,6 +228,35 @@ def _reap_stale_uploads(db) -> int:
     return len(versions)
 
 
+def _purge_soft_deleted(db, counts: PurgeCounts) -> None:
+    """Hard-delete every root soft-deleted longer than the retention window, cascading its subtree.
+    Roots are processed top-down so a parent removes its children before a later pass queries them;
+    each pass re-queries the DB, and every helper guards against a row already removed."""
+    days = settings.soft_delete_retention_days
+    if days <= 0:
+        # 0/negative DISABLES the purge — guard BEFORE computing a cutoff so a misconfigured 0
+        # can never make cutoff == now() and hard-delete every soft-deleted row.
+        log.info("cleanup: disabled (soft_delete_retention_days=%s)", days)
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    for p in db.query(Project).filter(Project.deleted_at.isnot(None), Project.deleted_at < cutoff).all():
+        _purge_project(db, p.id, counts)
+    for f in db.query(Folder).filter(Folder.deleted_at.isnot(None), Folder.deleted_at < cutoff).all():
+        _purge_folder(db, f.id, counts)
+    for a in db.query(Asset).filter(Asset.deleted_at.isnot(None), Asset.deleted_at < cutoff).all():
+        _purge_asset(db, a.id, counts)
+    for v in db.query(AssetVersion).filter(AssetVersion.deleted_at.isnot(None), AssetVersion.deleted_at < cutoff).all():
+        _purge_version(db, v.id, counts)
+    for c in db.query(Comment).filter(Comment.deleted_at.isnot(None), Comment.deleted_at < cutoff).all():
+        _purge_comment(db, c.id, counts)
+    for link in db.query(ShareLink).filter(ShareLink.deleted_at.isnot(None), ShareLink.deleted_at < cutoff).all():
+        _purge_share_link(db, link.id, counts)
+    db.query(Approval).filter(Approval.deleted_at.isnot(None), Approval.deleted_at < cutoff).delete(synchronize_session=False)
+    db.query(AssetShare).filter(AssetShare.deleted_at.isnot(None), AssetShare.deleted_at < cutoff).delete(synchronize_session=False)
+    db.flush()
+
+
 @celery_app.task(name="reap_stale_uploads")
 def reap_stale_uploads():
     """Periodic beat task: reclaim storage from stuck/failed uploads."""

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -1,10 +1,21 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 
 from .celery_app import celery_app
 from ..database import SessionLocal
 from ..config import settings
-from ..models.asset import AssetVersion, MediaFile, ProcessingStatus
+from ..models.asset import (
+    Asset, AssetVersion, MediaFile, CarouselItem, ProcessingStatus,
+)
+from ..models.comment import Comment, Annotation, CommentAttachment, CommentReaction
+from ..models.approval import Approval
+from ..models.share import ShareLink, ShareLinkItem, ShareLinkActivity, AssetShare
+from ..models.project import Project, ProjectMember
+from ..models.folder import Folder
+from ..models.metadata import MetadataField, AssetMetadata, Collection, CollectionShare
+from ..models.branding import ProjectBranding, WatermarkSettings
+from ..models.activity import Mention, ActivityLog, Notification
 from ..services.s3_service import (
     list_stale_multipart_uploads, abort_multipart_upload, delete_object, delete_prefix,
 )
@@ -18,6 +29,42 @@ def _safe(fn, *args):
         fn(*args)
     except Exception as exc:  # noqa: BLE001 - best-effort cleanup
         log.warning("reaper: %s%r failed: %s", fn.__name__, args, exc)
+
+
+@dataclass
+class PurgeCounts:
+    """Accumulates what a purge run reclaimed. `retention_days` is filled by `_run_cleanup`."""
+    retention_days: int = 0
+    projects: int = 0
+    folders: int = 0
+    assets: int = 0
+    versions: int = 0
+    media_files: int = 0
+    comments: int = 0
+    share_links: int = 0
+    share_links_expired: int = 0
+    s3_deletes: int = 0
+
+
+def _purge_comment(db, comment_id, counts: PurgeCounts) -> None:
+    """Hard-delete a comment and its whole subtree (replies, annotations, attachments (+S3),
+    reactions, mentions, comment-scoped notifications). Mutates db; does NOT commit."""
+    c = db.query(Comment).filter(Comment.id == comment_id).first()
+    if c is None:
+        return  # already removed by an overlapping root/recursion
+    for reply in db.query(Comment).filter(Comment.parent_id == comment_id).all():
+        _purge_comment(db, reply.id, counts)
+    for att in db.query(CommentAttachment).filter(CommentAttachment.comment_id == comment_id).all():
+        _safe(delete_object, att.s3_key)
+        counts.s3_deletes += 1
+    db.query(CommentAttachment).filter(CommentAttachment.comment_id == comment_id).delete(synchronize_session=False)
+    db.query(Annotation).filter(Annotation.comment_id == comment_id).delete(synchronize_session=False)
+    db.query(CommentReaction).filter(CommentReaction.comment_id == comment_id).delete(synchronize_session=False)
+    db.query(Mention).filter(Mention.comment_id == comment_id).delete(synchronize_session=False)
+    db.query(Notification).filter(Notification.comment_id == comment_id).delete(synchronize_session=False)
+    db.query(Comment).filter(Comment.id == comment_id).delete(synchronize_session=False)
+    counts.comments += 1
+    db.flush()
 
 
 def _reap_stale_uploads(db) -> int:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -124,6 +124,16 @@ def auth_headers(client, mock_db, test_user):
     app.dependency_overrides.pop(get_current_user, None)
 
 
+@pytest.fixture(autouse=True)
+def _bypass_setup_guard(monkeypatch):
+    """Mark initial setup complete so SetupGuardMiddleware doesn't 503 auth-gated client tests.
+    The middleware caches a module-level `_setup_complete` flag checked against the REAL DB (its own
+    SessionLocal, ignoring the get_db override); a fresh CI DB has no superadmin, so without this every
+    client request 503s (masked only by the >=40 floor). No test asserts the needs_setup/503 path, so a
+    blanket bypass is safe; monkeypatch restores the flag after each test."""
+    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
+
+
 @pytest.fixture
 def real_db():
     """Real-Postgres session inside a transaction that is always rolled back (no writes persist).

--- a/apps/api/tests/test_admin_purge.py
+++ b/apps/api/tests/test_admin_purge.py
@@ -1,0 +1,24 @@
+"""Tests for the manual superadmin purge endpoint (#65)."""
+import apps.api.routers.admin as admin_module
+from apps.api.tasks.cleanup_tasks import PurgeCounts
+
+
+def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user):
+    test_user.is_superadmin = False
+    resp = client.post("/admin/purge", headers=auth_headers)
+    assert resp.status_code == 403
+
+
+def test_purge_returns_counts_for_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
+    test_user.is_superadmin = True
+    fake = PurgeCounts(retention_days=30, projects=2, assets=5, versions=7, media_files=7,
+                       comments=3, share_links=1, share_links_expired=4, s3_deletes=20)
+    monkeypatch.setattr(admin_module, "_run_cleanup", lambda db: fake)
+
+    resp = client.post("/admin/purge", headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["retention_days"] == 30
+    assert body["projects"] == 2
+    assert body["share_links_expired"] == 4

--- a/apps/api/tests/test_admin_purge.py
+++ b/apps/api/tests/test_admin_purge.py
@@ -1,6 +1,5 @@
 """Tests for the manual superadmin purge endpoint (#65)."""
 import apps.api.routers.admin as admin_module
-from apps.api.tasks.cleanup_tasks import PurgeCounts
 
 
 def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
@@ -10,17 +9,14 @@ def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user, mon
     assert resp.status_code == 403
 
 
-def test_purge_returns_counts_for_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
+def test_purge_enqueues_task_for_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
     monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     test_user.is_superadmin = True
-    fake = PurgeCounts(retention_days=30, projects=2, assets=5, versions=7, media_files=7,
-                       comments=3, share_links=1, share_links_expired=4, s3_deletes=20)
-    monkeypatch.setattr(admin_module, "_run_cleanup", lambda db: fake)
+    calls = []
+    monkeypatch.setattr(admin_module, "send_task_safe", lambda task, *a, **k: calls.append(task))
 
     resp = client.post("/admin/purge", headers=auth_headers)
 
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["retention_days"] == 30
-    assert body["projects"] == 2
-    assert body["share_links_expired"] == 4
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "started"
+    assert admin_module.cleanup_soft_deleted in calls

--- a/apps/api/tests/test_admin_purge.py
+++ b/apps/api/tests/test_admin_purge.py
@@ -2,15 +2,13 @@
 import apps.api.routers.admin as admin_module
 
 
-def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
+def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user):
     test_user.is_superadmin = False
     resp = client.post("/admin/purge", headers=auth_headers)
     assert resp.status_code == 403
 
 
 def test_purge_enqueues_task_for_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     test_user.is_superadmin = True
     calls = []
     monkeypatch.setattr(admin_module, "send_task_safe", lambda task, *a, **k: calls.append(task))

--- a/apps/api/tests/test_admin_purge.py
+++ b/apps/api/tests/test_admin_purge.py
@@ -3,13 +3,15 @@ import apps.api.routers.admin as admin_module
 from apps.api.tasks.cleanup_tasks import PurgeCounts
 
 
-def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user):
+def test_purge_requires_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
+    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     test_user.is_superadmin = False
     resp = client.post("/admin/purge", headers=auth_headers)
     assert resp.status_code == 403
 
 
 def test_purge_returns_counts_for_superadmin(client, auth_headers, mock_db, test_user, monkeypatch):
+    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     test_user.is_superadmin = True
     fake = PurgeCounts(retention_days=30, projects=2, assets=5, versions=7, media_files=7,
                        comments=3, share_links=1, share_links_expired=4, s3_deletes=20)

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -1,0 +1,93 @@
+"""Tests for the retention-window cascade GC (issue #65 core)."""
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import apps.api.tasks.cleanup_tasks as ct
+from apps.api.models.user import User
+from apps.api.models.project import Project, ProjectType
+from apps.api.models.folder import Folder
+from apps.api.models.asset import (
+    Asset, AssetType, AssetVersion, MediaFile, CarouselItem, FileType, ProcessingStatus,
+)
+from apps.api.models.comment import Comment, Annotation, CommentAttachment, CommentReaction
+from apps.api.models.approval import Approval, ApprovalStatus
+from apps.api.models.share import ShareLink, ShareLinkItem, ShareLinkActivity, AssetShare, ShareActivityAction
+from apps.api.models.metadata import MetadataField, AssetMetadata, Collection, CollectionShare, FieldType
+from apps.api.models.branding import ProjectBranding, WatermarkSettings
+from apps.api.models.activity import Mention, ActivityLog, Notification, NotificationType
+
+
+# ── seed helpers (module-level; extended by later tasks) ─────────────────────────
+
+def _user(db):
+    u = User(email=f"gc-{uuid.uuid4()}@t.local", name="t")
+    db.add(u); db.flush()
+    return u
+
+
+def _project(db, owner, deleted_hours_ago=None):
+    p = Project(name="t", project_type=ProjectType.personal, created_by=owner.id)
+    db.add(p); db.flush()
+    if deleted_hours_ago is not None:
+        p.deleted_at = datetime.now(timezone.utc) - timedelta(hours=deleted_hours_ago)
+        db.flush()
+    return p
+
+
+def _asset(db, project, owner, folder=None, deleted_hours_ago=None):
+    a = Asset(project_id=project.id, name="t", asset_type=AssetType.video, created_by=owner.id,
+              folder_id=(folder.id if folder else None))
+    db.add(a); db.flush()
+    if deleted_hours_ago is not None:
+        a.deleted_at = datetime.now(timezone.utc) - timedelta(hours=deleted_hours_ago)
+        db.flush()
+    return a
+
+
+def _version(db, asset, owner, status=ProcessingStatus.ready, deleted_hours_ago=None):
+    v = AssetVersion(asset_id=asset.id, version_number=1, processing_status=status, created_by=owner.id)
+    db.add(v); db.flush()
+    if deleted_hours_ago is not None:
+        v.deleted_at = datetime.now(timezone.utc) - timedelta(hours=deleted_hours_ago)
+        db.flush()
+    return v
+
+
+def _comment(db, asset, version, owner, parent=None):
+    c = Comment(asset_id=asset.id, version_id=version.id, author_id=owner.id, body="hi",
+                parent_id=(parent.id if parent else None))
+    db.add(c); db.flush()
+    return c
+
+
+def test_purge_comment_removes_subtree_and_attachment_s3(real_db, monkeypatch):
+    deleted = []
+    monkeypatch.setattr(ct, "delete_object", lambda k: deleted.append(k))
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: deleted.append(k))
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    asset = _asset(real_db, project, owner)
+    version = _version(real_db, asset, owner)
+    parent = _comment(real_db, asset, version, owner)
+    reply = _comment(real_db, asset, version, owner, parent=parent)
+    real_db.add(Annotation(comment_id=parent.id, drawing_data={}))
+    real_db.add(CommentAttachment(comment_id=parent.id, file_type="image", s3_key="att/x",
+                                  original_filename="a.png", file_size_bytes=1))
+    real_db.add(CommentReaction(comment_id=parent.id, user_id=owner.id, emoji="👍"))
+    real_db.add(Mention(comment_id=parent.id, mentioned_user_id=owner.id))
+    real_db.add(Notification(user_id=owner.id, type=NotificationType.comment,
+                             asset_id=asset.id, comment_id=parent.id))
+    real_db.flush()
+
+    counts = ct.PurgeCounts()
+    ct._purge_comment(real_db, parent.id, counts)
+
+    assert real_db.query(Comment).filter(Comment.id.in_([parent.id, reply.id])).count() == 0
+    assert real_db.query(Annotation).filter_by(comment_id=parent.id).count() == 0
+    assert real_db.query(CommentAttachment).filter_by(comment_id=parent.id).count() == 0
+    assert real_db.query(CommentReaction).filter_by(comment_id=parent.id).count() == 0
+    assert real_db.query(Mention).filter_by(comment_id=parent.id).count() == 0
+    assert real_db.query(Notification).filter_by(comment_id=parent.id).count() == 0
+    assert "att/x" in deleted
+    assert counts.comments == 2  # parent + reply

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -265,3 +265,53 @@ def test_purge_project_removes_everything(real_db, monkeypatch):
     assert real_db.query(ActivityLog).filter_by(project_id=project.id).count() == 0
     assert "branding/logo.png" in deleted and "posters/p.webp" in deleted
     assert counts.projects == 1 and counts.assets == 2 and counts.folders == 1
+
+
+from apps.api.config import settings
+from apps.api.tests.conftest import _make_mock_db
+
+
+def test_purge_soft_deleted_respects_retention_window(real_db, monkeypatch):
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 30)
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    owner = _user(real_db)
+    old = _project(real_db, owner, deleted_hours_ago=24 * 40)     # 40 days > 30 → purge
+    recent = _project(real_db, owner, deleted_hours_ago=24 * 5)   # 5 days < 30 → keep
+    _asset(real_db, old, owner)
+    _asset(real_db, recent, owner)
+
+    counts = ct.PurgeCounts()
+    ct._purge_soft_deleted(real_db, counts)
+
+    assert real_db.query(Project).filter_by(id=old.id).count() == 0
+    assert real_db.query(Project).filter_by(id=recent.id).count() == 1
+    assert counts.projects == 1
+
+
+def test_purge_soft_deleted_purges_standalone_old_version(real_db, monkeypatch):
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 30)
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)                    # live project
+    asset = _asset(real_db, project, owner)               # live asset
+    stale = _version(real_db, asset, owner, deleted_hours_ago=24 * 40)  # reaper-soft-deleted
+    _media(real_db, stale)
+
+    counts = ct.PurgeCounts()
+    ct._purge_soft_deleted(real_db, counts)
+
+    assert real_db.query(AssetVersion).filter_by(id=stale.id).count() == 0
+    assert real_db.query(Asset).filter_by(id=asset.id).count() == 1   # live asset untouched
+    assert counts.versions == 1
+
+
+def test_purge_soft_deleted_disabled_when_zero(monkeypatch):
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 0)
+    db = _make_mock_db()
+    counts = ct.PurgeCounts()
+    ct._purge_soft_deleted(db, counts)
+    db.query.assert_not_called()

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -193,3 +193,32 @@ def test_purge_asset_removes_full_subtree(real_db, monkeypatch):
     assert real_db.query(Notification).filter_by(asset_id=asset.id).count() == 0
     assert real_db.query(ShareLink).filter_by(id=other_link.id).count() == 1  # project link survives
     assert counts.assets == 1
+
+
+def _folder(db, project, owner, parent=None):
+    f = Folder(project_id=project.id, name=f"fld-{uuid.uuid4()}", created_by=owner.id,
+               parent_id=(parent.id if parent else None))
+    db.add(f); db.flush()
+    return f
+
+
+def test_purge_folder_recurses_nested_and_assets(real_db, monkeypatch):
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    root = _folder(real_db, project, owner)
+    nested = _folder(real_db, project, owner, parent=root)
+    a_root = _asset(real_db, project, owner, folder=root)
+    a_nested = _asset(real_db, project, owner, folder=nested)
+    _version(real_db, a_nested, owner)
+    link = _share_link(real_db, owner, folder=root)
+
+    counts = ct.PurgeCounts()
+    ct._purge_folder(real_db, root.id, counts)
+
+    assert real_db.query(Folder).filter(Folder.id.in_([root.id, nested.id])).count() == 0
+    assert real_db.query(Asset).filter(Asset.id.in_([a_root.id, a_nested.id])).count() == 0
+    assert real_db.query(ShareLink).filter_by(id=link.id).count() == 0
+    assert counts.folders == 2 and counts.assets == 2

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -346,21 +346,37 @@ def test_cleanup_soft_deleted_beat_registered():
 
 
 def test_gc_covers_all_inbound_fks_to_purged_tables():
-    """Guard: every foreign key pointing INTO a table the GC hard-deletes must be handled by a
-    _purge_* helper (deleted child-first). Reflected from Base.metadata so a NEW inbound FK added
-    later fails CI instead of crashing the daily job with an IntegrityError in production.
-    If this fails, the printed (table, column) references a purged table but no helper deletes it
-    first — extend the correct _purge_* helper in cleanup_tasks.py, then add it to KNOWN_HANDLED."""
-    # Ensure all models are registered on Base.metadata.
-    import apps.api.models.asset, apps.api.models.project, apps.api.models.folder  # noqa: F401
-    import apps.api.models.comment, apps.api.models.share, apps.api.models.approval  # noqa: F401
-    import apps.api.models.metadata, apps.api.models.branding, apps.api.models.activity  # noqa: F401
+    """Guard: every foreign key pointing INTO a table the GC hard-deletes from must be handled by a
+    _purge_* helper (deleted child-first). Covers ALL ~25 tables the GC cascade hard-deletes rows
+    from (not just the 9 top-level "container" tables) — leaf/junction tables like approvals,
+    asset_shares, carousel_items and notifications are just as capable of gaining a new inbound FK.
+    Reflected from Base.metadata (with every model module imported so no table is missed) so a NEW
+    inbound FK added later fails CI instead of crashing the daily job with an IntegrityError in
+    production. If this fails, the printed (table, column) references a purged table but no helper
+    deletes it first — extend the correct _purge_* helper in cleanup_tasks.py, then add it to
+    KNOWN_HANDLED."""
+    # Ensure ALL models are registered on Base.metadata — every module under apps/api/models/.
+    import apps.api.models.asset  # noqa: F401
+    import apps.api.models.project  # noqa: F401
+    import apps.api.models.folder  # noqa: F401
+    import apps.api.models.comment  # noqa: F401
+    import apps.api.models.share  # noqa: F401
+    import apps.api.models.approval  # noqa: F401
+    import apps.api.models.metadata  # noqa: F401
+    import apps.api.models.branding  # noqa: F401
+    import apps.api.models.activity  # noqa: F401
+    import apps.api.models.user  # noqa: F401
+    import apps.api.models.instance_settings  # noqa: F401
     from apps.api.database import Base
 
-    # Tables the GC cascade-deletes INTO (their inbound FKs must be handled child-first).
+    # Every table the GC cascade hard-deletes rows from (grep `cleanup_tasks.py` for
+    # `.delete(synchronize_session=False)` + the row-delete calls in each `_purge_*` helper).
     PURGED_TABLES = {
-        "projects", "folders", "assets", "asset_versions", "media_files",
-        "comments", "share_links", "collections", "metadata_fields",
+        "projects", "folders", "assets", "asset_versions", "media_files", "comments", "share_links",
+        "collections", "metadata_fields", "approvals", "asset_shares", "asset_metadata", "carousel_items",
+        "collection_shares", "share_link_items", "share_link_activity", "watermark_settings",
+        "project_members", "project_brandings", "activity_logs", "annotations", "comment_attachments",
+        "comment_reactions", "mentions", "notifications",
     }
     # (referencing_table, referencing_column) confirmed handled by a _purge_* helper.
     KNOWN_HANDLED = {
@@ -404,3 +420,16 @@ def test_gc_covers_all_inbound_fks_to_purged_tables():
         f"New inbound FK(s) into GC-purged tables not covered by a _purge_* helper: {sorted(unhandled)}. "
         f"Extend the cascade in cleanup_tasks.py, then add them to KNOWN_HANDLED."
     )
+
+
+def test_retention_days_clamped_to_max(monkeypatch):
+    from apps.api.config import settings
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 2_592_000)  # seconds-not-days fat-finger
+    assert ct._retention_days() == ct._MAX_RETENTION_DAYS
+
+
+def test_purge_soft_deleted_does_not_overflow_on_huge_retention(mock_db, monkeypatch):
+    from apps.api.config import settings
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 2_592_000)
+    counts = ct.PurgeCounts()
+    ct._purge_soft_deleted(mock_db, counts)  # must NOT raise OverflowError; mock_db returns [] for all queries

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -224,6 +224,48 @@ def test_purge_folder_recurses_nested_and_assets(real_db, monkeypatch):
     assert counts.folders == 2 and counts.assets == 2
 
 
+def test_purge_folder_deletes_soft_deleted_child_asset(real_db, monkeypatch):
+    """Regression: normal case — a folder and its still-member soft-deleted asset are both purged."""
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    folder = _folder(real_db, project, owner)
+    folder.deleted_at = datetime.now(timezone.utc); real_db.flush()
+    asset = _asset(real_db, project, owner, folder=folder, deleted_hours_ago=1)
+
+    counts = ct.PurgeCounts()
+    ct._purge_folder(real_db, folder.id, counts)
+
+    assert real_db.query(Folder).filter_by(id=folder.id).count() == 0
+    assert real_db.query(Asset).filter_by(id=asset.id).count() == 0
+    assert counts.folders == 1 and counts.assets == 1
+
+
+def test_purge_folder_skips_child_reparented_out_since_scan(real_db, monkeypatch):
+    """Fix A2: a child asset restored (reparented to root) between the scan and the cascade must
+    survive — _purge_folder re-checks folder_id membership under FOR UPDATE before recursing/deleting."""
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    folder = _folder(real_db, project, owner)
+    folder.deleted_at = datetime.now(timezone.utc); real_db.flush()
+    asset = _asset(real_db, project, owner, folder=folder, deleted_hours_ago=1)
+    # Simulate a restore-to-root that happened after the outer scan listed this asset as a child.
+    asset.folder_id = None
+    real_db.flush()
+
+    counts = ct.PurgeCounts()
+    ct._purge_folder(real_db, folder.id, counts)
+
+    assert real_db.query(Folder).filter_by(id=folder.id).count() == 0
+    assert real_db.query(Asset).filter_by(id=asset.id).count() == 1  # survived — no longer a member
+    assert counts.folders == 1 and counts.assets == 0
+
+
 def test_purge_project_removes_everything(real_db, monkeypatch):
     deleted = []
     monkeypatch.setattr(ct, "delete_object", lambda k: deleted.append(k))

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -343,3 +343,64 @@ def test_cleanup_soft_deleted_beat_registered():
     from apps.api.tasks.celery_app import celery_app
     entry = celery_app.conf.beat_schedule["cleanup-soft-deleted"]
     assert entry["task"] == "cleanup_soft_deleted"
+
+
+def test_gc_covers_all_inbound_fks_to_purged_tables():
+    """Guard: every foreign key pointing INTO a table the GC hard-deletes must be handled by a
+    _purge_* helper (deleted child-first). Reflected from Base.metadata so a NEW inbound FK added
+    later fails CI instead of crashing the daily job with an IntegrityError in production.
+    If this fails, the printed (table, column) references a purged table but no helper deletes it
+    first — extend the correct _purge_* helper in cleanup_tasks.py, then add it to KNOWN_HANDLED."""
+    # Ensure all models are registered on Base.metadata.
+    import apps.api.models.asset, apps.api.models.project, apps.api.models.folder  # noqa: F401
+    import apps.api.models.comment, apps.api.models.share, apps.api.models.approval  # noqa: F401
+    import apps.api.models.metadata, apps.api.models.branding, apps.api.models.activity  # noqa: F401
+    from apps.api.database import Base
+
+    # Tables the GC cascade-deletes INTO (their inbound FKs must be handled child-first).
+    PURGED_TABLES = {
+        "projects", "folders", "assets", "asset_versions", "media_files",
+        "comments", "share_links", "collections", "metadata_fields",
+    }
+    # (referencing_table, referencing_column) confirmed handled by a _purge_* helper.
+    KNOWN_HANDLED = {
+        # -> projects.id
+        ("assets", "project_id"), ("folders", "project_id"), ("share_links", "project_id"),
+        ("project_brandings", "project_id"), ("watermark_settings", "project_id"),
+        ("metadata_fields", "project_id"), ("collections", "project_id"),
+        ("project_members", "project_id"), ("activity_logs", "project_id"),
+        # -> folders.id
+        ("assets", "folder_id"), ("share_links", "folder_id"), ("share_link_items", "folder_id"),
+        ("asset_shares", "folder_id"), ("folders", "parent_id"),
+        # -> assets.id
+        ("asset_versions", "asset_id"), ("comments", "asset_id"), ("share_links", "asset_id"),
+        ("share_link_items", "asset_id"), ("asset_shares", "asset_id"), ("asset_metadata", "asset_id"),
+        ("activity_logs", "asset_id"), ("notifications", "asset_id"), ("approvals", "asset_id"),
+        # -> asset_versions.id
+        ("media_files", "version_id"), ("carousel_items", "version_id"),
+        ("comments", "version_id"), ("approvals", "version_id"),
+        # -> media_files.id
+        ("carousel_items", "media_file_id"),
+        # -> comments.id
+        ("comments", "parent_id"), ("annotations", "comment_id"), ("comment_attachments", "comment_id"),
+        ("comment_reactions", "comment_id"), ("mentions", "comment_id"), ("notifications", "comment_id"),
+        # -> share_links.id
+        ("share_link_items", "share_link_id"), ("share_link_activity", "share_link_id"),
+        ("watermark_settings", "share_link_id"),
+        # -> collections.id
+        ("collection_shares", "collection_id"),
+        # -> metadata_fields.id
+        ("asset_metadata", "field_id"),
+    }
+
+    inbound = set()
+    for tbl in Base.metadata.tables.values():
+        for fk in tbl.foreign_keys:
+            if fk.column.table.name in PURGED_TABLES:
+                inbound.add((tbl.name, fk.parent.name))
+
+    unhandled = inbound - KNOWN_HANDLED
+    assert not unhandled, (
+        f"New inbound FK(s) into GC-purged tables not covered by a _purge_* helper: {sorted(unhandled)}. "
+        f"Extend the cascade in cleanup_tasks.py, then add them to KNOWN_HANDLED."
+    )

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -158,3 +158,38 @@ def test_purge_share_link_removes_items_activity_watermark(real_db):
     assert real_db.query(ShareLinkActivity).filter_by(share_link_id=link.id).count() == 0
     assert real_db.query(WatermarkSettings).filter_by(share_link_id=link.id).count() == 0
     assert counts.share_links == 1
+
+
+def test_purge_asset_removes_full_subtree(real_db, monkeypatch):
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    asset = _asset(real_db, project, owner)
+    version = _version(real_db, asset, owner)
+    _media(real_db, version)
+    field = MetadataField(project_id=project.id, name="f", field_type=FieldType.text)
+    real_db.add(field); real_db.flush()
+    real_db.add(AssetMetadata(asset_id=asset.id, field_id=field.id, value={"v": 1}))
+    link = _share_link(real_db, owner, asset=asset)
+    other_link = _share_link(real_db, owner, project=project)
+    real_db.add(ShareLinkItem(share_link_id=other_link.id, asset_id=asset.id))  # cross-link ref
+    real_db.add(AssetShare(asset_id=asset.id, shared_with_user_id=owner.id, shared_by=owner.id))
+    real_db.add(ActivityLog(asset_id=asset.id, action="created"))
+    real_db.add(Notification(user_id=owner.id, type=NotificationType.assignment, asset_id=asset.id))
+    real_db.flush()
+
+    counts = ct.PurgeCounts()
+    ct._purge_asset(real_db, asset.id, counts)
+
+    assert real_db.query(Asset).filter_by(id=asset.id).count() == 0
+    assert real_db.query(AssetVersion).filter_by(asset_id=asset.id).count() == 0
+    assert real_db.query(AssetMetadata).filter_by(asset_id=asset.id).count() == 0
+    assert real_db.query(ShareLink).filter_by(id=link.id).count() == 0
+    assert real_db.query(ShareLinkItem).filter_by(asset_id=asset.id).count() == 0
+    assert real_db.query(AssetShare).filter_by(asset_id=asset.id).count() == 0
+    assert real_db.query(ActivityLog).filter_by(asset_id=asset.id).count() == 0
+    assert real_db.query(Notification).filter_by(asset_id=asset.id).count() == 0
+    assert real_db.query(ShareLink).filter_by(id=other_link.id).count() == 1  # project link survives
+    assert counts.assets == 1

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -91,3 +91,40 @@ def test_purge_comment_removes_subtree_and_attachment_s3(real_db, monkeypatch):
     assert real_db.query(Notification).filter_by(comment_id=parent.id).count() == 0
     assert "att/x" in deleted
     assert counts.comments == 2  # parent + reply
+
+
+def _media(db, version, ftype=FileType.video, processed="processed/x/", thumb="thumb/x"):
+    mf = MediaFile(version_id=version.id, file_type=ftype, original_filename="f.mp4",
+                   mime_type="video/mp4", file_size_bytes=10, s3_key_raw=f"raw/{version.id}",
+                   s3_key_processed=processed, s3_key_thumbnail=thumb)
+    db.add(mf); db.flush()
+    return mf
+
+
+def test_purge_version_removes_media_carousel_and_s3(real_db, monkeypatch):
+    deleted = []
+    monkeypatch.setattr(ct, "delete_object", lambda k: deleted.append(k))
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: deleted.append(k))
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    asset = _asset(real_db, project, owner)
+    version = _version(real_db, asset, owner)
+    mf = _media(real_db, version)
+    real_db.add(CarouselItem(version_id=version.id, media_file_id=mf.id, position=0))
+    comment = _comment(real_db, asset, version, owner)
+    real_db.add(Approval(asset_id=asset.id, version_id=version.id, user_id=owner.id,
+                         status=ApprovalStatus.approved))
+    real_db.flush()
+
+    counts = ct.PurgeCounts()
+    ct._purge_version(real_db, version.id, counts)
+
+    assert real_db.query(AssetVersion).filter_by(id=version.id).count() == 0
+    assert real_db.query(MediaFile).filter_by(version_id=version.id).count() == 0
+    assert real_db.query(CarouselItem).filter_by(version_id=version.id).count() == 0
+    assert real_db.query(Comment).filter_by(version_id=version.id).count() == 0
+    assert real_db.query(Approval).filter_by(version_id=version.id).count() == 0
+    assert real_db.query(Asset).filter_by(id=asset.id).count() == 1  # asset untouched
+    assert set(deleted) == {f"raw/{version.id}", "processed/x/", "thumb/x"}
+    assert counts.versions == 1 and counts.media_files == 1

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -315,3 +315,31 @@ def test_purge_soft_deleted_disabled_when_zero(monkeypatch):
     counts = ct.PurgeCounts()
     ct._purge_soft_deleted(db, counts)
     db.query.assert_not_called()
+
+
+def test_run_cleanup_returns_counts_and_stamps_retention(real_db, monkeypatch):
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 30)
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    owner = _user(real_db)
+    _project(real_db, owner, deleted_hours_ago=24 * 40)
+
+    counts = ct._run_cleanup(real_db)
+
+    assert counts.retention_days == 30
+    assert counts.projects == 1
+
+
+def test_run_cleanup_disabled_when_zero(monkeypatch):
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 0)
+    db = _make_mock_db()
+    counts = ct._run_cleanup(db)
+    db.query.assert_not_called()
+    assert counts.projects == 0 and counts.share_links_expired == 0
+
+
+def test_cleanup_soft_deleted_beat_registered():
+    from apps.api.tasks.celery_app import celery_app
+    entry = celery_app.conf.beat_schedule["cleanup-soft-deleted"]
+    assert entry["task"] == "cleanup_soft_deleted"

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone, timedelta
 
 import apps.api.tasks.cleanup_tasks as ct
 from apps.api.models.user import User
-from apps.api.models.project import Project, ProjectType
+from apps.api.models.project import Project, ProjectType, ProjectMember
 from apps.api.models.folder import Folder
 from apps.api.models.asset import (
     Asset, AssetType, AssetVersion, MediaFile, CarouselItem, FileType, ProcessingStatus,
@@ -222,3 +222,46 @@ def test_purge_folder_recurses_nested_and_assets(real_db, monkeypatch):
     assert real_db.query(Asset).filter(Asset.id.in_([a_root.id, a_nested.id])).count() == 0
     assert real_db.query(ShareLink).filter_by(id=link.id).count() == 0
     assert counts.folders == 2 and counts.assets == 2
+
+
+def test_purge_project_removes_everything(real_db, monkeypatch):
+    deleted = []
+    monkeypatch.setattr(ct, "delete_object", lambda k: deleted.append(k))
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: deleted.append(k))
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    project.poster_s3_key = "posters/p.webp"; real_db.flush()
+    folder = _folder(real_db, project, owner)
+    foldered = _asset(real_db, project, owner, folder=folder)
+    loose = _asset(real_db, project, owner)
+    _version(real_db, loose, owner)
+    real_db.add(ProjectBranding(project_id=project.id, logo_s3_key="branding/logo.png"))
+    real_db.add(WatermarkSettings(project_id=project.id))
+    real_db.add(ProjectMember(project_id=project.id, user_id=owner.id))
+    coll = Collection(project_id=project.id, name="c", created_by=owner.id)
+    real_db.add(coll); real_db.flush()
+    real_db.add(CollectionShare(collection_id=coll.id, token=f"c-{uuid.uuid4()}", created_by=owner.id))
+    field = MetadataField(project_id=project.id, name="f", field_type=FieldType.text)
+    real_db.add(field); real_db.flush()
+    real_db.add(AssetMetadata(asset_id=loose.id, field_id=field.id, value={"v": 1}))
+    _share_link(real_db, owner, project=project)
+    real_db.add(ActivityLog(project_id=project.id, action="created"))
+    real_db.flush()
+
+    counts = ct.PurgeCounts()
+    ct._purge_project(real_db, project.id, counts)
+
+    assert real_db.query(Project).filter_by(id=project.id).count() == 0
+    assert real_db.query(Folder).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(Asset).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(ProjectBranding).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(WatermarkSettings).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(ProjectMember).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(Collection).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(CollectionShare).filter_by(collection_id=coll.id).count() == 0
+    assert real_db.query(MetadataField).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(ShareLink).filter_by(project_id=project.id).count() == 0
+    assert real_db.query(ActivityLog).filter_by(project_id=project.id).count() == 0
+    assert "branding/logo.png" in deleted and "posters/p.webp" in deleted
+    assert counts.projects == 1 and counts.assets == 2 and counts.folders == 1

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -433,3 +433,37 @@ def test_purge_soft_deleted_does_not_overflow_on_huge_retention(mock_db, monkeyp
     monkeypatch.setattr(settings, "soft_delete_retention_days", 2_592_000)
     counts = ct.PurgeCounts()
     ct._purge_soft_deleted(mock_db, counts)  # must NOT raise OverflowError; mock_db returns [] for all queries
+
+
+def test_lock_if_still_purgeable_rejects_restored_and_recent(real_db):
+    from datetime import datetime, timezone, timedelta
+    owner = _user(real_db)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+    aged = _project(real_db, owner, deleted_hours_ago=24 * 40)
+    recent = _project(real_db, owner, deleted_hours_ago=24 * 5)
+    restored = _project(real_db, owner, deleted_hours_ago=24 * 40)
+    restored.deleted_at = None
+    real_db.flush()
+    assert ct._lock_if_still_purgeable(real_db, Project, aged.id, cutoff) is not None
+    assert ct._lock_if_still_purgeable(real_db, Project, recent.id, cutoff) is None
+    assert ct._lock_if_still_purgeable(real_db, Project, restored.id, cutoff) is None
+
+
+def test_run_cleanup_skips_when_advisory_lock_held(real_db, monkeypatch):
+    from apps.api.config import settings
+    from apps.api.database import engine
+    from sqlalchemy import text
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 30)
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+    owner = _user(real_db)
+    old = _project(real_db, owner, deleted_hours_ago=24 * 40)
+    other = engine.connect()
+    try:
+        other.execute(text("SELECT pg_advisory_lock(:k)"), {"k": ct._PURGE_ADVISORY_LOCK_KEY})
+        counts = ct._run_cleanup(real_db)
+        assert counts.projects == 0                                    # skipped — nothing purged
+        assert real_db.query(Project).filter_by(id=old.id).count() == 1  # survived
+    finally:
+        other.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": ct._PURGE_ADVISORY_LOCK_KEY})
+        other.close()

--- a/apps/api/tests/test_cleanup_soft_deleted.py
+++ b/apps/api/tests/test_cleanup_soft_deleted.py
@@ -128,3 +128,33 @@ def test_purge_version_removes_media_carousel_and_s3(real_db, monkeypatch):
     assert real_db.query(Asset).filter_by(id=asset.id).count() == 1  # asset untouched
     assert set(deleted) == {f"raw/{version.id}", "processed/x/", "thumb/x"}
     assert counts.versions == 1 and counts.media_files == 1
+
+
+def _share_link(db, owner, asset=None, folder=None, project=None):
+    link = ShareLink(token=f"tok-{uuid.uuid4()}", created_by=owner.id,
+                     asset_id=(asset.id if asset else None),
+                     folder_id=(folder.id if folder else None),
+                     project_id=(project.id if project else None))
+    db.add(link); db.flush()
+    return link
+
+
+def test_purge_share_link_removes_items_activity_watermark(real_db):
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+    asset = _asset(real_db, project, owner)
+    link = _share_link(real_db, owner, asset=asset)
+    real_db.add(ShareLinkItem(share_link_id=link.id, asset_id=asset.id))
+    real_db.add(ShareLinkActivity(share_link_id=link.id, action=ShareActivityAction.opened,
+                                  actor_email="x@t.local"))
+    real_db.add(WatermarkSettings(project_id=project.id, share_link_id=link.id))
+    real_db.flush()
+
+    counts = ct.PurgeCounts()
+    ct._purge_share_link(real_db, link.id, counts)
+
+    assert real_db.query(ShareLink).filter_by(id=link.id).count() == 0
+    assert real_db.query(ShareLinkItem).filter_by(share_link_id=link.id).count() == 0
+    assert real_db.query(ShareLinkActivity).filter_by(share_link_id=link.id).count() == 0
+    assert real_db.query(WatermarkSettings).filter_by(share_link_id=link.id).count() == 0
+    assert counts.share_links == 1

--- a/apps/api/tests/test_orphan_sweep.py
+++ b/apps/api/tests/test_orphan_sweep.py
@@ -68,3 +68,20 @@ def test_orphan_sweep_disabled_when_grace_zero(mock_db, monkeypatch):
     monkeypatch.setattr(ct, "list_keys", lambda prefix: called.append(prefix) or [])
     counts = ct._sweep_orphan_s3(mock_db)
     assert counts.orphans == 0 and called == []                      # never listed the bucket
+
+
+def test_orphan_sweep_safety_abort_on_empty_live_set(mock_db, monkeypatch):
+    """Fix B: if the live-set is EMPTY (0 MediaFile rows — e.g. DATABASE_URL points at the wrong/empty
+    DB) but keys were scanned, deletion must be refused even with ORPHAN_SWEEP_DELETE=true — otherwise
+    every object in the bucket would be treated as an orphan and wiped."""
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    all_keys = [
+        ("raw/some-proj/some-asset/some-ver/original.mp4", old, 500),
+        ("processed/some-proj/some-asset/some-ver/master.m3u8", old, 300),
+    ]
+    # mock_db.all() defaults to [] -> db.query(MediaFile...).all() returns [] -> empty live-set.
+    counts, deleted = _run(mock_db, monkeypatch, all_keys, grace=24, delete=True)
+
+    assert deleted == []
+    assert counts.deleted == 0
+    assert counts.orphans == 2  # still correctly reports what was scanned

--- a/apps/api/tests/test_orphan_sweep.py
+++ b/apps/api/tests/test_orphan_sweep.py
@@ -1,0 +1,70 @@
+"""Tests for the S3 orphan sweeper (issue #110)."""
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import apps.api.tasks.cleanup_tasks as ct
+from apps.api.config import settings
+from apps.api.models.user import User
+from apps.api.models.project import Project, ProjectType
+from apps.api.models.asset import Asset, AssetType, AssetVersion, MediaFile, FileType, ProcessingStatus
+
+
+def _seed_media(db):
+    u = User(email=f"orph-{uuid.uuid4()}@t.local", name="t"); db.add(u); db.flush()
+    p = Project(name="t", project_type=ProjectType.personal, created_by=u.id); db.add(p); db.flush()
+    a = Asset(project_id=p.id, name="t", asset_type=AssetType.video, created_by=u.id); db.add(a); db.flush()
+    v = AssetVersion(asset_id=a.id, version_number=1, processing_status=ProcessingStatus.ready, created_by=u.id); db.add(v); db.flush()
+    raw = f"raw/{p.id}/{a.id}/{v.id}/original.mp4"
+    mf = MediaFile(version_id=v.id, file_type=FileType.video, original_filename="f.mp4", mime_type="video/mp4",
+                   file_size_bytes=100, s3_key_raw=raw,
+                   s3_key_processed=f"processed/{p.id}/{a.id}/{v.id}",
+                   s3_key_thumbnail=f"processed/{p.id}/{a.id}/{v.id}/thumb0.jpg")
+    db.add(mf); db.flush()
+    return str(p.id), str(a.id), str(v.id), raw
+
+
+def _run(db, monkeypatch, all_keys, grace=24, delete=False):
+    monkeypatch.setattr(settings, "orphan_sweep_grace_hours", grace)
+    monkeypatch.setattr(settings, "orphan_sweep_delete", delete)
+    deleted = []
+    monkeypatch.setattr(ct, "delete_object", lambda k: deleted.append(k))
+    monkeypatch.setattr(ct, "list_keys", lambda prefix: [(k, lm, s) for (k, lm, s) in all_keys if k.startswith(prefix)])
+    counts = ct._sweep_orphan_s3(db)
+    return counts, deleted
+
+
+def test_orphan_sweep_reports_only_true_orphans(real_db, monkeypatch):
+    pid, aid, vid, raw = _seed_media(real_db)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    recent = datetime.now(timezone.utc) - timedelta(hours=1)
+    all_keys = [
+        (raw, old, 100),                                              # live raw -> not orphan
+        (f"processed/{pid}/{aid}/{vid}/720p/seg001.ts", old, 200),    # HLS segment under live prefix -> not orphan
+        (f"processed/{pid}/{aid}/{vid}/thumb0.jpg", old, 10),         # live thumbnail -> not orphan
+        ("raw/dead-proj/dead-asset/dead-ver/original.mp4", old, 500), # genuine orphan
+        ("processed/ghost/ghost/ghost/master.m3u8", recent, 300),     # unknown but RECENT -> skipped (grace)
+    ]
+    counts, deleted = _run(real_db, monkeypatch, all_keys, grace=24, delete=False)
+    assert counts.orphans == 1 and counts.orphan_bytes == 500
+    assert counts.deleted == 0 and deleted == []                      # report-only
+
+
+def test_orphan_sweep_deletes_only_orphan_when_enabled(real_db, monkeypatch):
+    pid, aid, vid, raw = _seed_media(real_db)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    all_keys = [
+        (raw, old, 100),
+        (f"processed/{pid}/{aid}/{vid}/720p/seg001.ts", old, 200),
+        ("raw/dead/dead/dead/original.mp4", old, 500),
+    ]
+    counts, deleted = _run(real_db, monkeypatch, all_keys, grace=24, delete=True)
+    assert counts.deleted == 1
+    assert deleted == ["raw/dead/dead/dead/original.mp4"]             # only the orphan; live keys untouched
+
+
+def test_orphan_sweep_disabled_when_grace_zero(mock_db, monkeypatch):
+    monkeypatch.setattr(settings, "orphan_sweep_grace_hours", 0)
+    called = []
+    monkeypatch.setattr(ct, "list_keys", lambda prefix: called.append(prefix) or [])
+    counts = ct._sweep_orphan_s3(mock_db)
+    assert counts.orphans == 0 and called == []                      # never listed the bucket

--- a/apps/api/tests/test_restore_project_guard.py
+++ b/apps/api/tests/test_restore_project_guard.py
@@ -1,0 +1,61 @@
+"""Tests for restore-into-deleted-project guard (#65 adversarial-review fix A1).
+
+There is no project-restore endpoint (only /assets/{id}/restore and /folders/{id}/restore) — a
+soft-deleted project is permanent/purge-only. Without this guard, restoring an asset or folder whose
+project is soft-deleted would report success while leaving the item parented under a project the
+retention GC's `_purge_project` cascade will hard-delete on its next pass (with no re-check of
+children's own deleted_at) — a silent, unrecoverable data-loss trap.
+"""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import apps.api.routers.folders as folders_module
+
+
+def test_restore_asset_rejects_soft_deleted_project(
+    client, auth_headers, mock_db, test_user, monkeypatch
+):
+    monkeypatch.setattr(folders_module, "require_project_role", lambda db, pid, u, r: None)
+
+    project_id = uuid.uuid4()
+    asset = MagicMock()
+    asset.project_id = project_id
+    asset.deleted_at = datetime.now(timezone.utc)
+
+    project = MagicMock()
+    project.deleted_at = datetime.now(timezone.utc)  # soft-deleted
+
+    # Query sequence in restore_asset after require_project_role is bypassed:
+    #   1) asset lookup -> asset (soft-deleted)
+    #   2) project lookup -> project (soft-deleted)
+    mock_db.first.side_effect = [asset, project]
+
+    resp = client.post(f"/assets/{uuid.uuid4()}/restore", headers=auth_headers)
+
+    assert resp.status_code == 409
+    assert "project has been deleted" in resp.json()["detail"]
+
+
+def test_restore_folder_rejects_soft_deleted_project(
+    client, auth_headers, mock_db, test_user, monkeypatch
+):
+    monkeypatch.setattr(folders_module, "require_project_role", lambda db, pid, u, r: None)
+
+    project_id = uuid.uuid4()
+    folder = MagicMock()
+    folder.project_id = project_id
+    folder.deleted_at = datetime.now(timezone.utc)
+
+    project = MagicMock()
+    project.deleted_at = datetime.now(timezone.utc)  # soft-deleted
+
+    # Query sequence in restore_folder after require_project_role is bypassed:
+    #   1) folder lookup -> folder (soft-deleted)
+    #   2) project lookup -> project (soft-deleted)
+    mock_db.first.side_effect = [folder, project]
+
+    resp = client.post(f"/folders/{uuid.uuid4()}/restore", headers=auth_headers)
+
+    assert resp.status_code == 409
+    assert "project has been deleted" in resp.json()["detail"]

--- a/apps/api/tests/test_share_link_expiry.py
+++ b/apps/api/tests/test_share_link_expiry.py
@@ -1,0 +1,54 @@
+"""Tests for share-link expiry: the conservative expire sweep + enforcement regression (#65)."""
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import apps.api.tasks.cleanup_tasks as ct
+from apps.api.config import settings
+from apps.api.models.user import User
+from apps.api.models.project import Project, ProjectType
+from apps.api.models.share import ShareLink
+
+
+def _owner(db):
+    u = User(email=f"exp-{uuid.uuid4()}@t.local", name="t")
+    db.add(u); db.flush()
+    return u
+
+
+def _link(db, owner, project, expires_days_ago=None):
+    link = ShareLink(token=f"tok-{uuid.uuid4()}", created_by=owner.id, project_id=project.id)
+    db.add(link); db.flush()
+    if expires_days_ago is not None:
+        link.expires_at = datetime.now(timezone.utc) - timedelta(days=expires_days_ago)
+        db.flush()
+    return link
+
+
+def test_expire_share_links_sweeps_only_long_expired(real_db, monkeypatch):
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 30)
+    owner = _owner(real_db)
+    project = Project(name="t", project_type=ProjectType.personal, created_by=owner.id)
+    real_db.add(project); real_db.flush()
+
+    long_expired = _link(real_db, owner, project, expires_days_ago=40)   # > 30 → soft-delete
+    recently_expired = _link(real_db, owner, project, expires_days_ago=5)  # < 30 → keep editable
+    never_expires = _link(real_db, owner, project, expires_days_ago=None)
+
+    counts = ct.PurgeCounts()
+    ct._expire_share_links(real_db, counts)
+
+    # _expire_share_links mutates these same ORM objects in-session — assert directly (no refresh,
+    # which would reload the uncommitted rows from the DB and reset deleted_at to NULL).
+    assert long_expired.deleted_at is not None
+    assert recently_expired.deleted_at is None
+    assert never_expires.deleted_at is None
+    assert counts.share_links_expired == 1
+
+
+def test_expire_share_links_disabled_when_zero(monkeypatch):
+    from apps.api.tests.conftest import _make_mock_db
+    monkeypatch.setattr(settings, "soft_delete_retention_days", 0)
+    db = _make_mock_db()
+    counts = ct.PurgeCounts()
+    ct._expire_share_links(db, counts)
+    db.query.assert_not_called()

--- a/apps/api/tests/test_share_link_expiry.py
+++ b/apps/api/tests/test_share_link_expiry.py
@@ -1,12 +1,17 @@
 """Tests for share-link expiry: the conservative expire sweep + enforcement regression (#65)."""
 import uuid
 from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
 
 import apps.api.tasks.cleanup_tasks as ct
 from apps.api.config import settings
 from apps.api.models.user import User
 from apps.api.models.project import Project, ProjectType
 from apps.api.models.share import ShareLink
+from apps.api.services.permissions import validate_share_link
 
 
 def _owner(db):
@@ -52,3 +57,27 @@ def test_expire_share_links_disabled_when_zero(monkeypatch):
     counts = ct.PurgeCounts()
     ct._expire_share_links(db, counts)
     db.query.assert_not_called()
+
+
+def _mock_db_returning(link):
+    db = MagicMock()
+    db.query.return_value = db
+    db.filter.return_value = db
+    db.first.return_value = link
+    return db
+
+
+def test_validate_share_link_rejects_expired():
+    link = MagicMock(is_enabled=True,
+                     expires_at=datetime.now(timezone.utc) - timedelta(hours=1))
+    with pytest.raises(HTTPException) as exc:
+        validate_share_link(_mock_db_returning(link), "tok")
+    assert exc.value.status_code == 410
+
+
+def test_validate_share_link_allows_future_and_none_expiry():
+    future = MagicMock(is_enabled=True,
+                       expires_at=datetime.now(timezone.utc) + timedelta(hours=1))
+    assert validate_share_link(_mock_db_returning(future), "tok") is future
+    never = MagicMock(is_enabled=True, expires_at=None)
+    assert validate_share_link(_mock_db_returning(never), "tok") is never

--- a/apps/api/tests/test_upload_folder_validation.py
+++ b/apps/api/tests/test_upload_folder_validation.py
@@ -1,0 +1,80 @@
+"""Tests for folder validation on POST /upload/initiate (#65).
+
+Without this validation, a live asset could be created under a soft-deleted
+(trashed) or foreign-project folder. The retention GC's `_purge_folder` deletes
+assets by `folder_id` with no `deleted_at` filter (it must, to avoid FK
+violations when the folder itself is hard-deleted), so an unvalidated
+`folder_id` on initiate becomes a data-loss vector: a live asset silently
+gets swept up and hard-deleted (S3 objects included) the next time its
+trashed folder is purged.
+"""
+import uuid
+from unittest.mock import MagicMock
+
+import apps.api.routers.upload as upload_module
+
+
+def _valid_body(**overrides):
+    body = {
+        "project_id": str(uuid.uuid4()),
+        "folder_id": str(uuid.uuid4()),
+        "mime_type": "image/png",
+        "original_filename": "a.png",
+        "file_size_bytes": 10,
+        "asset_name": "a",
+    }
+    body.update(overrides)
+    return body
+
+
+def test_initiate_upload_rejects_soft_deleted_or_foreign_folder(
+    client, auth_headers, mock_db, test_user, monkeypatch
+):
+    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
+    # Bypass the upstream gates so we isolate the folder-validation path.
+    monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
+    monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
+
+    project = MagicMock()
+    # Query sequence inside initiate_upload after the gates are bypassed:
+    #   1) project lookup -> project (truthy)
+    #   2) folder lookup -> None (folder missing / soft-deleted / foreign project)
+    mock_db.first.side_effect = [project, None]
+
+    resp = client.post("/upload/initiate", json=_valid_body(), headers=auth_headers)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Folder not found"
+
+
+def test_initiate_upload_allows_valid_folder(
+    client, auth_headers, mock_db, test_user, monkeypatch
+):
+    """Sanity check: a real, project-owned, non-deleted folder is accepted."""
+    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
+    monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
+    monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
+    monkeypatch.setattr(
+        upload_module, "create_multipart_upload", lambda s3_key, mime_type: "fake-upload-id"
+    )
+
+    project = MagicMock()
+    folder = MagicMock()
+    asset = MagicMock()
+    asset.id = uuid.uuid4()
+    asset.asset_type = upload_module.AssetType.image
+
+    # Query sequence: project lookup -> project, folder lookup -> folder,
+    # then last_version lookup -> None (first version).
+    mock_db.first.side_effect = [project, folder, None]
+
+    def _add(obj):
+        # Emulate the DB assigning identity/attrs to the asset/version on add+flush.
+        if not hasattr(obj, "id") or obj.id is None:
+            obj.id = uuid.uuid4()
+
+    mock_db.add.side_effect = _add
+
+    resp = client.post("/upload/initiate", json=_valid_body(), headers=auth_headers)
+
+    assert resp.status_code == 200

--- a/apps/api/tests/test_upload_folder_validation.py
+++ b/apps/api/tests/test_upload_folder_validation.py
@@ -30,7 +30,6 @@ def _valid_body(**overrides):
 def test_initiate_upload_rejects_soft_deleted_or_foreign_folder(
     client, auth_headers, mock_db, test_user, monkeypatch
 ):
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     # Bypass the upstream gates so we isolate the folder-validation path.
     monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
     monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
@@ -51,7 +50,6 @@ def test_initiate_upload_allows_valid_folder(
     client, auth_headers, mock_db, test_user, monkeypatch
 ):
     """Sanity check: a real, project-owned, non-deleted folder is accepted."""
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
     monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
     monkeypatch.setattr(
@@ -85,7 +83,6 @@ def test_initiate_upload_new_version_ignores_bad_folder(
     (e.g. now-trashed) folder_id must not cause a spurious 404 -- there is no
     data-loss risk in this branch.
     """
-    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
     monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
     monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
     monkeypatch.setattr(

--- a/apps/api/tests/test_upload_folder_validation.py
+++ b/apps/api/tests/test_upload_folder_validation.py
@@ -60,9 +60,6 @@ def test_initiate_upload_allows_valid_folder(
 
     project = MagicMock()
     folder = MagicMock()
-    asset = MagicMock()
-    asset.id = uuid.uuid4()
-    asset.asset_type = upload_module.AssetType.image
 
     # Query sequence: project lookup -> project, folder lookup -> folder,
     # then last_version lookup -> None (first version).
@@ -77,4 +74,52 @@ def test_initiate_upload_allows_valid_folder(
 
     resp = client.post("/upload/initiate", json=_valid_body(), headers=auth_headers)
 
+    assert resp.status_code == 200
+
+
+def test_initiate_upload_new_version_ignores_bad_folder(
+    client, auth_headers, mock_db, test_user, monkeypatch
+):
+    """Uploading a new VERSION of an existing asset (asset_id given) must NOT
+    validate folder_id: that path ignores/does not persist folder_id, so a bogus
+    (e.g. now-trashed) folder_id must not cause a spurious 404 -- there is no
+    data-loss risk in this branch.
+    """
+    monkeypatch.setattr("apps.api.middleware.setup_guard._setup_complete", True)
+    monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
+    monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
+    monkeypatch.setattr(
+        upload_module, "create_multipart_upload", lambda s3_key, mime_type: "fake-upload-id"
+    )
+
+    project_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+
+    project = MagicMock()
+    asset = MagicMock()
+    asset.id = asset_id
+    asset.project_id = project_id  # must match body.project_id (else 400)
+    asset.asset_type = upload_module.AssetType.image
+
+    # Query sequence for the asset_id (new-version) branch:
+    #   1) project lookup -> project
+    #   2) asset lookup -> asset  (NO folder lookup happens in this branch)
+    #   3) last_version lookup -> None (first version for this asset)
+    mock_db.first.side_effect = [project, asset, None]
+
+    def _add(obj):
+        if not hasattr(obj, "id") or obj.id is None:
+            obj.id = uuid.uuid4()
+
+    mock_db.add.side_effect = _add
+
+    body = _valid_body(
+        project_id=str(project_id),
+        asset_id=str(asset_id),
+        folder_id=str(uuid.uuid4()),  # bogus/trashed folder id -- must be ignored
+    )
+    resp = client.post("/upload/initiate", json=body, headers=auth_headers)
+
+    # The key assertion: NOT rejected for the bad folder.
+    assert resp.status_code != 404
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Release candidate consolidating the full **garbage-collection** work for #65 into one branch off `main`, for a single adversarial review + CI-green gate before release. This is the whole stack (previously PRs #106/#111/#112/#113, now superseded by this integration branch) as one line of commits.

## What's included

**Retention-window GC (core, #65):**
- Daily `cleanup_soft_deleted` beat task: hard-deletes rows soft-deleted longer than `SOFT_DELETE_RETENTION_DAYS` (default 30, `0` disables, clamped to avoid `OverflowError`) and reclaims their S3, cascading `Project → Folder → Asset → Version → MediaFile / Comment / Approval / ShareLink` child-first (no ORM relationships / `ondelete=CASCADE`, so ordering is explicit; a metadata-driven test guards FK-completeness across all 25 purged tables).
- Conservative expired-share-link sweep; a **410 expiry-enforcement regression lock**.
- Async superadmin `POST /admin/purge` (enqueues the task, returns `202`).

**Data-safety fixes (from two adversarial passes):**
- Upload `folder_id` validation (exists / in-project / not soft-deleted), scoped to the new-asset path.
- Purge-vs-restore guards: `FOR UPDATE` root re-check + `pg_try_advisory_xact_lock` (no overlapping runs); `restore_asset`/`restore_folder` now **409** when the project is soft-deleted (no project-restore path exists); `_purge_folder` re-checks child membership under lock so a restored-and-reparented child is never hard-deleted.

**Follow-ups (#108, #110):**
- **#108** — autouse SetupGuard test bypass → full suite green; CI gate tightened from a `≥40 passed` floor to **zero-failure**.
- **#110** — **report-only-first S3 orphan sweeper** (`raw/` + `processed/`): off by default (`ORPHAN_SWEEP_GRACE_HOURS=0`), report-only (`ORPHAN_SWEEP_DELETE=false`), grace window so active uploads are never flagged, and an empty-live-set safety abort. Live-key logic verified against the transcoder so it can never delete a live object.

## Testing

- [x] Backend tests pass — full suite **131 passed, 0 failed** against real Postgres; CI green (zero-failure gate).
- [ ] Frontend builds — N/A (backend only)
- [ ] Tested manually in browser — N/A (backend only)

## Review

Every commit was TDD'd and individually reviewed; the integrated branch went through an adversarial multi-agent review that caught a HIGH restore-vs-cascade data-loss bug (now fixed + independently re-verified — no remaining path).

Closes #65. Closes #107. Closes #108. Closes #110.

Remaining non-blocking follow-ups (orphan-sweeper coverage for `posters/`/branding/attachments + review hardening notes) are tracked in #115. Collection sharing (#109) is closed as *not planned* — the feature has no frontend wiring or consumption endpoint.
