### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-09
+
 ### Fixed
 - **Celery workers no longer report `unhealthy`** — the prod image no longer bakes an API-only `HEALTHCHECK` (`curl :8000/health`); it now lives on the `api` service in `docker-compose.prod.yml`, so `worker`/`beat`/`email_worker` (which don't serve HTTP) report their real state instead of perpetually unhealthy.
 - **A slow or unreachable object store no longer blocks app startup** — the startup S3 bucket check now runs off the request path (background thread) with bounded timeouts and never crashes/hangs the app (previously a slow S3 could block startup ~60s+). Failures log a clear warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Celery workers no longer report `unhealthy`** — the prod image no longer bakes an API-only `HEALTHCHECK` (`curl :8000/health`); it now lives on the `api` service in `docker-compose.prod.yml`, so `worker`/`beat`/`email_worker` (which don't serve HTTP) report their real state instead of perpetually unhealthy.
-- **A slow or unreachable object store no longer blocks app startup** — the startup S3 bucket check now runs off the request path (background thread) with bounded timeouts and never crashes/hangs the app (previously a slow S3 could block startup ~60s+). Failures log a clear warning.
+- **A slow or unreachable object store no longer blocks app startup** — the startup S3 bucket check now runs off the request path (background thread) with bounded timeouts and never crashes/hangs the app (previously a slow S3 could block startup ~60s+). It retries a transient failure with backoff, so a store that comes up shortly after start self-heals without a manual restart; a persistent failure logs a clear warning.
 - **Email is documented as required for login, with a startup warning** — FreeFrame signs users in via emailed magic codes, so without a working mailer nobody can log in. The app now logs a clear warning at startup when email isn't configured, and `docs/deployment.md` + `.env.example` call it out.
 
 ## [1.4.0] - 2026-07-09

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import re
+import time
 from functools import lru_cache
 import boto3
 from botocore.config import Config
@@ -155,22 +156,39 @@ def ensure_bucket_exists():
             pass  # Policy config failed, non-critical
 
 
-def run_startup_bucket_setup() -> None:
+def run_startup_bucket_setup(attempts: int = 5, base_delay: float = 3.0, _sleep=time.sleep) -> None:
     """App-startup entrypoint for bucket setup that NEVER raises.
 
     A slow or unreachable object store must not crash or block app startup, so this
-    swallows every error and logs a clear warning instead. Call it off the request
-    path (a daemon thread from the FastAPI lifespan) — see main.py.
+    swallows every error and logs a clear warning instead. It retries a transient
+    failure a few times with linear backoff, so a store that comes up shortly after
+    the app self-heals without a manual restart (that self-heal was previously a
+    side effect of the crash-loop that finding #6 intentionally removed). Call it off
+    the request path (a daemon thread from the FastAPI lifespan) — see main.py.
+
+    `_sleep` is injectable so tests can run the retry loop without real delays.
     """
-    try:
-        ensure_bucket_exists()
-    except Exception as e:  # noqa: BLE001 - startup must survive any storage failure
-        where = "AWS" if _is_aws_s3() else settings.s3_endpoint
-        logger.warning(
-            "S3/object-storage setup failed at startup — uploads and streaming will "
-            "not work until storage is reachable (S3_STORAGE=%s, endpoint=%s): %s",
-            settings.s3_storage, where, e,
-        )
+    for attempt in range(1, attempts + 1):
+        try:
+            ensure_bucket_exists()
+            return
+        except Exception as e:  # noqa: BLE001 - startup must survive any storage failure
+            where = "AWS" if _is_aws_s3() else settings.s3_endpoint
+            if attempt < attempts:
+                delay = base_delay * attempt
+                logger.warning(
+                    "S3/object-storage setup attempt %d/%d failed (S3_STORAGE=%s, endpoint=%s); "
+                    "retrying in %.0fs: %s",
+                    attempt, attempts, settings.s3_storage, where, delay, e,
+                )
+                _sleep(delay)
+            else:
+                logger.warning(
+                    "S3/object-storage setup failed after %d attempts — uploads and streaming "
+                    "will not work until storage is reachable and the app is restarted "
+                    "(S3_STORAGE=%s, endpoint=%s): %s",
+                    attempts, settings.s3_storage, where, e,
+                )
 
 
 def get_content_type(key: str) -> tuple[str, str]:

--- a/apps/api/tests/test_startup_hardening.py
+++ b/apps/api/tests/test_startup_hardening.py
@@ -15,23 +15,43 @@ from apps.api.services.email_service import mail_is_configured
 
 
 def test_startup_bucket_setup_swallows_and_logs_failure(monkeypatch, caplog):
+    calls = {"n": 0}
+
     def boom():
+        calls["n"] += 1
         raise RuntimeError("S3 unreachable")
 
     monkeypatch.setattr(s3_service, "ensure_bucket_exists", boom)
     with caplog.at_level(logging.WARNING):
-        run_startup_bucket_setup()  # must NOT raise — app startup can't crash on S3
+        # inject a no-op sleep so the retries don't actually wait
+        run_startup_bucket_setup(attempts=4, base_delay=0, _sleep=lambda *_: None)  # must NOT raise
+    assert calls["n"] == 4, "expected it to retry the bucket check before giving up"
     assert any(
         "storage" in r.getMessage().lower() or "s3" in r.getMessage().lower()
         for r in caplog.records
     ), "expected a warning naming storage/S3"
 
 
+def test_startup_bucket_setup_retries_transient_failure_until_success(monkeypatch):
+    """A store that's briefly unreachable at startup must self-heal without a restart."""
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError("S3 temporarily unreachable")
+        # third attempt succeeds
+
+    monkeypatch.setattr(s3_service, "ensure_bucket_exists", flaky)
+    run_startup_bucket_setup(attempts=5, base_delay=0, _sleep=lambda *_: None)
+    assert calls["n"] == 3, "expected it to keep retrying a transient failure until it succeeds"
+
+
 def test_startup_bucket_setup_runs_the_check_on_success(monkeypatch):
     calls = {"n": 0}
     monkeypatch.setattr(s3_service, "ensure_bucket_exists", lambda: calls.__setitem__("n", calls["n"] + 1))
     run_startup_bucket_setup()
-    assert calls["n"] == 1
+    assert calls["n"] == 1, "a first-attempt success must not retry"
 
 
 def test_mail_not_configured_when_smtp_host_empty(monkeypatch):


### PR DESCRIPTION
Cuts **v1.4.1** — prod-hardening fixes surfaced by the v1.4.0 local prod deploy test (#143), plus one follow-up from an adversarial regression review of #143.

## Released in this version
### Fixed
- Celery workers no longer report `unhealthy` (removed the API-only `HEALTHCHECK` from the shared prod image; it lives on the `api` service in `docker-compose.prod.yml`).
- A slow/unreachable object store no longer blocks app startup (bucket check runs off the request path, bounded timeouts, never crashes). **It now retries a transient failure with backoff**, so a store that comes up shortly after start self-heals without a manual restart.
- Email documented as required for login, with a startup warning when it isn't configured.

## Review provenance
An adversarial multi-agent review of #143 refuted 16/18 findings; the one real (low-sev) residual was that the non-blocking startup swallowed a transient failure with no retry — closed here. Covered by `apps/api/tests/test_startup_hardening.py`.

Merging this tags `v1.4.1` and publishes the GitHub Release, which moves the `latest` channel pointer.