### PR TITLE
feat: default to password-first on login page

### DIFF
--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -14,7 +14,7 @@ type Step = 'email' | 'code' | 'password' | 'classic'
 
 export function LoginForm() {
   const router = useRouter()
-  const [step, setStep] = useState<Step>('email')
+  const [step, setStep] = useState<Step>('classic')
   const [email, setEmail] = useState('')
   const [emailError, setEmailError] = useState('')
   const [code, setCode] = useState(['', '', '', '', '', ''])


### PR DESCRIPTION
## What this does

Changes the login form default step from magic-code (`'email'`) to password (`'classic'`), so returning users land on the password form first.

Magic-code sign-in is still available via the "Back to magic link" link at the bottom of the password form.

## Why

For self-hosted instances with established users, password-based login is the most common flow. Magic-code-first is better for new/invited users who may not have a password yet, but the reverse is true for mature instances. This change makes the default match the primary use case while keeping both options.

## Files changed

- `apps/web/components/auth/login-form.tsx` — +1/-1 line

## Testing

- Frontend: `pnpm --filter web build`
- Manual: Open login page — password form should appear first, with a "Back to magic link" link at the bottom.