### PR TITLE
fix(config): fail loud on S3_STORAGE=s3 + non-AWS S3_ENDPOINT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,8 @@ REDIS_URL=redis://localhost:6379/0
 # backend. To keep media on your own host, run an S3-compatible server (MinIO)
 # and point FreeFrame at it (see the optional block in docker-compose.prod.yml).
 #
-#   S3_STORAGE=s3     → native AWS S3.  S3_ENDPOINT is IGNORED.
+#   S3_STORAGE=s3     → native AWS S3.  S3_ENDPOINT is IGNORED (pointing it at a
+#                       non-AWS URL fails fast at startup — use "minio" instead).
 #   S3_STORAGE=minio  → any other S3-compatible endpoint (self-hosted MinIO,
 #                       Cloudflare R2, Backblaze B2, DO Spaces, Ceph, …).
 #                       S3_ENDPOINT is used and required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **S3 prefix cleanup stays compatible with older S3-compatible storage** ([#97](https://github.com/Techiebutler/freeframe/pull/97)) — boto3/botocore ≥ 1.36 (which FreeFrame is upgrading to) send a CRC32 data-integrity checksum on batch `DeleteObjects` instead of the legacy `Content-MD5` header; S3-compatible backends predating AWS flexible checksums (MinIO older than ~2025, older Ceph/RGW, etc.) reject it with `MissingContentMD5`, which would break HLS/prefix cleanup (`delete_prefix`). `delete_prefix` now falls back to per-key deletes when a backend rejects the batch delete, and the bundled dev MinIO image is bumped to a release that supports the new checksums. Self-hosters on an external store older than 2025 keep working via the fallback (upgrade it for the faster batch-delete path). `put_object`/multipart uploads are unaffected.
+- **Misconfigured S3 storage now fails fast instead of silently routing to AWS** — with `S3_STORAGE=s3` (native AWS), `S3_ENDPOINT` is ignored, so pairing it with a non-AWS endpoint (Cloudflare R2, Backblaze B2, self-hosted MinIO, …) used to silently send traffic to AWS. Startup now raises a clear error naming the offending endpoint and pointing to `S3_STORAGE=minio`. Valid configs (native AWS, or any `minio`-mode endpoint) are unaffected.
 
 ## [1.3.1] - 2026-07-08
 

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -1,6 +1,18 @@
 import os
 from pathlib import Path
+from urllib.parse import urlparse
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Default S3 endpoint (local MinIO). Shared between the field default and the
+# consistency validator so the two can't drift.
+DEFAULT_S3_ENDPOINT = "http://minio:9000"
+
+
+def _is_aws_endpoint(url: str) -> bool:
+    """True if `url`'s host is an AWS S3 endpoint (an ``*.amazonaws.com`` host)."""
+    host = (urlparse(url).hostname or "").lower()
+    return host == "amazonaws.com" or host.endswith(".amazonaws.com")
 
 # Find .env file - check current dir, then project root
 # __file__ = apps/api/config.py, so parent.parent = project root
@@ -28,7 +40,7 @@ class Settings(BaseSettings):
     redis_url: str
     s3_storage: str = "minio"  # "s3" for AWS S3, "minio" for local MinIO
     s3_bucket: str = "freeframe"
-    s3_endpoint: str = "http://minio:9000"
+    s3_endpoint: str = DEFAULT_S3_ENDPOINT
     s3_access_key: str = "minioadmin"
     s3_secret_key: str = "minioadmin"
     s3_region: str = "us-east-1"
@@ -80,5 +92,26 @@ class Settings(BaseSettings):
     smtp_user: str | None = None
     smtp_password: str | None = None
     smtp_use_tls: bool = True
+
+    @model_validator(mode="after")
+    def _check_s3_endpoint_consistency(self):
+        """Fail loud on `S3_STORAGE=s3` + a real custom (non-AWS) `S3_ENDPOINT`.
+
+        In `s3` mode the client talks to native AWS and S3_ENDPOINT is ignored,
+        so pairing it with an R2/B2/MinIO URL would silently route to AWS. An
+        untouched default and any `*.amazonaws.com` endpoint are harmless and
+        allowed; a custom non-AWS endpoint is a misconfiguration.
+        """
+        if self.s3_storage.lower() == "s3":
+            endpoint = (self.s3_endpoint or "").strip()
+            if endpoint and endpoint != DEFAULT_S3_ENDPOINT and not _is_aws_endpoint(endpoint):
+                raise ValueError(
+                    f"S3_STORAGE=s3 selects native AWS S3 and ignores S3_ENDPOINT, but "
+                    f"S3_ENDPOINT is set to a non-AWS URL ({endpoint!r}). To use a custom "
+                    f"S3-compatible endpoint (MinIO, Cloudflare R2, Backblaze B2, "
+                    f"DigitalOcean Spaces), set S3_STORAGE=minio. To use native AWS S3, "
+                    f"leave S3_ENDPOINT unset."
+                )
+        return self
 
 settings = Settings()

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -23,9 +23,10 @@ def _is_aws_s3() -> bool:
 
 def get_s3_client():
     """
-    Create S3 client. Auto-detects AWS vs MinIO:
-    - If access_key starts with 'AKIA' -> use AWS S3 (no endpoint_url)
-    - Otherwise -> use custom endpoint (MinIO or S3-compatible)
+    Create the S3 client for server-side operations. Selection is driven by
+    S3_STORAGE (see _is_aws_s3):
+    - "s3"   -> native AWS S3 (no endpoint_url; S3_ENDPOINT is not used)
+    - other  -> S3_ENDPOINT for MinIO or another S3-compatible backend
     """
     if _is_aws_s3():
         # Real AWS S3 - don't pass endpoint_url

--- a/apps/api/tests/test_s3_config.py
+++ b/apps/api/tests/test_s3_config.py
@@ -1,0 +1,59 @@
+"""Validation of S3_STORAGE / S3_ENDPOINT consistency in Settings.
+
+`S3_STORAGE=s3` selects native AWS S3 and ignores S3_ENDPOINT. Pairing it with a
+real custom (non-AWS) endpoint is a misconfiguration that used to silently route
+to AWS; it must now fail loudly at Settings load.
+"""
+import pytest
+from pydantic import ValidationError
+
+from apps.api.config import Settings
+
+DEFAULT_MINIO_ENDPOINT = "http://minio:9000"
+
+
+def _settings(**overrides):
+    """Build a Settings instance from explicit values, bypassing the env file.
+
+    Required fields are supplied; s3_* values are passed as kwargs (which take
+    precedence over any S3_* env vars the test runner set), so each case is
+    deterministic.
+    """
+    base = dict(
+        database_url="postgresql://u:p@localhost:5432/db",
+        redis_url="redis://localhost:6379/0",
+        jwt_secret="test-secret",
+    )
+    base.update(overrides)
+    return Settings(_env_file=None, **base)
+
+
+def test_s3_mode_with_custom_non_aws_endpoint_raises():
+    with pytest.raises(ValidationError, match="S3_STORAGE=s3"):
+        _settings(s3_storage="s3", s3_endpoint="https://acct.r2.cloudflarestorage.com")
+
+
+def test_s3_mode_is_case_insensitive():
+    with pytest.raises(ValidationError):
+        _settings(s3_storage="S3", s3_endpoint="https://s3.example-compat.com")
+
+
+def test_s3_mode_with_empty_endpoint_ok():
+    s = _settings(s3_storage="s3", s3_endpoint="")
+    assert s.s3_storage == "s3"
+
+
+def test_s3_mode_with_default_minio_endpoint_ok():
+    # An untouched default is not a meaningful override; it is ignored in s3 mode.
+    s = _settings(s3_storage="s3", s3_endpoint=DEFAULT_MINIO_ENDPOINT)
+    assert s.s3_endpoint == DEFAULT_MINIO_ENDPOINT
+
+
+def test_s3_mode_with_aws_endpoint_ok():
+    s = _settings(s3_storage="s3", s3_endpoint="https://s3.us-west-2.amazonaws.com")
+    assert s.s3_storage == "s3"
+
+
+def test_minio_mode_with_custom_endpoint_ok():
+    s = _settings(s3_storage="minio", s3_endpoint="https://acct.r2.cloudflarestorage.com")
+    assert s.s3_storage == "minio"


### PR DESCRIPTION
## Problem
With `S3_STORAGE=s3`, the S3 client talks to **native AWS** and `S3_ENDPOINT` is **ignored** (`_is_aws_s3()` keys off the flag). So an operator who sets `S3_STORAGE=s3` together with a non-AWS endpoint (Cloudflare R2, Backblaze B2, self-hosted MinIO) — a natural mistake, and what the *old* docs wrongly suggested — is **silently routed to AWS**, producing confusing auth failures or writes to the wrong place. `_is_aws_s3()` also gates AWS-only bucket setup (LocationConstraint; skipping the CORS + public-read policy S3-compatible backends need), so the misconfig is doubly wrong.

(The docs were already corrected in #135; this closes the remaining *code* gap — the silent misroute.)

## Fix — strict, fail loud
A Pydantic `@model_validator(mode="after")` on `Settings` (runs on every `Settings()` load, so **api, worker, and beat** all fail loud — a FastAPI-lifespan check would miss the Celery workers). When `s3_storage == "s3"`, it raises a clear `ValueError` **only if** `S3_ENDPOINT` is a *real custom non-AWS* endpoint: non-empty, not the `http://minio:9000` default, and not an `*.amazonaws.com` host.

**Zero impact on valid configs:**
| `S3_STORAGE` | `S3_ENDPOINT` | Result |
|---|---|---|
| `s3` | unset / default / `*.amazonaws.com` | ✅ native AWS |
| `s3` | custom non-AWS (R2/B2/…) | ❌ loud error at startup |
| `minio` (any non-`s3`) | anything | ✅ uses endpoint |

Also fixes the **stale `get_s3_client()` docstring** (claimed an `AKIA`-prefix rule the code never implemented). `s3_public_endpoint` is untouched (already honored in `s3` mode — no footgun).

## Tests & verification
- `apps/api/tests/test_s3_config.py` — 6 cases (conflict raises; empty / default / AWS / minio+custom all pass), written test-first (verified red → green).
- Full backend suite: **124 passed** locally (the only errors are pre-existing DB-integration tests that need a live Postgres — confirmed identical with the change reverted).
- Smoke-tested the **real `settings = Settings()` startup path**: `s3`+R2 → exits 1 with the actionable message; `s3`+empty/AWS and `minio`+R2 → load fine.

Docs/compose only default unchanged; guardrail noted in `.env.example` + CHANGELOG `[Unreleased]`.