### PR TITLE
fix(ci): promote-stable gate must ignore its own check-run

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -41,15 +41,21 @@ jobs:
 
           if [ "${FORCE}" != "true" ]; then
             runs="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT}/check-runs")"
-            total="$(echo "$runs" | jq '.check_runs | length')"
-            bad="$(echo "$runs" | jq '[.check_runs[] | select(.conclusion != "success")] | length')"
+            # Exclude this workflow's OWN check-run: a workflow_dispatch run registers a
+            # `promote` check-run on the default branch's HEAD commit. When a release is
+            # promoted straight from main HEAD (the common case), that HEAD *is* the tag
+            # commit being gated, so this run would count its own in_progress/failed
+            # `promote` check as a non-success and refuse to promote against itself.
+            checks="$(echo "$runs" | jq '[.check_runs[] | select(.name != "promote")]')"
+            total="$(echo "$checks" | jq 'length')"
+            bad="$(echo "$checks" | jq '[.[] | select(.conclusion != "success")] | length')"
             if [ "$total" -lt 1 ]; then
               echo "::error::No CI check-runs found for ${TAG} (${COMMIT}); refusing to promote. Re-run with force=true only if this tag legitimately has no CI."
               exit 1
             fi
             if [ "$bad" -gt 0 ]; then
               echo "::error::${TAG} has non-success checks; refusing to promote:"
-              echo "$runs" | jq -r '.check_runs[] | select(.conclusion != "success") | "  - \(.name): \(.conclusion // .status)"'
+              echo "$checks" | jq -r '.[] | select(.conclusion != "success") | "  - \(.name): \(.conclusion // .status)"'
               exit 1
             fi
             echo "All ${total} CI check(s) green for ${TAG}."


### PR DESCRIPTION
## Problem
The `promote-stable.yml` CI-green gate **self-poisons** when the release tag is current `main` HEAD — the normal case, since you cut a release from main and promote it immediately.

A `workflow_dispatch` run registers a check-run named `promote` on the default branch's HEAD commit. That HEAD *is* the tag commit being gated, so:
- while the promote job runs, its own `promote` check-run is `in_progress` (conclusion `null` ≠ `success`) → the gate counts itself as a non-success check and **fails against itself**;
- the failed run then leaves a permanent `promote: failure` check-run, which blocks **every** subsequent non-forced retry.

This bit the **v1.4.1** promotion (worked around with `force=true` after manually confirming real CI was green). It didn't affect v1.3.1 only because that tag wasn't main HEAD at promote time.

## Fix
Filter the workflow's own `promote` check-run out before counting, so the gate only inspects real CI:

```bash
checks="$(echo "$runs" | jq '[.check_runs[] | select(.name != "promote")]')"
total="$(echo "$checks" | jq 'length')"
bad="$(echo "$checks" | jq '[.[] | select(.conclusion != "success")] | length')"
```

## Validation
Ran the new logic against the real check-runs on the v1.4.1 commit (`b52448a3`), which carries the poisoning `promote: failure`:

```
excluded-promote total=5 bad=0   → gate verdict: PASS
remaining: move-latest, Lint, Backend Tests, Frontend Build, Docker Build (all success)
```

The `force=true` override is unchanged, and a genuinely-red commit still fails the gate (its real CI checks remain in the set).