### PR TITLE
fix: keep S3 prefix cleanup working on older S3-compatible backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **S3 prefix cleanup stays compatible with older S3-compatible storage** ([#97](https://github.com/Techiebutler/freeframe/pull/97)) — boto3/botocore ≥ 1.36 (which FreeFrame is upgrading to) send a CRC32 data-integrity checksum on batch `DeleteObjects` instead of the legacy `Content-MD5` header; S3-compatible backends predating AWS flexible checksums (MinIO older than ~2025, older Ceph/RGW, etc.) reject it with `MissingContentMD5`, which would break HLS/prefix cleanup (`delete_prefix`). `delete_prefix` now falls back to per-key deletes when a backend rejects the batch delete, and the bundled dev MinIO image is bumped to a release that supports the new checksums. Self-hosters on an external store older than 2025 keep working via the fallback (upgrade it for the faster batch-delete path). `put_object`/multipart uploads are unaffected.
+
 ## [1.3.1] - 2026-07-08
 
 ### Added

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -273,7 +273,19 @@ def delete_prefix(prefix: str) -> None:
         resp = s3.list_objects_v2(**kwargs)
         objects = [{"Key": o["Key"]} for o in resp.get("Contents", [])]
         if objects:
-            s3.delete_objects(Bucket=settings.s3_bucket, Delete={"Objects": objects})
+            try:
+                s3.delete_objects(Bucket=settings.s3_bucket, Delete={"Objects": objects})
+            except ClientError as e:
+                # botocore >=1.36 sends a CRC32 data-integrity checksum on batch DeleteObjects
+                # instead of the legacy Content-MD5 header. S3-compatible backends that predate
+                # AWS flexible checksums (older MinIO/Ceph/etc.) reject it with MissingContentMD5.
+                # Fall back to per-key deletes, which require no checksum, so cleanup still works.
+                err = e.response.get("Error", {})
+                if err.get("Code") == "MissingContentMD5" or "content-md5" in err.get("Message", "").lower():
+                    for obj in objects:
+                        s3.delete_object(Bucket=settings.s3_bucket, Key=obj["Key"])
+                else:
+                    raise
         if resp.get("IsTruncated"):
             kwargs["ContinuationToken"] = resp.get("NextContinuationToken")
         else:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minioadmin


### PR DESCRIPTION
## Problem
boto3/botocore ≥ 1.36 send a CRC32 data-integrity checksum on batch `DeleteObjects` instead of the legacy `Content-MD5` header. S3-compatible backends that predate AWS flexible checksums (MinIO older than ~2025, older Ceph/RGW, etc.) reject the request with `MissingContentMD5`, which breaks `delete_prefix` — the call used for HLS/prefix cleanup and garbage collection. This surfaces the moment we take the boto3 1.35 → 1.43 bump (#97).

`put_object` and multipart uploads are **not** affected — only the batch `DeleteObjects` API is.

## Fix
1. **`delete_prefix` falls back to per-key `delete_object`** when a backend rejects the batch delete with `MissingContentMD5` (per-key deletes require no checksum). Keeps cleanup working on any older S3-compatible store.
2. **Bundled dev MinIO bumped** `RELEASE.2024-09-13` → `RELEASE.2025-04-22`, a release that supports the new checksums, so the fast batch-delete path works out of the box for the bundled stack.
3. CHANGELOG note under `[Unreleased]`.

## Verified against real MinIO (boto3 1.43.40)
| MinIO | put_object | multipart | batch delete_objects |
|-------|-----------|-----------|----------------------|
| `RELEASE.2024-09-13` (old pin) | OK | OK | **FAIL (MissingContentMD5)** |
| `RELEASE.2025-04-22` (new pin) | OK | OK | **OK** |

And the fallback path directly: against the old MinIO, batch delete fails → per-key `delete_object` fallback succeeds → prefix fully cleaned (0 objects remaining).

Self-hosters on an external store older than 2025 keep working via the fallback; upgrading it restores the faster batch path.

After this merges, I'll rebase #97 onto main so its CI runs against this fix, then merge the bump.