### PR TITLE
feat(release): add stable/latest release channels

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -1,0 +1,61 @@
+name: Promote release to stable
+
+# Manually promote a released tag to the `stable` branch, which self-hosters
+# track for production. Refuses to promote a tag whose commit did not pass CI,
+# so a bad release can never become `stable`. Rollback = re-run this with an
+# older, known-good tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to promote to stable (e.g. v1.3.1)"
+        required: true
+        type: string
+      force:
+        description: "Skip the CI-green gate (only for tags with no CI, e.g. docs-only)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Verify CI is green, then move `stable`
+        env:
+          TAG: ${{ inputs.tag }}
+          FORCE: ${{ inputs.force }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          COMMIT="$(git rev-list -n1 "refs/tags/${TAG}")"
+          echo "Promoting ${TAG} (${COMMIT}) -> stable"
+
+          if [ "${FORCE}" != "true" ]; then
+            runs="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT}/check-runs")"
+            total="$(echo "$runs" | jq '.check_runs | length')"
+            bad="$(echo "$runs" | jq '[.check_runs[] | select(.conclusion != "success")] | length')"
+            if [ "$total" -lt 1 ]; then
+              echo "::error::No CI check-runs found for ${TAG} (${COMMIT}); refusing to promote. Re-run with force=true only if this tag legitimately has no CI."
+              exit 1
+            fi
+            if [ "$bad" -gt 0 ]; then
+              echo "::error::${TAG} has non-success checks; refusing to promote:"
+              echo "$runs" | jq -r '.check_runs[] | select(.conclusion != "success") | "  - \(.name): \(.conclusion // .status)"'
+              exit 1
+            fi
+            echo "All ${total} CI check(s) green for ${TAG}."
+          else
+            echo "::warning::force=true — skipping the CI-green gate for ${TAG}."
+          fi
+
+          git push --force origin "${COMMIT}:refs/heads/stable"
+          echo "::notice::stable now points at ${TAG} (${COMMIT})"

--- a/.github/workflows/release-pointers.yml
+++ b/.github/workflows/release-pointers.yml
@@ -1,0 +1,33 @@
+name: Move latest pointer
+
+# When a GitHub Release is published, fast-forward the `latest` branch to that
+# release's tag so cloners of `latest` always get the newest release. `stable`
+# is intentionally NOT touched here — it moves only via the manual
+# "Promote release to stable" workflow after validation.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  move-latest:
+    # Pre-releases (RCs, betas) do not move `latest`.
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Move `latest` to the released tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          COMMIT="$(git rev-list -n1 "refs/tags/${TAG}")"
+          echo "Moving latest -> ${TAG} (${COMMIT})"
+          git push --force origin "${COMMIT}:refs/heads/latest"
+          echo "::notice::latest now points at ${TAG} (${COMMIT})"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,23 @@ Read this section before writing backend code or tests.
 
 ---
 
+## Releases & branches
+
+FreeFrame ships **moving branch pointers** on top of immutable `vX.Y.Z` tags. Know which is which:
+
+- **`main`** — active development. PRs target `main`; it may be ahead of any release.
+- **`stable`** — the last **validated** release. **This is what production self-hosters run** (`git clone -b stable`). Never tell users to run `main` in production, and don't point install/deploy docs at `main` — point them at `stable`.
+- **`latest`** — the newest published release (auto-moved by `.github/workflows/release-pointers.yml`). For early adopters.
+- **`vX.Y.Z`** — immutable release tags; never move or delete them.
+
+Rules for agents:
+
+- **Don't create, move, or force-push `stable` / `latest`** — they are moved only by the release workflows (`release-pointers.yml` on release publish; `promote-stable.yml` manually, which gates on green CI). See [`docs/RELEASING.md`](docs/RELEASING.md).
+- **Don't cut releases or tags** unless explicitly asked — releases are manual and CHANGELOG-driven.
+- Default user-facing install/deploy instructions to `stable` (see the README "Release channels" table).
+
+---
+
 ## Finding things & getting help
 
 - **An endpoint or schema:** browse http://localhost:8000/docs, or grep `apps/api/routers/`.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,24 @@ Open [http://localhost:3000](http://localhost:3000) to access FreeFrame. The fir
 | API Docs    | http://localhost:8000/docs    |
 | MinIO Console | http://localhost:9001       |
 
+## Release channels
+
+Production self-hosters should run a **released** version, not `main`:
+
+| Ref | What it is | Use it if… |
+|-----|-----------|------------|
+| `stable` | The latest release we've validated — a bad release is never promoted here. | **Production (safe default):** `git clone -b stable …`, then `git pull` to update. |
+| `latest` | The newest published release (moves on every release). | You want new features sooner and can tolerate the occasional regression. |
+| `v1.3.1` (any `vX.Y.Z`) | An immutable, pinned release. | You want to pin an exact version: `git checkout v1.3.1`. |
+| `main` | Active development; may be unreleased or unstable. | You're developing or contributing to FreeFrame. |
+
+Release notes are on the [Releases page](https://github.com/Techiebutler/freeframe/releases). Maintainers: see [docs/RELEASING.md](docs/RELEASING.md).
+
 ## Production Deployment
 
 ```bash
+git clone -b stable https://github.com/Techiebutler/freeframe.git
+cd freeframe
 cp .env.example .env.prod
 # Edit .env.prod — set your credentials, S3, email config
 # For SSL: also set DOMAIN and ACME_EMAIL (Traefik auto-provisions Let's Encrypt certs)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,53 @@
+# Releasing FreeFrame
+
+FreeFrame uses **moving branch pointers** on top of immutable `vX.Y.Z` tags so
+self-hosters can track a known-good version instead of `main`.
+
+| Ref | Moves? | Who moves it | For |
+|-----|--------|--------------|-----|
+| `main` | every merge | contributors | development |
+| `vX.Y.Z` | never | release cutter (manual tag) | permanent history / pinning |
+| `latest` | every release | **`release-pointers.yml`** (auto) | early adopters |
+| `stable` | on promotion | **`promote-stable.yml`** (manual) | production self-hosters |
+
+## Cutting a release
+
+1. Make sure `main` is green and the `CHANGELOG.md` `[Unreleased]` section is
+   complete. Move those entries under a new `## [X.Y.Z] - YYYY-MM-DD` heading.
+2. Tag the release commit and push the tag:
+   ```bash
+   git tag vX.Y.Z <commit>      # usually main's HEAD
+   git push origin vX.Y.Z
+   ```
+3. Publish a **GitHub Release** for `vX.Y.Z` with notes (the CHANGELOG section).
+   - Publishing it triggers `release-pointers.yml`, which **auto-moves `latest`**
+     to `vX.Y.Z`. (Mark it a *pre-release* to keep `latest` where it is.)
+
+## Promoting to `stable`
+
+`latest` moves immediately; `stable` moves only after you've validated the
+release (soak it as `latest`, smoke-test, watch for breakage reports).
+
+- Run the **"Promote release to stable"** workflow (Actions → Run workflow) with
+  `tag: vX.Y.Z`.
+- It **refuses to promote unless that tag's commit passed CI** (≥1 check-run and
+  all `success`). Use `force: true` only for a tag that legitimately has no CI
+  (e.g. docs-only).
+
+## Rolling back a bad release
+
+`stable` is just a pointer — move it back to the last good tag:
+
+- Run **"Promote release to stable"** again with the previous good `tag`
+  (e.g. `v1.3.0`).
+- Optionally edit the bad GitHub Release to mark it clearly broken. The
+  immutable `vX.Y.Z` tag stays as-is; only the `stable` pointer retreats.
+
+## One-time setup (already done)
+
+- `stable` and `latest` branches were created at **v1.3.1**.
+- `latest`/`stable` must **not** have required-review branch protection, or the
+  workflows' `GITHUB_TOKEN` (`contents: write`) can't push them. Only `main` is
+  protected.
+- Moving `latest`/`stable` does **not** run `ci.yml` (it triggers on
+  `push: branches: [main]` only), so there's no CI storm and no trigger loop.


### PR DESCRIPTION
## Problem
FreeFrame is self-hosted by cloning + building. The README told users to `git clone` (→ **`main`**) and build — so a mid-development `main` or a bad merge can break a cloner, and a bad *release* had no known-good pointer to fall back to.

## Solution — moving branch pointers on top of immutable `vX.Y.Z` tags
| Ref | Moves | For |
|-----|-------|-----|
| `main` | every merge | development |
| `vX.Y.Z` | never | permanent history / pinning |
| `latest` | every release (auto) | early adopters |
| `stable` | on validated promotion | **production self-hosters** |

A bad release is simply never promoted, so `stable` users never receive it; rollback is a pointer move.

## What's here
- **`.github/workflows/release-pointers.yml`** — on `release: published` (skips pre-releases), force-updates `latest` to the release tag.
- **`.github/workflows/promote-stable.yml`** — manual `workflow_dispatch` (`tag` input); **refuses to promote unless that tag's commit passed CI** (≥1 check-run, all `success`; `force` override for CI-less/docs tags), then moves `stable`. Rollback = re-run with an older good tag.
- **README** — a *Release channels* table; production deploy now clones `-b stable`.
- **`docs/RELEASING.md`** — cut / promote / rollback flow for maintainers.
- **AGENTS.md** — release-branch rules so coding agents don't touch `stable`/`latest` or point docs at `main`.

## Verified
- Both workflows parse as valid YAML.
- Dry-ran the promote CI-gate logic against real commits: a **green** commit → *PROMOTE (4 green)*; a **red** commit → *REFUSE (1 non-success)*.
- Neither new workflow triggers on push/PR, and moving `latest`/`stable` doesn't run `ci.yml` (`push: branches: [main]` only) — no CI storm or trigger loop.

## Follow-up (out of PR)
Create the initial `stable` and `latest` branches at **v1.3.1** (`be9a59e8`), and ensure they carry no required-review protection so the workflows' `GITHUB_TOKEN` can push them.