### PR TITLE
ci: count OpenAPI paths instead of len(app.routes) in import smoke check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,12 @@ jobs:
         run: |
           python -c "
           from apps.api.main import app
-          print(f'FastAPI app loaded: {len(app.routes)} routes')
-          assert len(app.routes) >= 30, f'Expected 30+ routes but got {len(app.routes)} — routers may have been removed'
+          # Count API paths from the OpenAPI schema instead of len(app.routes): recent
+          # FastAPI versions store lazy included-router wrappers, so app.routes no longer
+          # reflects the real endpoint count (it drops sharply) while the schema still does.
+          paths = len(app.openapi()['paths'])
+          print(f'FastAPI app loaded: {paths} API paths')
+          assert paths >= 30, f'Expected 30+ API paths but got {paths} — routers may have been removed'
           "
 
   # ─── Frontend ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
The `Check imports resolve` CI step guards against routers being accidentally deleted by asserting `len(app.routes) >= 30`. On recent FastAPI versions this count is no longer meaningful: FastAPI stores lazy included-router wrappers, so `len(app.routes)` drops sharply (~132 → ~23 on 0.139) even though every endpoint still registers — and the guard fails spuriously.

This switches the guard to count `app.openapi()['paths']`, which reflects the real, version-stable API surface.

## Why
Unblocks the FastAPI 0.115 → 0.139 dependency bump (#95), whose **only** CI failure is this guard (all 69 tests pass under 0.139). CI-only; no application behavior change.

## Verified
- Current main (FastAPI 0.115): `len(app.openapi()['paths'])` = 104 ≥ 30 ✓
- FastAPI 0.139 (reproduced): `len(app.routes)` = 23 (fails old guard) but `openapi()['paths']` = 104 ✓

After this merges, I'll rebase #95 onto main so its CI passes, then merge the bump.