### PR TITLE
fix(share): honor creator passphrase bypass on folder-share assets/thumbnail endpoints (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Passphrase-protected share previews no longer show "No content yet"** ([#119](https://github.com/Techiebutler/freeframe/issues/119)) — the public `/share/{token}/assets` and `/share/{token}/thumbnail/{asset_id}` endpoints now honor the authenticated link creator's passphrase bypass (matching `/share/{token}/stream/{asset_id}`), so the dashboard settings preview loads a password-protected link's assets instead of rendering an empty state.
+
 ## [1.3.0] - 2026-07-07
 
 ### Upgrade notes

--- a/apps/api/routers/share.py
+++ b/apps/api/routers/share.py
@@ -1158,9 +1158,14 @@ def get_folder_share_assets(
     per_page: int = 50,
     share_session: Optional[str] = Query(None, alias="share_session"),
     db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_user),
 ):
-    """Public endpoint — no auth required. Returns assets and subfolders for a folder or project share link."""
-    link = validate_share_link_with_session(db, token, share_session=share_session)
+    """Public endpoint — optional auth. Returns assets and subfolders for a folder or project share link.
+
+    The authenticated link creator bypasses the passphrase (e.g. the dashboard settings preview),
+    matching `/share/{token}/stream/{asset_id}`.
+    """
+    link = validate_share_link_with_session(db, token, share_session=share_session, current_user=current_user)
 
     is_project_share = link.project_id is not None
     if not link.folder_id and not is_project_share:
@@ -1420,9 +1425,13 @@ def get_share_thumbnail_url(
     asset_id: uuid.UUID,
     share_session: Optional[str] = Query(None, alias="share_session"),
     db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_user),
 ):
-    """Public endpoint — no auth required. Returns presigned thumbnail URL for an asset in a share link."""
-    link = validate_share_link_with_session(db, token, share_session=share_session)
+    """Public endpoint — optional auth. Returns presigned thumbnail URL for an asset in a share link.
+
+    The authenticated link creator bypasses the passphrase, matching the other share endpoints.
+    """
+    link = validate_share_link_with_session(db, token, share_session=share_session, current_user=current_user)
 
     asset = _get_asset(db, asset_id)
 

--- a/apps/api/tests/test_share_password_preview.py
+++ b/apps/api/tests/test_share_password_preview.py
@@ -1,0 +1,100 @@
+"""Regression tests for #119 — passphrase-protected share preview shows "No content yet".
+
+The dashboard share-link preview (and thumbnail loader) call the public folder-share
+endpoints as the *authenticated link creator*. Those endpoints must forward `current_user`
+into `validate_share_link_with_session` so the creator-bypass fires; otherwise a
+password-protected link returns 403 "Password required" and the frontend renders an
+empty "No content yet" state even though the link contains assets.
+
+The stream endpoint (`/share/{token}/stream/{asset_id}`) already does this correctly;
+these tests cover the two endpoints that previously omitted it.
+"""
+import uuid
+from unittest.mock import MagicMock, patch
+
+from apps.api.middleware.auth import get_optional_user
+from apps.api.main import app
+
+
+def _password_link_owned_by(user, *, project_id=None, folder_id=None):
+    """A password-protected ShareLink whose creator is `user`."""
+    link = MagicMock()
+    link.id = uuid.uuid4()
+    link.password_hash = "$2b$12$hashvalue"
+    link.created_by = user.id
+    link.project_id = project_id
+    link.folder_id = folder_id
+    link.allow_download = False
+    link.permission = "comment"
+    return link
+
+
+@patch("apps.api.services.permissions.verify_share_session")
+@patch("apps.api.services.permissions.validate_share_link")
+def test_folder_share_assets_creator_bypasses_password(
+    mock_validate_link, mock_verify_session, client, mock_db, test_user
+):
+    """The authenticated creator viewing the preview must get 200 (not 403) for a
+    password-protected project/folder share — no share_session provided."""
+    # Resolve the optional bearer to the link creator.
+    app.dependency_overrides[get_optional_user] = lambda: test_user
+
+    link = _password_link_owned_by(test_user, project_id=uuid.uuid4())
+    mock_validate_link.return_value = link
+
+    # Make the inline query chains resolve to an empty (but valid) result set.
+    mock_db.order_by.return_value = mock_db
+    mock_db.offset.return_value = mock_db
+    mock_db.limit.return_value = mock_db
+    mock_db.scalar.return_value = 0
+    mock_db.all.return_value = []
+
+    response = client.get("/share/some-token/assets?page=1&per_page=50")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["assets"] == []
+    assert body["subfolders"] == []
+    # The creator bypass must be reached without ever consulting a share session.
+    mock_verify_session.assert_not_called()
+
+
+@patch("apps.api.routers.share.generate_presigned_get_url")
+@patch("apps.api.routers.share._get_latest_media_file")
+@patch("apps.api.routers.share._validate_asset_in_share")
+@patch("apps.api.routers.share._get_asset")
+@patch("apps.api.services.permissions.verify_share_session")
+@patch("apps.api.services.permissions.validate_share_link")
+def test_share_thumbnail_creator_bypasses_password(
+    mock_validate_link,
+    mock_verify_session,
+    mock_get_asset,
+    mock_validate_in_share,
+    mock_get_latest_media_file,
+    mock_presign,
+    client,
+    mock_db,
+    test_user,
+):
+    """Same creator-bypass wiring for `/share/{token}/thumbnail/{asset_id}`."""
+    app.dependency_overrides[get_optional_user] = lambda: test_user
+
+    asset_id = uuid.uuid4()
+    link = _password_link_owned_by(test_user, project_id=uuid.uuid4())
+    mock_validate_link.return_value = link
+
+    asset = MagicMock()
+    asset.id = asset_id
+    mock_get_asset.return_value = asset
+    mock_validate_in_share.return_value = None
+
+    media_file = MagicMock()
+    media_file.s3_key_thumbnail = "thumbnails/proj/asset.webp"
+    mock_get_latest_media_file.return_value = media_file
+    mock_presign.side_effect = lambda key, **kwargs: f"https://s3.example/{key}?sig=x"
+
+    response = client.get(f"/share/some-token/thumbnail/{asset_id}")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["url"].startswith("https://s3.example/")
+    mock_verify_session.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #119. On the dashboard share-link detail screen, the preview showed **"No content yet"** for any folder/project/multi share that had a **passphrase** enabled — even though the link contained assets.

Root cause: the public `/share/{token}/assets` and `/share/{token}/thumbnail/{asset_id}` endpoints never accepted a `current_user` dependency, so they always called `validate_share_link_with_session(..., current_user=None)`. The creator-bypass branch (`if current_user and link.created_by == current_user.id`) was therefore unreachable, and a password-protected link returned `403 Password required` to the creator's own preview. The frontend (`share-link-detail.tsx`) collapses any non-ok response into the empty state. `/share/{token}/stream/{asset_id}` already had the correct wiring — these two endpoints were simply missed.

## Changes

- `get_folder_share_assets` and `get_share_thumbnail_url` now take `current_user: Optional[User] = Depends(get_optional_user)` and forward it to `validate_share_link_with_session`, so the authenticated link creator bypasses the passphrase (matching the stream endpoint).
- Adds `apps/api/tests/test_share_password_preview.py` — regression tests that run the real `validate_share_link_with_session` + endpoint routing as the authenticated creator (fail with 403 before the fix, pass after).
- CHANGELOG entry under `[Unreleased] → Fixed`.

## Testing

- [x] Backend tests pass (`python -m pytest apps/api/tests/ -v`) — **133 passed**
- [ ] Frontend builds — n/a (no frontend changes)
- [x] Tested manually in browser — passphrase-protected share preview now loads assets instead of "No content yet"

## Notes

Frontend hardening (showing a distinct "locked" preview for a genuine 403 rather than "No content yet") is intentionally left as a follow-up; the backend fix resolves the creator-preview case reported here.
