### PR TITLE
fix: prod hardening from v1.4.0 deploy test (healthcheck, non-blocking S3 startup, email-required)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,9 @@ REFRESH_TOKEN_EXPIRE_DAYS=7
 FRONTEND_URL=http://localhost:3000
 
 # ─── Email ──────────────────────────────────────────────────
+# REQUIRED for login: FreeFrame signs users in with emailed magic codes (and
+# sends invites/notifications). Without a working mailer, users cannot log in —
+# the app logs a warning at startup if email isn't configured.
 # Option 1: SMTP (Mailgun, Postmark, SendGrid, self-hosted, etc.)
 MAIL_PROVIDER=smtp
 MAIL_FROM_ADDRESS=noreply@example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Celery workers no longer report `unhealthy`** — the prod image no longer bakes an API-only `HEALTHCHECK` (`curl :8000/health`); it now lives on the `api` service in `docker-compose.prod.yml`, so `worker`/`beat`/`email_worker` (which don't serve HTTP) report their real state instead of perpetually unhealthy.
+- **A slow or unreachable object store no longer blocks app startup** — the startup S3 bucket check now runs off the request path (background thread) with bounded timeouts and never crashes/hangs the app (previously a slow S3 could block startup ~60s+). Failures log a clear warning.
+- **Email is documented as required for login, with a startup warning** — FreeFrame signs users in via emailed magic codes, so without a working mailer nobody can log in. The app now logs a clear warning at startup when email isn't configured, and `docs/deployment.md` + `.env.example` call it out.
+
 ## [1.4.0] - 2026-07-09
 
 ### Upgrade notes

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -22,8 +22,10 @@ RUN adduser --disabled-password --no-create-home appuser
 
 WORKDIR /workspace
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+# No HEALTHCHECK here: this image is shared by the API *and* the Celery
+# worker/beat/email_worker, which don't serve HTTP — a baked-in `curl :8000/health`
+# marks every worker perpetually "unhealthy". The API's healthcheck lives on the
+# `api` service in docker-compose.prod.yml instead.
 
 USER appuser
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,16 +1,27 @@
+import logging
 import os
+import threading
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
 from .routers import auth, users, projects, upload, events, assets, me, comments, approvals, share, metadata, branding, notifications, admin, setup, folders, hls_proxy, instance_settings
-from .services.s3_service import ensure_bucket_exists
+from .services.s3_service import run_startup_bucket_setup
+from .services.email_service import mail_is_configured
 from .middleware.global_rate_limit import GlobalRateLimitMiddleware
 from .middleware.setup_guard import SetupGuardMiddleware
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    ensure_bucket_exists()
+    # Run bucket setup off the request path (daemon thread) so a slow or unreachable
+    # object store can't block app startup (deploy-test finding #6).
+    threading.Thread(target=run_startup_bucket_setup, name="s3-bucket-setup", daemon=True).start()
+    if not mail_is_configured():
+        logging.getLogger("apps.api.startup").warning(
+            "Email is not configured (MAIL_PROVIDER=%s) — magic-code login and invites "
+            "will FAIL until you configure SMTP or SES. See docs/deployment.md.",
+            settings.mail_provider,
+        )
     yield
 
 _disable_docs = os.getenv("DISABLE_DOCS", "").lower() in ("true", "1", "yes")

--- a/apps/api/services/email_service.py
+++ b/apps/api/services/email_service.py
@@ -7,6 +7,19 @@ from botocore.exceptions import ClientError
 from ..config import settings
 
 
+def mail_is_configured(s=settings) -> bool:
+    """Whether the configured mailer can actually send.
+
+    Email is REQUIRED for login (magic codes) and invites, so the app warns at
+    startup when it's not set up. `smtp` needs a host; `ses` may authenticate via
+    an IAM role, so we can't reliably detect it and assume it's configured.
+    """
+    provider = (s.mail_provider or "").lower()
+    if provider == "smtp":
+        return bool(s.smtp_host)
+    return provider == "ses"
+
+
 class EmailService:
     """
     Email service that supports both AWS SES and standard SMTP.

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -4,10 +4,15 @@ import os
 import re
 from functools import lru_cache
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from ..config import settings
 
 logger = logging.getLogger(__name__)
+
+# Short timeouts for the one-off startup bucket check, so a slow or unreachable
+# store can't hang app startup for boto3's default ~60s (deploy-test finding #6).
+_STARTUP_S3_CONFIG = Config(connect_timeout=5, read_timeout=10, retries={"max_attempts": 2})
 
 # S3 Content-Type and Cache-Control mappings
 CONTENT_TYPE_MAP = {
@@ -25,31 +30,28 @@ def _is_aws_s3() -> bool:
     """Check if using AWS S3 (vs MinIO/local). Controlled by S3_STORAGE env var."""
     return settings.s3_storage.lower() == "s3"
 
-@lru_cache(maxsize=1)
-def get_s3_client():
-    """
-    Create the S3 client for server-side operations. Selection is driven by
-    S3_STORAGE (see _is_aws_s3):
+def _build_s3_client(config=None):
+    """Construct an S3 client. Selection is driven by S3_STORAGE (see _is_aws_s3):
     - "s3"   -> native AWS S3 (no endpoint_url; S3_ENDPOINT is not used)
     - other  -> S3_ENDPOINT for MinIO or another S3-compatible backend
+    Pass `config` (a botocore Config) when you need bounded timeouts (startup check).
     """
-    if _is_aws_s3():
-        # Real AWS S3 - don't pass endpoint_url
-        return boto3.client(
-            "s3",
-            aws_access_key_id=settings.s3_access_key,
-            aws_secret_access_key=settings.s3_secret_key,
-            region_name=settings.s3_region,
-        )
-    else:
-        # MinIO or S3-compatible storage
-        return boto3.client(
-            "s3",
-            endpoint_url=settings.s3_endpoint,
-            aws_access_key_id=settings.s3_access_key,
-            aws_secret_access_key=settings.s3_secret_key,
-            region_name=settings.s3_region,
-        )
+    kwargs = {
+        "aws_access_key_id": settings.s3_access_key,
+        "aws_secret_access_key": settings.s3_secret_key,
+        "region_name": settings.s3_region,
+    }
+    if not _is_aws_s3():
+        kwargs["endpoint_url"] = settings.s3_endpoint
+    if config is not None:
+        kwargs["config"] = config
+    return boto3.client("s3", **kwargs)
+
+
+@lru_cache(maxsize=1)
+def get_s3_client():
+    """The shared, cached S3 client for server-side operations (see _build_s3_client)."""
+    return _build_s3_client()
 
 @lru_cache(maxsize=1)
 def _get_presign_client():
@@ -69,8 +71,13 @@ def _get_presign_client():
     return boto3.client("s3", **kwargs)
 
 def ensure_bucket_exists():
-    """Create the S3 bucket if it does not exist. Called on app startup."""
-    s3 = get_s3_client()
+    """Create the S3 bucket if it does not exist (+ configure CORS/policy on non-AWS).
+
+    Uses a short-timeout client so it fails fast rather than blocking for boto3's
+    default ~60s if the store is slow/unreachable. Run via run_startup_bucket_setup()
+    off the request path at startup — see main.py.
+    """
+    s3 = _build_s3_client(config=_STARTUP_S3_CONFIG)
     try:
         s3.head_bucket(Bucket=settings.s3_bucket)
     except ClientError as e:
@@ -146,6 +153,24 @@ def ensure_bucket_exists():
             )
         except ClientError:
             pass  # Policy config failed, non-critical
+
+
+def run_startup_bucket_setup() -> None:
+    """App-startup entrypoint for bucket setup that NEVER raises.
+
+    A slow or unreachable object store must not crash or block app startup, so this
+    swallows every error and logs a clear warning instead. Call it off the request
+    path (a daemon thread from the FastAPI lifespan) — see main.py.
+    """
+    try:
+        ensure_bucket_exists()
+    except Exception as e:  # noqa: BLE001 - startup must survive any storage failure
+        where = "AWS" if _is_aws_s3() else settings.s3_endpoint
+        logger.warning(
+            "S3/object-storage setup failed at startup — uploads and streaming will "
+            "not work until storage is reachable (S3_STORAGE=%s, endpoint=%s): %s",
+            settings.s3_storage, where, e,
+        )
 
 
 def get_content_type(key: str) -> tuple[str, str]:

--- a/apps/api/tests/test_startup_hardening.py
+++ b/apps/api/tests/test_startup_hardening.py
@@ -1,0 +1,46 @@
+"""Prod-hardening from the v1.4.0 deploy test.
+
+- run_startup_bucket_setup(): the app must not crash/hang if S3 is slow or
+  unreachable at startup — the bucket check runs off the request path and its
+  failures are swallowed + logged (issue: 60s startup block, #6).
+- mail_is_configured(): detect an unconfigured mailer so startup can warn that
+  magic-code login will fail (issue: SMTP-required, #2).
+"""
+import logging
+
+from apps.api.config import settings
+from apps.api.services import s3_service
+from apps.api.services.s3_service import run_startup_bucket_setup
+from apps.api.services.email_service import mail_is_configured
+
+
+def test_startup_bucket_setup_swallows_and_logs_failure(monkeypatch, caplog):
+    def boom():
+        raise RuntimeError("S3 unreachable")
+
+    monkeypatch.setattr(s3_service, "ensure_bucket_exists", boom)
+    with caplog.at_level(logging.WARNING):
+        run_startup_bucket_setup()  # must NOT raise — app startup can't crash on S3
+    assert any(
+        "storage" in r.getMessage().lower() or "s3" in r.getMessage().lower()
+        for r in caplog.records
+    ), "expected a warning naming storage/S3"
+
+
+def test_startup_bucket_setup_runs_the_check_on_success(monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setattr(s3_service, "ensure_bucket_exists", lambda: calls.__setitem__("n", calls["n"] + 1))
+    run_startup_bucket_setup()
+    assert calls["n"] == 1
+
+
+def test_mail_not_configured_when_smtp_host_empty(monkeypatch):
+    monkeypatch.setattr(settings, "mail_provider", "smtp")
+    monkeypatch.setattr(settings, "smtp_host", None)
+    assert mail_is_configured() is False
+
+
+def test_mail_configured_when_smtp_host_set(monkeypatch):
+    monkeypatch.setattr(settings, "mail_provider", "smtp")
+    monkeypatch.setattr(settings, "smtp_host", "smtp.example.com")
+    assert mail_is_configured() is True

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -208,6 +208,8 @@ FreeFrame applies this automatically to **non-AWS** buckets at startup when it h
 
 ### External SMTP
 
+> **⚠️ Email is required for login.** FreeFrame authenticates with emailed **magic codes**, and also sends invites/notifications. If email isn't configured, users **cannot log in** — the send fails and the app logs a warning at startup. Configure SMTP or SES before going live.
+
 Works with: **Mailgun, Postmark, SendGrid, Amazon SES, or any SMTP server.**
 
 Configure in `.env.prod`:


### PR DESCRIPTION
Fixes the 3 **medium** findings from the local prod-deploy validation of v1.4.0 (tested end-to-end on MinIO **and** real AWS S3). Targets **v1.4.1**.

## #1 — workers perpetually `unhealthy`
`apps/api/Dockerfile.prod` baked an API-only `HEALTHCHECK` (`curl :8000/health`); the image is shared by `worker`/`beat`/`email_worker`, which don't serve HTTP, so they were always unhealthy (breaks health-gated orchestration). **Removed the baked healthcheck** — the API's healthcheck already lives on the `api` service in `docker-compose.prod.yml`.

## #6 — ~60s startup block on the S3 bucket check
Against a real S3 bucket, `ensure_bucket_exists()` in the startup lifespan blocked ~60s (boto3 default timeout / region redirect), during which the app was unavailable. Now:
- the check runs **off the request path** (daemon thread) via `run_startup_bucket_setup()`, so the app is ready immediately;
- it uses a **bounded-timeout** client (connect 5s / read 10s / 2 retries) so it can't hang;
- it **never raises** — a slow/unreachable store logs a clear warning instead of crashing startup.

## #2 — magic-code login unusable without SMTP
Email is required for login, but a missing mailer just failed silently (task retries). Added `mail_is_configured()` + a **startup warning** when no mailer is set, and documented the requirement in `docs/deployment.md` + `.env.example`.

## Tests
`apps/api/tests/test_startup_hardening.py` — startup wrapper swallows+logs failures / runs the check; `mail_is_configured` detects the SMTP-without-host case. Written test-first (red→green); 25 non-DB tests green locally.

**Not in this PR** (low severity, left per scope): #4 `/home/appuser` perms, #5 observability. #3 (put_bucket_cors on MinIO) is MinIO-only.