### PR TITLE
docs: self-hosted MinIO for prod + correct S3_STORAGE/endpoint note

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,23 +37,40 @@ REDIS_URL=redis://localhost:6379/0
 # REDIS_URL=redis://:password@your-redis-host:6379/0
 
 # ─── S3 Storage ─────────────────────────────────────────────
-# Dev: "minio" uses the local MinIO container
-# Prod: "s3" for any S3-compatible provider (AWS, R2, B2, Spaces, etc.)
+# FreeFrame stores ALL media via the S3 API — there is no local-filesystem
+# backend. To keep media on your own host, run an S3-compatible server (MinIO)
+# and point FreeFrame at it (see the optional block in docker-compose.prod.yml).
+#
+#   S3_STORAGE=s3     → native AWS S3.  S3_ENDPOINT is IGNORED.
+#   S3_STORAGE=minio  → any other S3-compatible endpoint (self-hosted MinIO,
+#                       Cloudflare R2, Backblaze B2, DO Spaces, Ceph, …).
+#                       S3_ENDPOINT is used and required.
 S3_STORAGE=minio
 S3_BUCKET=freeframe
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_REGION=us-east-1
 S3_ENDPOINT=http://localhost:9000
-# S3_PUBLIC_ENDPOINT=          # Only if presigned URLs need a different base URL
+# S3_PUBLIC_ENDPOINT=          # Browser-reachable base URL for presigned URLs, if it
+#                              # differs from S3_ENDPOINT (e.g. internal http://minio:9000
+#                              # vs public https://storage.example.com). Set this whenever
+#                              # the browser can't reach S3_ENDPOINT directly.
 
-# Production S3 example (uncomment and fill in):
+# Production — native AWS S3 (uncomment and fill in):
 # S3_STORAGE=s3
 # S3_BUCKET=your-freeframe-bucket
 # S3_ACCESS_KEY=YOUR_S3_ACCESS_KEY
 # S3_SECRET_KEY=YOUR_S3_SECRET_KEY
 # S3_REGION=us-east-1
-# S3_ENDPOINT=                 # Set for non-AWS (e.g., https://acct.r2.cloudflarestorage.com)
+
+# Production — non-AWS S3-compatible (Cloudflare R2, Backblaze B2, DO Spaces, or
+# self-hosted MinIO). Keep S3_STORAGE as a non-"s3" value so S3_ENDPOINT is used:
+# S3_STORAGE=minio
+# S3_BUCKET=your-freeframe-bucket
+# S3_ACCESS_KEY=YOUR_ACCESS_KEY
+# S3_SECRET_KEY=YOUR_SECRET_KEY
+# S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+# S3_PUBLIC_ENDPOINT=https://media.your-domain.com   # if the browser needs a different host
 
 # ─── Auth ───────────────────────────────────────────────────
 # Prod: generate a strong secret →  openssl rand -hex 64

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,6 +63,61 @@ services:
       retries: 5
     restart: unless-stopped
 
+  # ─── Optional: self-hosted object storage (MinIO) ────────────────────────────
+  # FreeFrame has NO local-filesystem storage backend — it speaks only the S3 API.
+  # By default, point it at external S3-compatible storage (AWS S3, R2, B2, Spaces)
+  # via the S3_* vars in .env.prod. To instead keep media on THIS host, run your
+  # own MinIO by uncommenting the two services below, then:
+  #   1. add `miniodata:` under the top-level `volumes:` (see bottom of file);
+  #   2. add `depends_on: { minio: { condition: service_healthy } }` to
+  #      api / worker / email_worker / beat;
+  #   3. in .env.prod set:
+  #        S3_STORAGE=minio
+  #        S3_ENDPOINT=http://minio:9000
+  #        S3_PUBLIC_ENDPOINT=https://storage.${DOMAIN}   # MUST be browser-reachable
+  #        S3_ACCESS_KEY / S3_SECRET_KEY = strong values
+  # Presigned URLs are handed to the browser, so MinIO must be reachable from
+  # OUTSIDE the compose network — that is what the Traefik router below provides
+  # (point a `storage.<your-domain>` DNS record at this host). The app sets a
+  # public-read policy on the `processed/*` prefix itself on startup.
+  #
+  # minio:
+  #   image: minio/minio:RELEASE.2025-04-22T22-12-26Z   # 2025+ supports the boto3>=1.36 checksums
+  #   command: server /data --console-address ":9001"
+  #   environment:
+  #     MINIO_ROOT_USER: ${S3_ACCESS_KEY}
+  #     MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+  #     MINIO_CORS_ALLOW_ORIGIN: ${FRONTEND_URL}
+  #     MINIO_CORS_ALLOW_METHODS: GET,PUT,POST,DELETE,HEAD
+  #     MINIO_CORS_ALLOW_HEADERS: "*"
+  #     MINIO_CORS_EXPOSE_HEADERS: ETag,Content-Length,x-amz-request-id
+  #   volumes:
+  #     - miniodata:/data
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
+  #   restart: unless-stopped
+  #   labels:
+  #     - traefik.enable=true
+  #     - traefik.http.routers.minio.rule=Host(`storage.${DOMAIN}`)
+  #     - traefik.http.routers.minio.entrypoints=websecure
+  #     - traefik.http.routers.minio.tls.certresolver=letsencrypt
+  #     - traefik.http.services.minio.loadbalancer.server.port=9000
+  #
+  # minio-init:                     # one-shot: create the bucket (idempotent)
+  #   image: minio/mc:latest
+  #   depends_on:
+  #     minio:
+  #       condition: service_healthy
+  #   entrypoint: >
+  #     /bin/sh -c "
+  #     mc alias set local http://minio:9000 $${S3_ACCESS_KEY} $${S3_SECRET_KEY};
+  #     mc mb --ignore-existing local/$${S3_BUCKET};
+  #     exit 0;
+  #     "
+
   api:
     build:
       context: .
@@ -180,3 +235,4 @@ volumes:
   pgdata:
   redisdata:
   letsencrypt:
+  # miniodata:      # uncomment if you enable the optional self-hosted MinIO service above


### PR DESCRIPTION
## Why
Follow-up to a question about running FreeFrame with local storage. The prod compose ships no MinIO service (prod assumes external S3-compatible storage), and FreeFrame has **no local-filesystem backend** — all media goes through the S3 API. Self-hosters who want media on their own host need to run their own MinIO, and the `.env.example` guidance for non-AWS providers was misleading.

## Changes (docs / compose only — no code, no runtime change)
- **`docker-compose.prod.yml`** — adds an **optional, fully commented-out** `minio` + `minio-init` service block for self-hosters (persistent volume, CORS env, Traefik router on `storage.${DOMAIN}` so presigned URLs are browser-reachable), plus a commented `miniodata:` volume. Prod default is unchanged (external S3).
- **`.env.example`** — clarifies that there is no local-FS backend, and corrects the storage-selection rule:
  - `S3_STORAGE=s3` → native AWS S3, **`S3_ENDPOINT` is ignored**.
  - `S3_STORAGE=minio` (any non-`s3` value) → uses `S3_ENDPOINT`; this is what R2/B2/Spaces/self-hosted MinIO must use. The old note told users to set `S3_STORAGE=s3` **and** an endpoint for R2, which the code silently ignores.
  - Documents `S3_PUBLIC_ENDPOINT` for browser-reachable presigned URLs.

## Notes
- The selection rule reflects current behavior in `s3_service.py` (`_is_aws_s3()` = `s3_storage == 's3'`); this PR only aligns the docs with the code (does not change the code).
- Uses `minio/minio:RELEASE.2025-04-22` in the template — a release that supports the boto3 ≥1.36 checksums (see #134).