### PR TITLE
test(api): fix flaky stream-URL assertion (random token could contain 's3')

### DIFF
--- a/apps/api/tests/test_assets_stream_url.py
+++ b/apps/api/tests/test_assets_stream_url.py
@@ -60,7 +60,10 @@ def test_video_stream_returns_hls_proxy_url_with_token(
     assert url.startswith("/stream/hls/master.m3u8?token="), (
         f"Expected /stream/hls/master.m3u8?token=..., got: {url}"
     )
-    assert "s3" not in url.lower(), (
+    # Only inspect the part before the query string: the opaque JWT token can
+    # incidentally contain "s3" (flaking this check), whereas a leaked presigned
+    # S3 URL would still carry "s3" in its host/path here.
+    assert "s3" not in url.split("?", 1)[0].lower(), (
         f"Stream URL must not contain a presigned S3 URL, got: {url}"
     )
 


### PR DESCRIPTION
## Problem
`test_video_stream_returns_hls_proxy_url_with_token` intermittently fails, reddening CI on unrelated PRs (it lost the coin-flip on the **#138 merge to main**, though #138 touched no backend code):

```
AssertionError: Stream URL must not contain a presigned S3 URL, got: /stream/hls/master.m3u8?token=***
assert 's3' not in '/stream/hls...wtqd5xistssi'
```

The test asserts `"s3" not in url` where `url = /stream/hls/master.m3u8?token=<random JWT>`. The JWT token is random and **sometimes contains the substring "s3"**, so the check fails unpredictably.

## Fix
The preceding assertion already confirms `url.startswith("/stream/hls/master.m3u8?token=")`, so the guard only needs to inspect the part **before the query string**:
```python
assert "s3" not in url.split("?", 1)[0].lower()
```
The path (`/stream/hls/master.m3u8`) is deterministic, and a leaked presigned S3 URL (`https://s3.example.com/...?X-Amz-...`) still carries "s3" in its host/path — so it's still caught.

## Verified
- Logic table: token-with-"s3" (the flake) **fail → pass**; presigned S3 URL still **rejected**; normal token still passes.
- Ran the test **12×** with fresh random tokens: 12/12 pass (deterministic).

Test-only change.