### PR TITLE
fix: cache S3 clients (#132) + require CORS ETag for browser uploads (#131)

### DIFF
--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import os
 import re
 from functools import lru_cache
 import boto3
 from botocore.exceptions import ClientError
 from ..config import settings
+
+logger = logging.getLogger(__name__)
 
 # S3 Content-Type and Cache-Control mappings
 CONTENT_TYPE_MAP = {
@@ -108,8 +111,19 @@ def ensure_bucket_exists():
                     ]
                 },
             )
-        except ClientError:
-            pass  # CORS config failed, non-critical
+        except ClientError as e:
+            # Non-fatal, but surfaced: browser multipart uploads assemble the
+            # CompleteMultipartUpload from each part's ETag response header,
+            # which the browser only exposes when the bucket's CORS
+            # ExposeHeaders includes "ETag". If we can't set CORS here, uploads
+            # may fail client-side with a generic error and no server log —
+            # so warn and point the operator at the docs (issue #131).
+            logger.warning(
+                "Could not set bucket CORS on %r (%s). Browser multipart uploads "
+                "need the bucket CORS ExposeHeaders to include 'ETag'; configure it "
+                "manually on your S3 provider — see docs/deployment.md (External S3 Storage).",
+                settings.s3_bucket, e,
+            )
 
         # Set public-read policy on processed/ prefix so HLS sub-playlists
         # and .ts segments can be fetched without presigned URLs

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from functools import lru_cache
 import boto3
 from botocore.exceptions import ClientError
 from ..config import settings
@@ -21,6 +22,7 @@ def _is_aws_s3() -> bool:
     """Check if using AWS S3 (vs MinIO/local). Controlled by S3_STORAGE env var."""
     return settings.s3_storage.lower() == "s3"
 
+@lru_cache(maxsize=1)
 def get_s3_client():
     """
     Create the S3 client for server-side operations. Selection is driven by
@@ -46,6 +48,7 @@ def get_s3_client():
             region_name=settings.s3_region,
         )
 
+@lru_cache(maxsize=1)
 def _get_presign_client():
     """
     Client for generating presigned URLs. Uses s3_public_endpoint if set,

--- a/apps/api/tests/test_s3_client_cache.py
+++ b/apps/api/tests/test_s3_client_cache.py
@@ -1,0 +1,53 @@
+"""The S3 clients are constructed once and reused (issue #132).
+
+`hls_proxy` presigns one URL per HLS segment; without caching, a long VOD
+manifest re-created a boto3 client per segment (~7s for a 55-min video). The
+client factories must build the client once and reuse it.
+"""
+import pytest
+
+from apps.api.services import s3_service
+from apps.api.services.s3_service import get_s3_client, _get_presign_client
+
+
+@pytest.fixture(autouse=True)
+def _clear_client_caches():
+    # Reset the caches around each test (guarded so this also works before the
+    # @lru_cache is added — i.e. during the red phase).
+    for fn in (get_s3_client, _get_presign_client):
+        getattr(fn, "cache_clear", lambda: None)()
+    yield
+    for fn in (get_s3_client, _get_presign_client):
+        getattr(fn, "cache_clear", lambda: None)()
+
+
+def test_get_s3_client_built_once_and_reused(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_client(*args, **kwargs):
+        calls["n"] += 1
+        return object()
+
+    monkeypatch.setattr(s3_service.boto3, "client", fake_client)
+
+    first = get_s3_client()
+    second = get_s3_client()
+
+    assert first is second
+    assert calls["n"] == 1
+
+
+def test_presign_client_built_once_and_reused(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_client(*args, **kwargs):
+        calls["n"] += 1
+        return object()
+
+    monkeypatch.setattr(s3_service.boto3, "client", fake_client)
+
+    first = _get_presign_client()
+    second = _get_presign_client()
+
+    assert first is second
+    assert calls["n"] == 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -179,7 +179,7 @@ S3_SECRET_KEY=YOUR_SECRET_KEY
 S3_REGION=us-east-1
 ```
 
-For **non-AWS providers**, also set the endpoint:
+For **non-AWS S3-compatible providers** (R2, B2, Spaces, MinIO, Hetzner, …), set `S3_STORAGE` to a non-`s3` value (e.g. `minio`) so `S3_ENDPOINT` is used — with `S3_STORAGE=s3` the client talks to native AWS and the endpoint is **ignored** (FreeFrame refuses to start if `s3` is combined with a non-AWS endpoint). Then set the endpoint:
 
 | Provider | S3_ENDPOINT |
 |----------|-------------|
@@ -188,7 +188,23 @@ For **non-AWS providers**, also set the endpoint:
 | DigitalOcean Spaces | `https://<region>.digitaloceanspaces.com` |
 | MinIO (self-hosted) | `http://your-minio-host:9000` |
 
-Make sure your bucket has CORS configured to allow requests from your FreeFrame domain.
+#### Bucket CORS — required for uploads
+
+Uploads go **directly from the browser to your bucket** via presigned URLs, so the bucket's CORS must allow your FreeFrame origin **and expose the `ETag` header** — the client reads each part's `ETag` to complete a multipart upload. If `ExposeHeaders` omits `ETag`, large uploads fail partway with a generic browser error ("Load failed") and **no server-side log**.
+
+```json
+{
+  "CORSRules": [{
+    "AllowedOrigins": ["https://your-freeframe-domain.example"],
+    "AllowedMethods": ["GET", "PUT", "POST", "HEAD", "DELETE"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3000
+  }]
+}
+```
+
+FreeFrame applies this automatically to **non-AWS** buckets at startup when it has permission (and logs a warning if it can't). Set it yourself for **AWS S3**, or wherever FreeFrame lacks CORS permission. **Hetzner Object Storage** exposes CORS only via API/CLI (not the Console UI), so it's easy to miss — apply the JSON above with `aws s3api put-bucket-cors`.
 
 ### External SMTP
 


### PR DESCRIPTION
Resolves two S3 issues reported by @Lennart-Pingpong ahead of v1.4.0. Both touch `s3_service.py`, so they're bundled (one commit each) to avoid a same-file conflict.

## #132 — HLS proxy re-created a boto3 client per segment (perf)
`hls_proxy` presigns one URL **per `.ts` segment** when rewriting a VOD manifest, and `get_s3_client()` / `_get_presign_client()` built a fresh boto3 client on every call — the reporter measured **~7s of blocking client construction** for a ~55-min video (~1670 segments) on *each* manifest fetch.

**Fix:** `@lru_cache(maxsize=1)` on both factories (boto3 clients are safe to reuse — the recommended pattern). Test-first: `test_s3_client_cache.py` asserts each client is built **once** and reused (verified red→green).

## #131 — browser uploads fail silently if bucket CORS doesn't expose `ETag`
Multipart uploads read each part's `ETag` response header to complete the upload; browsers only expose `ETag` when the bucket CORS `ExposeHeaders` includes it. Missing → large uploads fail with a generic "Load failed" and **no server log**. Hits Hetzner especially (CORS is API/CLI-only there).

**Fix (docs + surface the silent failure):**
- `docs/deployment.md`: new **"Bucket CORS — required for uploads"** section with the minimum CORS (`ExposeHeaders: ["ETag"]`) + Hetzner/AWS notes. Also corrected the adjacent non-AWS guidance (it said `S3_STORAGE=s3` + endpoint, which #137 now rejects at startup — use a non-`s3` value).
- `s3_service.py`: the `put_bucket_cors` failure was swallowed silently (`except ClientError: pass`) — now **logs a warning** so operators can see it.

## Verified
- `test_s3_client_cache.py`: 2 pass (red→green). Other S3 tests green; the one erroring test is a pre-existing DB-integration test (needs live Postgres — confirmed identical with the change stashed).
- `py_compile` clean; deployment.md fences balanced.

Closes #132
Closes #131