### PR TITLE
fix(review): version switcher plays selected stream (#66) + live version refresh & indicator (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Video version switcher now plays the selected version's stream** ([#66](https://github.com/Techiebutler/freeframe/issues/66)) — the review player fetched `/assets/{id}/stream` without a `version_id`, so switching versions updated the dropdown but the `<video>` kept playing the latest version's stream. The player now pins the stream to the selected version and re-fetches (resetting playback) when the version changes.
+- **New asset versions appear without a hard refresh, with an in-progress indicator** ([#118](https://github.com/Techiebutler/freeframe/issues/118)) — the review screen now revalidates the version list from transcode SSE events instead of a single best-effort timer, so a freshly uploaded version shows up and advances through uploading → processing → ready on its own. The version switcher trigger now surfaces a spinner/label while a new version is still uploading or processing (previously that status was only visible inside the dropdown).
+
 ## [1.3.0] - 2026-07-07
 
 ### Upgrade notes

--- a/apps/web/app/(dashboard)/projects/[id]/assets/[assetId]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/assets/[assetId]/page.tsx
@@ -17,6 +17,7 @@ import { ShareDialog } from '@/components/review/share-dialog'
 import { useReviewStore } from '@/stores/review-store'
 import { useAuthStore } from '@/stores/auth-store'
 import { useComments } from '@/hooks/use-comments'
+import { useSSE } from '@/hooks/use-sse'
 import { api } from '@/lib/api'
 import { useUploadStore } from '@/stores/upload-store'
 import { useBreadcrumbStore } from '@/stores/breadcrumb-store'
@@ -124,6 +125,18 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
     addReaction,
     removeReaction,
   } = useComments(asset?.id || '', currentVersion?.id || '')
+
+  // Keep the version list live: when a new version transcodes, revalidate so it
+  // appears/updates in the switcher without a hard refresh (#118). The review
+  // provider's versions are plain state, not SWR, so nothing else refetches them.
+  const refetchIfThisAsset = (eventAssetId: string) => {
+    if (eventAssetId === asset?.id) refetchVersions()
+  }
+  useSSE(asset?.project_id, {
+    onTranscodeProgress: (d) => refetchIfThisAsset(d.asset_id),
+    onTranscodeComplete: (d) => refetchIfThisAsset(d.asset_id),
+    onTranscodeFailed: (d) => refetchIfThisAsset(d.asset_id),
+  })
 
   // Deep-link to a specific comment from notification (?commentId=...)
   // Runs once after comments are loaded — seeks to timecode, focuses comment, shows annotation
@@ -370,8 +383,10 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
               if (!file || !asset) return
               startVersionUpload(file, asset.id, asset.name, asset.project_id)
               e.target.value = ''
-              // Refetch versions after a short delay to show the new uploading version
+              // Surface the newly-created version (starts as "uploading") quickly;
+              // SSE transcode events then drive it through processing → ready (#118).
               setTimeout(() => refetchVersions(), 800)
+              setTimeout(() => refetchVersions(), 2500)
             }}
           />
           <VersionSwitcher versions={versions} />

--- a/apps/web/components/review/__tests__/version-switcher.test.tsx
+++ b/apps/web/components/review/__tests__/version-switcher.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { VersionSwitcher } from '../version-switcher'
+import { useReviewStore } from '@/stores/review-store'
+import type { AssetVersion } from '@/types'
+
+function makeVersion(partial: Partial<AssetVersion> & { version_number: number }): AssetVersion {
+  return {
+    id: `v${partial.version_number}`,
+    asset_id: 'asset-1',
+    processing_status: 'ready',
+    created_by: 'user-1',
+    created_at: '',
+    deleted_at: null,
+    files: [],
+    ...partial,
+  } as AssetVersion
+}
+
+describe('VersionSwitcher trigger status indicator (#118)', () => {
+  beforeEach(() => {
+    useReviewStore.getState().reset()
+  })
+
+  it('shows a processing indicator on the always-visible trigger when the newest version is still processing', () => {
+    const v1 = makeVersion({ version_number: 1, processing_status: 'ready' })
+    const v2 = makeVersion({ version_number: 2, processing_status: 'processing' })
+    // Viewer is still on the ready v1 while v2 transcodes.
+    useReviewStore.getState().setCurrentVersion(v1)
+
+    render(<VersionSwitcher versions={[v1, v2]} />)
+
+    // Trigger reflects the currently-viewed version...
+    expect(screen.getByText('v1')).toBeInTheDocument()
+    // ...and surfaces that a newer version is being processed, without opening the dropdown.
+    expect(screen.getByTestId('version-status-indicator')).toBeInTheDocument()
+    expect(screen.getByTestId('version-status-indicator')).toHaveTextContent(/processing/i)
+  })
+
+  it('shows an uploading indicator while the newest version is uploading', () => {
+    const v1 = makeVersion({ version_number: 1, processing_status: 'ready' })
+    const v2 = makeVersion({ version_number: 2, processing_status: 'uploading' })
+    useReviewStore.getState().setCurrentVersion(v1)
+
+    render(<VersionSwitcher versions={[v1, v2]} />)
+
+    expect(screen.getByTestId('version-status-indicator')).toHaveTextContent(/uploading/i)
+  })
+
+  it('shows no processing indicator when every version is ready', () => {
+    const v1 = makeVersion({ version_number: 1, processing_status: 'ready' })
+    const v2 = makeVersion({ version_number: 2, processing_status: 'ready' })
+    useReviewStore.getState().setCurrentVersion(v2)
+
+    render(<VersionSwitcher versions={[v1, v2]} />)
+
+    expect(screen.queryByTestId('version-status-indicator')).toBeNull()
+  })
+})

--- a/apps/web/components/review/version-switcher.tsx
+++ b/apps/web/components/review/version-switcher.tsx
@@ -49,13 +49,32 @@ export function VersionSwitcher({ versions, className }: VersionSwitcherProps) {
 
   if (sorted.length === 0) return null
 
+  // Surface an in-flight new version (uploading/transcoding) on the always-visible
+  // trigger — otherwise its status is only visible after opening the dropdown (#118).
+  const latest = sorted[sorted.length - 1]
+  const latestStatus = latest?.processing_status
+  const inFlightCfg =
+    latestStatus === 'uploading' || latestStatus === 'processing'
+      ? versionStatusConfig[latestStatus]
+      : null
+
   return (
     <div className={cn('flex items-center gap-1.5', className)}>
       <span className="text-xs text-text-tertiary shrink-0">Version:</span>
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
-          <button className="inline-flex items-center gap-1 rounded-md px-2.5 py-1 bg-accent text-white text-xs font-medium hover:bg-accent/90 transition-colors outline-none">
-            v{currentVersion?.version_number ?? sorted[sorted.length - 1].version_number}
+          <button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 bg-accent text-white text-xs font-medium hover:bg-accent/90 transition-colors outline-none">
+            <span>v{currentVersion?.version_number ?? latest.version_number}</span>
+            {inFlightCfg && (
+              <span
+                data-testid="version-status-indicator"
+                className="inline-flex items-center gap-1 text-[11px] text-white/90"
+                title={`v${latest.version_number} — ${inFlightCfg.label}`}
+              >
+                {inFlightCfg.icon}
+                {inFlightCfg.label}
+              </span>
+            )}
             {sorted.length > 1 && <ChevronDown className="h-3 w-3 opacity-70" />}
           </button>
         </DropdownMenu.Trigger>

--- a/apps/web/components/review/video-player.tsx
+++ b/apps/web/components/review/video-player.tsx
@@ -171,6 +171,10 @@ export function VideoPlayer({
   // video doesn't keep playing while the new URL is being fetched.
   const versionId = currentVersion?.id;
   useEffect(() => {
+    // Guard against a superseded fetch: rapid version switching starts overlapping
+    // requests, and without this a slower earlier response could land last and leave
+    // the player on the wrong version's stream.
+    let ignore = false;
     setStreamUrl(null);
     if (initialStreamUrl) {
       const resolved = initialStreamUrl.startsWith("/")
@@ -188,6 +192,7 @@ export function VideoPlayer({
     api
       .get<StreamUrlResponse>(streamPath)
       .then((data) => {
+        if (ignore) return;
         // HLS proxy returns relative paths — prepend API URL
         const url = data.url.startsWith("/")
           ? `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"}${data.url}`
@@ -197,6 +202,9 @@ export function VideoPlayer({
       .catch(() => {
         /* stream URL errors handled by player error state */
       });
+    return () => {
+      ignore = true;
+    };
   }, [assetId, initialStreamUrl, versionId]);
 
   const player = useVideoPlayer(streamUrl);

--- a/apps/web/components/review/video-player.tsx
+++ b/apps/web/components/review/video-player.tsx
@@ -134,7 +134,7 @@ export function VideoPlayer({
   const [streamUrl, setStreamUrl] = useState<string | null>(null);
   const [loop, setLoop] = useState(false);
 
-  const { isDrawingMode, timeFormat, setTimeFormat, setPlayheadTime } =
+  const { isDrawingMode, timeFormat, setTimeFormat, setPlayheadTime, currentVersion } =
     useReviewStore();
   const { registerPauseHandler } = useReview();
   const [timeFormatOpen, setTimeFormatOpen] = useState(false);
@@ -167,8 +167,9 @@ export function VideoPlayer({
     }
   }
 
-  // Load the stream URL — reset immediately on asset change so the old video
-  // doesn't keep playing while the new URL is being fetched.
+  // Load the stream URL — reset immediately on asset OR version change so the old
+  // video doesn't keep playing while the new URL is being fetched.
+  const versionId = currentVersion?.id;
   useEffect(() => {
     setStreamUrl(null);
     if (initialStreamUrl) {
@@ -178,8 +179,14 @@ export function VideoPlayer({
       setStreamUrl(resolved);
       return;
     }
+    // Pin the stream to the selected version — without version_id the API falls
+    // back to the latest version, so the switcher never actually changes the
+    // playing stream (#66).
+    const streamPath = versionId
+      ? `/assets/${assetId}/stream?version_id=${versionId}`
+      : `/assets/${assetId}/stream`;
     api
-      .get<StreamUrlResponse>(`/assets/${assetId}/stream`)
+      .get<StreamUrlResponse>(streamPath)
       .then((data) => {
         // HLS proxy returns relative paths — prepend API URL
         const url = data.url.startsWith("/")
@@ -190,7 +197,7 @@ export function VideoPlayer({
       .catch(() => {
         /* stream URL errors handled by player error state */
       });
-  }, [assetId, initialStreamUrl]);
+  }, [assetId, initialStreamUrl, versionId]);
 
   const player = useVideoPlayer(streamUrl);
 


### PR DESCRIPTION
## Summary

Two fixes on the **dashboard asset review screen** (same surface). Fixes #66 and #118.

- **#66** — the version switcher updated the dropdown but the `<video>` kept playing the latest version's stream, because `video-player.tsx` fetched `/assets/{id}/stream` with no `version_id` and didn't react to the selected version.
- **#118** — after uploading a new version it didn't appear in the switcher until a hard refresh, and there was no in-progress indicator in the review UI.

## Changes

### #66 — version switcher plays the selected stream
- `video-player.tsx` reads `currentVersion` from the review store, appends `?version_id=` to the stream fetch, and adds `currentVersion?.id` to the effect deps (streamUrl resets → the player reloads the selected version). The backend `/assets/{id}/stream` already accepts `version_id`. Share mode (`initialStreamUrl`) is untouched.

### #118 — live version list + processing indicator
- The review screen subscribes to `useSSE(asset.project_id, …)` and calls `refetchVersions()` on `transcode_progress`/`complete`/`failed` for the asset, so a new version appears and advances uploading → processing → ready **without a hard refresh** (replacing the brittle single 800ms timer with a short couple-of-tries plus SSE).
- `VersionSwitcher`'s always-visible trigger now shows a spinner/label while the newest version is uploading/processing (previously that status was only visible inside the dropdown).

Product decision: a newly-ready version is **added to the switcher, not auto-selected**, to avoid interrupting an in-progress review.

## Testing
- [x] Backend tests — n/a (frontend-only change; `/assets/{id}/stream` already supports `version_id`)
- [x] Frontend builds / type-checks (`pnpm --filter web build`, `tsc --noEmit` → 0 errors) — **131 web tests pass** (3 new in `version-switcher.test.tsx` covering the trigger indicator)
- [ ] Manual browser click-through of the dashboard flow — recommended before merge (automated + unit coverage in place)

## Notes
Dashboard-only. The separate **public share player** version switcher is #120 (PR #125).
