### PR TITLE
Security audit fixes (C1-C2, H1-H3, M1-M9, L1-L3)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,0 +1,277 @@
+# FreeFrame Security Audit — 2026-07-12
+
+Scope: `rubenxyz/freeframe` fork @ `366ae61` (branch `feature/instance-branding`) +
+live instance at `/opt/freeframe` on `rubenxyz` (Incus container `freeframe`,
+branch `instance-rebrand` @ `ee80f87`) behind nginx → Cloudflare Tunnel at
+`https://www.kamiko.xyz/freeframe/`.
+
+Two prior security fixes are referenced:
+- magic-code enumeration prevention (live STATE.md 2026-06-22 — NOT upstream yet)
+- avatar upload IDOR + durable S3 key (PR #93 — open against upstream)
+
+This audit is independent of those. Findings below are grouped by severity and
+tagged with the affected file/line. "upstream" = `Techiebutler/freeframe`.
+"live" = the rubenxyz instance config.
+
+---
+
+## 🔴 CRITICAL
+
+### C1. `invite_token` leaked via `UserResponse` → account takeover
+`apps/api/schemas/auth.py:31` exposes `invite_token: str | None` on
+`UserResponse`. The `from_attributes=True` mapping reads the ORM column
+directly. Two *any-authenticated-user* endpoints return `UserResponse`:
+
+- `GET /users?ids=<user_id>,...` — `routers/users.py:18` ("Any authenticated
+  user can call this")
+- `GET /users/search?q=<email>` — `routers/users.py:35` (returns up to 10 hits)
+
+An authenticated user can therefore read the **unexpired `invite_token` of any
+user still in `pending_invite` status**, then call
+`POST /auth/accept-invite` (`routers/auth.py:154`) with that token + a chosen
+password → take over the invited user's account before the legitimate invitee
+does. `UserResponse` is also returned by `/auth/refresh`, `/auth/set-password`,
+every `/users/*` admin endpoint, and `/auth/me`, so the leak surface is wide.
+
+**Fix:** drop `invite_token` (and `is_superadmin`/`email_verified` should
+stay) from the public `UserResponse`; expose `invite_token` only via an
+admin-scoped serializer.
+
+### C2. Share-link password bypass on comment endpoints
+`apps/api/routers/comments.py:557` (`GET /share/{token}/comments`) and
+`comments.py:595` (`POST /share/{token}/comment`) call
+`validate_share_link(db, token)` — which only checks the token exists, is
+enabled, and is not expired (`services/permissions.py:114`). It does **not**
+verify the share-link password. Compare `routers/share.py:1195`, which
+correctly uses `validate_share_link_with_session` for `/share/{token}/assets`.
+
+A guest can read all comments on, and post comments to, any
+**password-protected** share link without supplying the password. The password
+gate on `/share/{token}` is meaningless if the comment surface is open.
+
+**Fix:** switch both comment endpoints to `validate_share_link_with_session`
+(passing `share_session` and `current_user` exactly like
+`get_folder_share_assets` does).
+
+---
+
+## 🟠 HIGH
+
+### H1. Magic-code auto-creates accounts (upstream)
+`apps/api/routers/auth.py:40` unconditionally creates a
+`pending_verification` user (the **first** such user becomes `is_superadmin`)
+when `POST /auth/send-magic-code` is called for an unknown email, then sends a
+real email via Resend. Any anonymous visitor can:
+- enumerate which emails have accounts (different code path/response timing),
+- drain the Resend quota,
+- create arbitrary `pending_verification` accounts,
+- and in a fresh deployment, become the **superadmin** by being first.
+
+Already fixed on live `instance-rebrand` (STATE.md 2026-06-22) but not
+upstream. **Fix upstream** the same way: return the same response shape for
+unknown emails, send nothing, create nothing.
+
+### H2. API docs + OpenAPI schema publicly served
+`apps/api/main.py:16,25-27` enables `/docs`, `/redoc`, `/openapi.json`
+whenever `DISABLE_DOCS` is not set. `docker-compose.prod.yml` sets it for the
+canonical deployment, but systemd/bare-metal deploys don't. **Live instance
+returns 200 on `https://www.kamiko.xyz/api/docs` and `/api/openapi.json`.** The
+schema enumerates the entire attack surface (every endpoint, every Pydantic
+field — including `invite_token` on `UserResponse`, which amplifies C1).
+
+**Fix (code):** log a loud startup warning when docs are enabled and
+`frontend_url` is not localhost. **Fix (live):** set `DISABLE_DOCS=true` in
+`/opt/freeframe/.env.freeframe` and restart `freeframe-api`.
+
+### H3. Share-link password sent in the URL
+`apps/api/routers/share.py:257` declares `password: Optional[str] = None` as a
+plain function parameter on the `GET /share/{token}` endpoint. FastAPI treats
+this as a **query parameter**. The frontend sends it that way
+(`app/share/[token]/page.tsx:94`). Passwords in URLs are logged by nginx
+access logs, browser history, Referer headers, and Cloudflare Tunnel logs,
+and remain in those logs long after the share session expires.
+
+**Fix:** introduce `POST /share/{token}/verify` accepting `{password}` in the
+body; GET drops the `password` param (and only returns `requires_password:
+true`). Frontend migrates to POST for the password submit.
+
+---
+
+## 🟡 MEDIUM
+
+### M1. No password strength/min-length validation
+`SetPasswordRequest`, `AcceptInviteRequest`, `RegisterRequest`,
+`LoginRequest` (`schemas/auth.py:8,12,53,58`) and `CreateSuperAdminRequest`
+(`routers/setup.py:26`) all use `password: str` with no constraints. Empty and
+1-char passwords are accepted. **Fix:** add `min_length=8, max_length=72`
+(that's also the bcrypt byte limit already enforced silently).
+
+### M2. S3 public-read policy on `processed/*` is unnecessary
+`apps/api/services/s3_service.py:128-148` sets a bucket policy granting
+`s3:GetObject` to `*` for every key under `processed/`. The HLS proxy in
+`routers/hls_proxy.py` already rewrites `.ts` segment URLs to **presigned**
+S3 URLs, so public-read is dead weight. On the live instance,
+`https://www.kamiko.xyz/ff-storage/processed/...` returns the object to anyone
+who guesses/leaks a key (UUIDs are not secret; share-link presigned GETs
+expose them). **Fix:** drop the policy; rely on presigned URLs.
+
+### M3. `InstanceBrandingUpdate.logo_*_key` accepts arbitrary S3 keys
+`apps/api/routers/instance_branding.py:114-122` `setattr`s
+client-supplied `logo_*_key` values directly. The next GET then presigns GETs
+for those keys — an admin-scoped arbitrary-bucket-read IDOR (any raw upload,
+any private avatar). Defense-in-depth: **validate keys start with `branding/`**.
+
+### M4. `avatar_url` accepts arbitrary input
+`apps/api/routers/users.py:93-94` (`PATCH /users/{id}`) writes
+`body.avatar_url` to the DB with no validation. With PR #93's
+`UserResponse`/`AuthorInfo` field_validators presigning whatever is in
+`avatar_url`, this becomes an IDOR for any S3 key. **Fix:** validate the value
+either starts with `avatars/{user_id}/` (an S3 key) or is rejected.
+
+### M5. Comment-attachment upload uses internal S3 endpoint + unsafe filename
+`apps/api/routers/comments.py:397-410` calls `s3 = s3_service.get_s3_client()`
+then `s3.generate_presigned_url("put_object", ...)`. The internal client uses
+`S3_ENDPOINT` (`http://localhost:9000` on MinIO deployments) — unreachable
+from the browser, so the presigned URL the client receives points at the
+user's own machine. It also leaks the internal endpoint to every API caller.
+Should use `s3_service.generate_presigned_put_url()` (the helper the avatar and
+branding fixes already introduced). Also: `body.file_name` is interpolated
+raw into the S3 key (`f"comment-attachments/{comment_id}/{uuid}/{file_name}"`)
+— S3 flattens `..` so no traversal, but control chars / `?` / `#` break keys
+and presigned URLs. **Fix:** use the helper + sanitize `file_name` to
+`[^A-Za-z0-9._-]` → `_`.
+
+### M6. Comment-attachment GET URLs serve inline (stored-XSS surface)
+`apps/api/routers/comments.py:58-66` `_build_attachment_response` generates a
+presigned GET URL with no `download_filename`. An attacker who uploads an
+attachment with `body.content_type = "text/html"` gets a URL that the browser
+renders as HTML. The content runs in the S3 origin (different from the app
+origin so it can't read app localStorage directly) but enables phishing and
+abuses the bucket as a hosting service. **Fix:** always pass
+`download_filename=attachment.original_filename` so S3 returns
+`Content-Disposition: attachment`.
+
+### M7. S3 bucket CORS config does not strip path from `frontend_url`
+`apps/api/services/s3_service.py:107` uses
+`AllowedOrigins: [settings.frontend_url, ...]` verbatim. Browser `Origin`
+headers never include a path, so any deployment with
+`FRONTEND_URL=https://host/freeframe` produces CORS-rejected uploads. Already
+fixed in `main.py` (upstream uses `urlparse`) and on the live instance —
+`ensure_bucket_exists` needs the same treatment. **Fix:** mirror the
+`urlparse` strip used in `main.py`.
+
+### M8. `update_preferences` accepts arbitrary dict
+`apps/api/routers/auth.py:239-254` takes `body: dict` — no Pydantic schema, no
+size limit. Users can store anything (giant JSON, nested objects). If any
+preference value is rendered back without escaping, it's a stored-XSS surface.
+**Fix:** introduce a `PreferencesUpdate` schema (known keys only, primitive
+values).
+
+### M9. Reusable refresh tokens + no rate limit on `/auth/refresh`
+`apps/api/routers/auth.py:219-231` issues new access + refresh tokens but does
+**not** invalidate the old refresh token. A stolen refresh token remains valid
+for 7 days. The endpoint also has no `rate_limit` dep
+(`/auth/send-magic-code` and `/auth/verify-magic-code` do). **Fix:** add a
+modest rate limit + (recommendation) rotate refresh tokens (one-time-use) in
+a follow-up.
+
+### M10. Tokens in `localStorage` + non-HttpOnly/non-Secure cookies
+`apps/web/lib/auth.ts:16-23` stores JWTs in `localStorage` and sets plain
+`SameSite=Lax` cookies (no `Secure`, no `HttpOnly`). Any XSS = full token
+theft, and there is no CSP either. The HttpOnly-cookie migration is a sizable
+refactor (requires API Set-Cookie handling) and is **documented as a
+recommendation**, not fixed here. Note: the middleware reads cookies via
+`request.cookies`, so dropping localStorage for HttpOnly cookies is the
+correct end-state.
+
+---
+
+## 🟢 LOW / defense-in-depth
+
+### L1. LIKE patterns not escaped
+`apps/api/routers/users.py:43-46` (`search_users`) and
+`apps/api/routers/me.py:100,124` (`list_my_assets`, `search_my_folders`) use
+`ilike(f"%{q}%")` without escaping `%` / `_`. Not SQL injection
+(parameterized) but wildcard-spoofing. Use the existing `_escape_like` helper
+already in `routers/share.py:51`.
+
+### L2. S3 bucket CORS too permissive
+`s3_service.py:105-106` sets `AllowedHeaders: ["*"]` and `AllowedMethods`
+including `DELETE`. No presigned-DELETE flow exists. Tighten to
+`["Content-Type", "Content-MD5", "x-amz-content-sha256", "x-amz-date"]` and
+drop `DELETE`.
+
+### L3. Hardcoded `/login` redirect ignores basePath
+`apps/web/lib/auth.ts:32` does `window.location.href = '/login'` — on the live
+`basePath: '/freeframe'` deployment this hits the nginx catch-all 302 and
+causes a "secure connection" error (per STATE.md the live instance already
+patches this). **Fix upstream:** make it `'/login'` resolved through
+`basePath`. (Minimal: prepend `process.env.NEXT_PUBLIC_BASE_PATH || ''`.)
+
+### L4. No nginx security headers
+Live `/etc/nginx/sites-available/freeframe` sets no
+`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+`Strict-Transport-Security`, `Referrer-Policy: no-referrer`, or CSP. Instance
+config fix (not upstream code).
+
+### L5. `X-Forwarded-Proto` set from `$scheme` (http) on the live nginx
+FastAPI believes it's serving HTTP — affects absolute redirect URLs and
+secure-cookie flags. Fix: `proxy_set_header X-Forwarded-Proto https;` on
+each `location` (or `map`-based).
+
+### L6. Systemd services run as `root`, `.env*` mode `644`, MinIO console on `*:9001`
+Live unit files (`freeframe-api`, `freeframe-web`, `freeframe-celery-worker`,
+`minio`) all run as `User=root`; the Incus lxc override disables every
+hardening knob (`NoNewPrivileges=no`, `ProtectSystem=no`, etc.).
+`.env.freeframe`, `.env`, `.db_creds` are world-readable (644) inside the
+container. MinIO's console binds `*:9001` (only reachable inside the bridge,
+but unnecessary). Defense-in-depth only — the container is "`Privileged: yes`
+" per STATE.md, so root-in-container is the de-facto trust boundary. Fix on
+the instance later.
+
+### L7. Missing `/etc/rubenxyz/SYSTEM.md`
+`AGENTS.md` → "First Action on Any Remote" reads `/etc/rubenxyz/SYSTEM.md`,
+but the file does not exist on the freeframe container. Process gap, not a
+vuln.
+
+---
+
+## Dependency audit
+`apps/web/package.json` pins `next: 14.2.35` (latest 14.2.x patch as of the
+audit), `hls.js: ^1.6.16`, `fabric: ^7.2.0`. No known critical CVE chain
+identified against these versions at audit time. Recommend running
+`pnpm audit` in CI and pinning patch releases. `pnpm-lock.yaml` is committed
+— keep it updated.
+
+`apps/api/requirements.txt` was not runtime-fingerprinted; recommend
+`pip-audit` for the API deps as well.
+
+---
+
+## Fix plan (this PR — upstream code only)
+Per-finding commits on `feature/security-fixes` (branched from `upstream/main`):
+
+1. C1 — drop `invite_token` from `UserResponse`; add admin-scoped serializer.
+2. C2 — comment endpoints use `validate_share_link_with_session`.
+3. H1 — send-magic-code no longer creates accounts or sends to unknown emails.
+4. H3 — `POST /share/{token}/verify` for password; GET drops the param;
+   frontend follow-up.
+5. M1 — password strength `min_length=8`.
+6. M3 — branding `logo_*_key` prefix validation.
+7. M4 — `avatar_url` prefix validation.
+8. M5 — attachment presign via `generate_presigned_put_url` + sanitize name.
+9. M6 — attachment GETs use `download_filename`.
+10. M2 — drop public-read bucket policy on `processed/*`.
+11. M7 — strip path when setting bucket CORS origin in `ensure_bucket_exists`.
+12. L2 — tighten bucket CORS headers/methods.
+13. M8 — `update_preferences` Pydantic schema.
+14. L1 — escape LIKE patterns in `users`/`me` routers.
+15. M9 — rate-limit `/auth/refresh`.
+16. L3 — basePath-aware `/login` redirect on the frontend.
+17. H2 — startup warning when docs are enabled on a non-localhost frontend_url.
+
+## Documented as recommendations (not fixed this PR)
+- M10 — JWT in HttpOnly-only cookies (large refactor).
+- Refresh-token rotation (one-time-use).
+- L4/L5/L6 — instance-side hardening (nginx headers, X-Forwarded-Proto,
+  systemd User=, file perms) — applied separately to the live instance.

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -38,10 +38,34 @@ app = FastAPI(
     openapi_url=None if _disable_docs else "/openapi.json",
 )
 
+# Surface an obvious warning when the interactive API docs + OpenAPI schema
+# are exposed on a production frontend. The schema enumerates every endpoint
+# and Pydantic field on the app, which is a significant attack-surface leak
+# when FRONTEND_URL is a public hostname. The /docs,/redoc,/openapi.json
+# endpoints should be disabled in production via DISABLE_DOCS=true.
+if not _disable_docs:
+    from urllib.parse import urlparse
+    _fu = (settings.frontend_url or "").strip()
+    _fh = (urlparse(_fu).hostname or "").lower()
+    if _fh and _fh not in ("localhost", "127.0.0.1", "0.0.0.0"):
+        logging.getLogger("apps.api.startup").warning(
+            "FastAPI docs and OpenAPI schema are ENABLED at /docs, /redoc, "
+            "/openapi.json with FRONTEND_URL=%r (non-localhost). Set "
+            "DISABLE_DOCS=true in production to suppress this exposure.",
+            _fu,
+        )
+
+# Browser Origin headers never include a path, so strip any path from
+# FRONTEND_URL before adding it to CORS allow_origins (e.g.
+# https://host/freeframe -> https://host). Otherwise browser uploads
+# from the deployed app are CORS-rejected.
+from urllib.parse import urlparse as _urlparse
+_cors_origin = f"{_urlparse(settings.frontend_url).scheme}://{_urlparse(settings.frontend_url).netloc}"
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        settings.frontend_url,
+        _cors_origin,
         "http://localhost:3000",
         "http://localhost:3001",
     ],

--- a/apps/api/routers/admin.py
+++ b/apps/api/routers/admin.py
@@ -7,7 +7,7 @@ import uuid
 from ..database import get_db
 from ..middleware.auth import get_current_user
 from ..models.user import User, UserStatus
-from ..schemas.auth import UserResponse, UpdateUserRoleRequest
+from ..schemas.auth import UserResponse, AdminUserResponse, UpdateUserRoleRequest
 from .users import require_admin
 from ..tasks.celery_app import send_task_safe
 from ..tasks.cleanup_tasks import cleanup_soft_deleted
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 
 # ── Endpoints ──────────────────────────────────────────────────────────────────
 
-@router.get("/users", response_model=list[UserResponse])
+@router.get("/users", response_model=list[AdminUserResponse])
 def list_all_users(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -33,7 +33,7 @@ def list_all_users(
     users = db.query(User).filter(User.deleted_at.is_(None)).all()
     return users
 
-@router.patch("/users/{user_id}/deactivate", response_model=UserResponse)
+@router.patch("/users/{user_id}/deactivate", response_model=AdminUserResponse)
 def deactivate_user(
     user_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -62,7 +62,7 @@ def deactivate_user(
     db.refresh(user)
     return user
 
-@router.patch("/users/{user_id}/reactivate", response_model=UserResponse)
+@router.patch("/users/{user_id}/reactivate", response_model=AdminUserResponse)
 def reactivate_user(
     user_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -84,7 +84,7 @@ def reactivate_user(
     db.refresh(user)
     return user
 
-@router.patch("/users/{user_id}/role", response_model=UserResponse)
+@router.patch("/users/{user_id}/role", response_model=AdminUserResponse)
 def update_user_role(
     user_id: uuid.UUID,
     body: UpdateUserRoleRequest,

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -220,7 +220,7 @@ def login(body: LoginRequest, db: Session = Depends(get_db)):
     )
 
 
-@router.post("/refresh", response_model=TokenResponse)
+@router.post("/refresh", response_model=TokenResponse, dependencies=[Depends(rate_limit("refresh_token", 30, 60))])
 def refresh_token(body: RefreshRequest, db: Session = Depends(get_db)):
     payload = decode_token(body.refresh_token)
     if not payload or payload.get("type") != "refresh":

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -41,26 +41,28 @@ def send_magic_code(body: SendMagicCodeRequest, db: Session = Depends(get_db)):
     """
     Send magic code to email.
     - If user exists: send code for login
-    - If user doesn't exist: create pending user and send code
+    - If user doesn't exist: return a constant-shape response without
+      sending an email or creating an account. New accounts come from
+      /setup (first superadmin) or an admin invite; allowing anonymous
+      account creation here enabled enumeration, Resend-quota abuse, and
+      takeover of a fresh install via first-user-becomes-superadmin.
     """
     user = get_user_by_email(db, body.email)
-    
+
     if not user:
-        # Check if this is the first user (becomes super admin)
-        user_count = db.query(User).filter(User.deleted_at.is_(None)).count()
-        is_first_user = user_count == 0
-        
-        # Create new user in pending_verification status
-        user = User(
+        # Do not auto-create accounts from magic-code requests. Previously
+        # this branch created a pending_verification user for any email
+        # entered (and the first such user became superadmin), allowing an
+        # anonymous visitor to enumerate accounts, drain the email
+        # provider's quota, and on a fresh install become the first
+        # superadmin by being first. New accounts come from /setup
+        # (first superadmin) or admin invites.
+        # Constant-shape response prevents user enumeration.
+        return SendMagicCodeResponse(
+            message="If that email has an account, a magic code has been sent.",
             email=body.email,
-            name=body.email.split("@")[0],  # Temporary name from email
-            status=UserStatus.pending_verification,
-            email_verified=False,
-            is_superadmin=is_first_user,  # First user becomes super admin
         )
-        db.add(user)
-        db.commit()
-    
+
     # Generate and store magic code in Redis
     code = generate_magic_code()
     store_magic_code(body.email, code)
@@ -70,9 +72,11 @@ def send_magic_code(body: SendMagicCodeRequest, db: Session = Depends(get_db)):
         send_task_safe(send_magic_code_email, body.email, code, MAGIC_CODE_EXPIRY_MINUTES)
     except Exception:
         pass  # Email delivery is best-effort; code is already in Redis
-    
+
+    # Same message shape as the unknown-email branch above to prevent
+    # user enumeration via response text.
     return SendMagicCodeResponse(
-        message="Magic code sent to your email",
+        message="If that email has an account, a magic code has been sent.",
         email=body.email,
     )
 
@@ -84,10 +88,13 @@ def verify_magic_code(body: VerifyMagicCodeRequest, db: Session = Depends(get_db
     Returns needs_password=True if user hasn't set a password yet.
     """
     user = get_user_by_email(db, body.email)
-    
+
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    
+        # Return 401 with the same detail verify_magic_code returns for a
+        # bad code, so unknown emails cannot be enumerated via the 404
+        # "User not found" path that existed before.
+        raise HTTPException(status_code=401, detail="Invalid code")
+
     if user.status == UserStatus.deactivated:
         raise HTTPException(status_code=401, detail="Account deactivated")
     

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -10,6 +10,7 @@ from ..schemas.auth import (
     SendMagicCodeRequest, SendMagicCodeResponse,
     VerifyMagicCodeRequest, SetPasswordRequest,
     AcceptInviteRequest, InviteInfoResponse,
+    PreferencesUpdate,
 )
 from ..services.auth_service import (
     hash_password, verify_password,
@@ -242,13 +243,16 @@ def get_me(current_user: User = Depends(get_current_user)):
 
 @router.patch("/me/preferences", response_model=UserResponse)
 def update_preferences(
-    body: dict,
+    body: PreferencesUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Update user preferences (theme, etc). Merges with existing preferences."""
     current_prefs = current_user.preferences or {}
-    current_prefs.update(body)
+    # Only known keys are accepted by PreferencesUpdate; merge them onto
+    # existing prefs so unspecified keys are preserved.
+    update_data = body.model_dump(exclude_unset=True)
+    current_prefs.update(update_data)
     current_user.preferences = current_prefs
     # Force SQLAlchemy to detect the JSON change
     from sqlalchemy.orm.attributes import flag_modified

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -56,7 +56,16 @@ def _get_comment(db: Session, comment_id: uuid.UUID) -> Comment:
 
 
 def _build_attachment_response(attachment: CommentAttachment) -> AttachmentResponse:
-    url = s3_service.generate_presigned_get_url(attachment.s3_key, expires_in=3600)
+    # Pass download_filename so S3 returns Content-Disposition: attachment
+    # and the browser downloads instead of rendering. Without it an
+    # attacker who uploads an attachment with content_type=text/html gets
+    # a URL the browser renders as HTML — a stored-XSS surface on the S3
+    # origin.
+    url = s3_service.generate_presigned_get_url(
+        attachment.s3_key,
+        expires_in=3600,
+        download_filename=attachment.original_filename or "attachment",
+    )
     return AttachmentResponse(
         id=attachment.id,
         file_name=attachment.original_filename,
@@ -394,19 +403,24 @@ def create_attachment(
     asset = _get_asset(db, comment.asset_id)
     require_asset_access(db, asset, current_user)
 
-    # Generate S3 key
-    key = f"comment-attachments/{comment_id}/{uuid.uuid4()}/{body.file_name}"
+    # Sanitize the filename so it cannot break the S3 key or the presigned
+    # URL. S3 flattens path separators, so this isn't traversal — but
+    # control characters, '?', '#', and whitespace break keys and presigned
+    # signatures. Keep the original filename on the attachment record for
+    # the Content-Disposition download name.
+    import re as _re
+    safe_name = _re.sub(r"[^A-Za-z0-9._-]+", "_", body.file_name or "attachment").strip("._") or "attachment"
 
-    # Generate presigned PUT URL
-    s3 = s3_service.get_s3_client()
-    upload_url = s3.generate_presigned_url(
-        "put_object",
-        Params={
-            "Bucket": settings.s3_bucket,
-            "Key": key,
-            "ContentType": body.content_type,
-        },
-        ExpiresIn=3600,
+    # Generate S3 key
+    key = f"comment-attachments/{comment_id}/{uuid.uuid4()}/{safe_name}"
+
+    # Generate presigned PUT URL via the public-endpoint helper so browser
+    # uploads reach S3/MinIO. Calling get_s3_client() directly used the
+    # internal S3_ENDPOINT (http://localhost:9000 in MinIO deployments),
+    # unreachable from the browser and leaking the internal endpoint to
+    # every API caller.
+    upload_url = s3_service.generate_presigned_put_url(
+        key, content_type=body.content_type, expires_in=3600
     )
 
     # Save attachment record

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from ..config import settings
@@ -32,7 +32,7 @@ from ..schemas.comment import (
     ReactionResponse,
 )
 from ..services import s3_service
-from ..services.permissions import require_asset_access, validate_share_link
+from ..services.permissions import require_asset_access, validate_share_link_with_session
 from ..tasks.email_tasks import send_mention_email, send_comment_email
 from ..tasks.celery_app import send_task_safe
 
@@ -547,14 +547,20 @@ def list_share_comments(
     asset_id: Optional[uuid.UUID] = None,
     version_id: Optional[uuid.UUID] = None,
     latest_only: bool = False,
+    share_session: Optional[str] = Query(None, alias="share_session"),
     db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_user),
 ):
-    """Public endpoint — list comments for a shared asset. No auth required.
+    """Public endpoint — list comments for a shared asset. No auth required
+    (but a password session OR authenticated link creator is required for
+    password-protected links, matching /share/{token}/assets).
     For folder/project shares, pass asset_id as query param to get comments for a specific asset.
     Pass version_id to scope comments to a single version (matches the authenticated review view).
     Pass latest_only=true to scope to the latest ready version — used by the folder/grid preview,
     which has no version picker."""
-    link = validate_share_link(db, token)
+    link = validate_share_link_with_session(
+        db, token, share_session=share_session, current_user=current_user
+    )
 
     # Determine the asset_id to list comments for
     target_asset_id = link.asset_id or asset_id
@@ -589,10 +595,13 @@ def list_share_comments(
 def guest_comment(
     token: str,
     body: GuestCommentCreate,
+    share_session: Optional[str] = Query(None, alias="share_session"),
     db: Session = Depends(get_db),
     current_user: Optional[User] = Depends(get_optional_user),
 ):
-    link = validate_share_link(db, token)
+    link = validate_share_link_with_session(
+        db, token, share_session=share_session, current_user=current_user
+    )
 
     # Check share link permission allows commenting
     if link.permission == SharePermission.view:

--- a/apps/api/routers/me.py
+++ b/apps/api/routers/me.py
@@ -19,6 +19,12 @@ from ..routers.assets import _build_asset_response, _build_asset_responses_bulk
 router = APIRouter(prefix="/me", tags=["me"])
 
 
+def _escape_like(s: str) -> str:
+    """Escape special LIKE pattern characters so user-supplied search
+    text is matched literally (not as wildcards). See users._escape_like."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 @router.get("/assets", response_model=list[AssetResponse])
 def list_my_assets(
     filter: Optional[str] = Query(default=None, description="owned|shared|mentioned|assigned|due_soon"),
@@ -97,7 +103,7 @@ def list_my_assets(
 
     # Apply search filter
     if q and q.strip():
-        query = query.filter(Asset.name.ilike(f"%{q.strip()}%"))
+        query = query.filter(Asset.name.ilike(f"%{_escape_like(q.strip())}%"))
 
     assets = query.order_by(Asset.created_at.desc()).offset(skip).limit(limit).all()
     return _build_asset_responses_bulk(assets, db)
@@ -121,7 +127,7 @@ def search_my_folders(
         Folder.deleted_at.is_(None),
     )
     if q and q.strip():
-        query = query.filter(Folder.name.ilike(f"%{q.strip()}%"))
+        query = query.filter(Folder.name.ilike(f"%{_escape_like(q.strip())}%"))
 
     folders = query.order_by(Folder.name).limit(limit).all()
 

--- a/apps/api/routers/setup.py
+++ b/apps/api/routers/setup.py
@@ -4,7 +4,7 @@ These are only available when no superadmin exists in the system.
 """
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 from ..database import get_db
 from ..models.user import User, UserStatus
@@ -23,7 +23,9 @@ class SetupStatusResponse(BaseModel):
 class CreateSuperAdminRequest(BaseModel):
     email: EmailStr
     name: str
-    password: str
+    # Match the auth schemas: 8-72 chars. bcrypt truncates at 72 bytes
+    # silently — surface it as a 400 instead.
+    password: str = Field(min_length=8, max_length=72)
 
 
 class SetupCompleteResponse(BaseModel):

--- a/apps/api/routers/share.py
+++ b/apps/api/routers/share.py
@@ -251,29 +251,19 @@ def list_share_links(
     ).all()
 
 
-@router.get("/share/{token}", response_model=ShareLinkValidateResponse, dependencies=[Depends(rate_limit("share_validate", 30, 60))])
-def validate_share_link_endpoint(
-    token: str,
-    password: Optional[str] = None,
+def _build_share_validate_response(
+    db: Session,
+    link: ShareLink,
+    current_user: Optional[User],
+    session_id: Optional[str] = None,
     log_open: bool = False,
-    db: Session = Depends(get_db),
-    current_user: Optional[User] = Depends(get_optional_user),
-):
-    """Public endpoint — optional auth. For secure links, requires authenticated user."""
-    link = validate_share_link(db, token)
+) -> ShareLinkValidateResponse:
+    """Build the full ShareLinkValidateResponse for a validated link.
 
-    # Check secure visibility — requires authenticated user
-    if link.visibility == "secure":
-        if not current_user:
-            return ShareLinkValidateResponse(
-                requires_auth=True,
-                requires_password=False,
-                title=link.title,
-                permission=link.permission,
-                visibility=link.visibility,
-            )
-
-    # Resolve folder name if this is a folder share
+    Called by both GET /share/{token} (no password verification) and
+    POST /share/{token}/verify (password verification).
+    """
+    # Resolve folder / project names
     folder_name = None
     project_name = None
     if link.folder_id:
@@ -284,25 +274,6 @@ def validate_share_link_endpoint(
         project = db.query(Project).filter(Project.id == link.project_id, Project.deleted_at.is_(None)).first()
         if project:
             project_name = project.name
-
-    session_id = None
-    if link.password_hash:
-        if not password:
-            return ShareLinkValidateResponse(
-                requires_password=True,
-                title=link.title,
-                permission=link.permission,
-            )
-        try:
-            plain_bytes = password[:72].encode('utf-8')
-            hashed_bytes = link.password_hash.encode('utf-8')
-            if not bcrypt.checkpw(plain_bytes, hashed_bytes):
-                raise HTTPException(status_code=403, detail="Incorrect password")
-        except ValueError:
-            raise HTTPException(status_code=403, detail="Incorrect password")
-        # Password verified — create a session so subsequent requests skip re-verification
-        session_id = secrets.token_urlsafe(32)
-        create_share_session(token, session_id)
 
     if log_open:
         actor_email = current_user.email if current_user else "anonymous"
@@ -377,6 +348,97 @@ def validate_share_link_endpoint(
         asset=asset_data,
         branding=branding_data,
         share_session=session_id,
+    )
+
+
+@router.get("/share/{token}", response_model=ShareLinkValidateResponse, dependencies=[Depends(rate_limit("share_validate", 30, 60))])
+def validate_share_link_endpoint(
+    token: str,
+    log_open: bool = False,
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_user),
+):
+    """Public endpoint — optional auth. For secure links, requires authenticated user.
+
+    Does NOT verify the share-link password. Password-protected links return
+    `requires_password=True`; the caller must POST /share/{token}/verify with
+    the password in the body to obtain a `share_session`. The password used to
+    be a query parameter on this GET, which leaked it into nginx access logs,
+    browser history, Referer headers, and Cloudflare Tunnel logs.
+    """
+    link = validate_share_link(db, token)
+
+    # Check secure visibility — requires authenticated user
+    if link.visibility == "secure":
+        if not current_user:
+            return ShareLinkValidateResponse(
+                requires_auth=True,
+                requires_password=False,
+                title=link.title,
+                permission=link.permission,
+                visibility=link.visibility,
+            )
+
+    # Password-protected links: short-circuit and request POST /verify.
+    # Authenticated link creator bypasses the password (dashboard preview).
+    if link.password_hash:
+        if current_user and link.created_by == current_user.id:
+            return _build_share_validate_response(db, link, current_user, log_open=log_open)
+        return ShareLinkValidateResponse(
+            requires_password=True,
+            title=link.title,
+            permission=link.permission,
+        )
+
+    return _build_share_validate_response(db, link, current_user, log_open=log_open)
+
+
+@router.post(
+    "/share/{token}/verify",
+    response_model=ShareLinkValidateResponse,
+    dependencies=[Depends(rate_limit("share_verify", 30, 60))],
+)
+def verify_share_link_password(
+    token: str,
+    body: "ShareVerifyRequest",
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_user),
+):
+    """Verify a share-link password and return the full validate response
+    with a `share_session` for subsequent requests.
+
+    The password is sent in the request body (not as a query string param)
+    so it isn't logged by nginx, browser history, Referer headers, or proxy
+    logs. See SECURITY_AUDIT H3.
+    """
+    from ..schemas.share import ShareVerifyRequest  # local import to avoid cycle at module load
+    # Re-validate the body with the schema (FastAPI already does this, but
+    # keeps the import above meaningful in case the type annotation is
+    # stripped by tooling).
+    _ = ShareVerifyRequest.model_validate(body)
+
+    link = validate_share_link(db, token)
+
+    # Authenticated link creator bypasses the password (dashboard preview)
+    if not (current_user and link.created_by == current_user.id):
+        if not link.password_hash:
+            # No password set — nothing to verify. Return the validate response.
+            return _build_share_validate_response(db, link, current_user)
+        try:
+            plain_bytes = body.password[:72].encode('utf-8')
+            hashed_bytes = link.password_hash.encode('utf-8')
+            if not bcrypt.checkpw(plain_bytes, hashed_bytes):
+                raise HTTPException(status_code=403, detail="Incorrect password")
+        except ValueError:
+            raise HTTPException(status_code=403, detail="Incorrect password")
+
+    # Password verified (or creator bypass) — create a session so
+    # subsequent /share/{token}/assets, /comments, etc. skip re-verification.
+    session_id = secrets.token_urlsafe(32)
+    create_share_session(token, session_id)
+
+    return _build_share_validate_response(
+        db, link, current_user, session_id=session_id, log_open=body.log_open
     )
 
 

--- a/apps/api/routers/share.py
+++ b/apps/api/routers/share.py
@@ -34,6 +34,7 @@ from ..schemas.share import (
     ShareLinkResponse,
     ShareLinkUpdate,
     ShareLinkValidateResponse,
+    ShareVerifyRequest,
 )
 from ..services.permissions import require_project_role, validate_share_link, validate_share_link_with_session
 from ..services.redis_service import create_share_session
@@ -400,7 +401,7 @@ def validate_share_link_endpoint(
 )
 def verify_share_link_password(
     token: str,
-    body: "ShareVerifyRequest",
+    body: ShareVerifyRequest,
     db: Session = Depends(get_db),
     current_user: Optional[User] = Depends(get_optional_user),
 ):
@@ -411,12 +412,6 @@ def verify_share_link_password(
     so it isn't logged by nginx, browser history, Referer headers, or proxy
     logs. See SECURITY_AUDIT H3.
     """
-    from ..schemas.share import ShareVerifyRequest  # local import to avoid cycle at module load
-    # Re-validate the body with the schema (FastAPI already does this, but
-    # keeps the import above meaningful in case the type annotation is
-    # stripped by tooling).
-    _ = ShareVerifyRequest.model_validate(body)
-
     link = validate_share_link(db, token)
 
     # Authenticated link creator bypasses the password (dashboard preview)

--- a/apps/api/routers/users.py
+++ b/apps/api/routers/users.py
@@ -4,7 +4,7 @@ import uuid
 import secrets
 from datetime import datetime, timezone, timedelta
 from ..database import get_db
-from ..schemas.auth import UserResponse, InviteRequest, UpdateProfileRequest
+from ..schemas.auth import UserResponse, AdminUserResponse, InviteRequest, UpdateProfileRequest
 from ..models.user import User, UserStatus
 from ..middleware.auth import get_current_user
 from ..services.auth_service import hash_password, get_user_by_email
@@ -51,7 +51,7 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
         raise HTTPException(status_code=403, detail="Admin access required")
     return current_user
 
-@router.post("/invite", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/invite", response_model=AdminUserResponse, status_code=status.HTTP_201_CREATED)
 def invite_user(body: InviteRequest, db: Session = Depends(get_db), current_user: User = Depends(require_admin)):
     if get_user_by_email(db, body.email):
         raise HTTPException(status_code=400, detail="Email already registered")
@@ -93,7 +93,7 @@ def update_user(user_id: uuid.UUID, body: UpdateProfileRequest, db: Session = De
     db.refresh(user)
     return user
 
-@router.patch("/{user_id}/deactivate", response_model=UserResponse)
+@router.patch("/{user_id}/deactivate", response_model=AdminUserResponse)
 def deactivate_user(user_id: uuid.UUID, db: Session = Depends(get_db), _: User = Depends(require_admin)):
     user = db.query(User).filter(User.id == user_id, User.deleted_at.is_(None)).first()
     if not user:
@@ -103,7 +103,7 @@ def deactivate_user(user_id: uuid.UUID, db: Session = Depends(get_db), _: User =
     db.refresh(user)
     return user
 
-@router.patch("/{user_id}/reactivate", response_model=UserResponse)
+@router.patch("/{user_id}/reactivate", response_model=AdminUserResponse)
 def reactivate_user(user_id: uuid.UUID, db: Session = Depends(get_db), _: User = Depends(require_admin)):
     user = db.query(User).filter(User.id == user_id, User.deleted_at.is_(None)).first()
     if not user:

--- a/apps/api/routers/users.py
+++ b/apps/api/routers/users.py
@@ -88,7 +88,20 @@ def update_user(user_id: uuid.UUID, body: UpdateProfileRequest, db: Session = De
     if body.name is not None:
         user.name = body.name.strip()
     if body.avatar_url is not None:
-        user.avatar_url = body.avatar_url
+        # Defense-in-depth: avatar_url must be either null (clearing the
+        # avatar) or an S3 key scoped under avatars/{user_id}/ (the key
+        # shape issued by /users/me/avatar-upload, and the prefix the
+        # UserResponse field_validator assumes when resolving to a
+        # presigned GET). Allowing arbitrary values here would let a user
+        # mint a presigned GET for any private object in the bucket by
+        # setting avatar_url to its key.
+        prefix = f"avatars/{user_id}/"
+        if body.avatar_url != "" and not body.avatar_url.startswith(prefix):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"avatar_url must be an S3 key under {prefix} (or empty to clear)",
+            )
+        user.avatar_url = body.avatar_url or None
     db.commit()
     db.refresh(user)
     return user

--- a/apps/api/routers/users.py
+++ b/apps/api/routers/users.py
@@ -14,6 +14,15 @@ from ..config import settings
 
 router = APIRouter(prefix="/users", tags=["users"])
 
+
+def _escape_like(s: str) -> str:
+    """Escape special LIKE pattern characters so user-supplied search
+    text is matched literally (not as wildcards). Not SQL injection —
+    SQLAlchemy parameterizes — but `%`/`_` would otherwise act as
+    wildcards and could be used to enumerate or DoS the search."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 @router.get("", response_model=list[UserResponse])
 def get_users_batch(
     ids: str = Query(..., description="Comma-separated user IDs"),
@@ -38,7 +47,7 @@ def search_users(
     current_user: User = Depends(get_current_user),
 ):
     """Search users by name or email. Returns up to 10 matching users."""
-    pattern = f"%{q}%"
+    pattern = f"%{_escape_like(q)}%"
     users = db.query(User).filter(
         User.deleted_at.is_(None),
         (User.name.ilike(pattern) | User.email.ilike(pattern)),

--- a/apps/api/routers/users.py
+++ b/apps/api/routers/users.py
@@ -88,20 +88,7 @@ def update_user(user_id: uuid.UUID, body: UpdateProfileRequest, db: Session = De
     if body.name is not None:
         user.name = body.name.strip()
     if body.avatar_url is not None:
-        # Defense-in-depth: avatar_url must be either null (clearing the
-        # avatar) or an S3 key scoped under avatars/{user_id}/ (the key
-        # shape issued by /users/me/avatar-upload, and the prefix the
-        # UserResponse field_validator assumes when resolving to a
-        # presigned GET). Allowing arbitrary values here would let a user
-        # mint a presigned GET for any private object in the bucket by
-        # setting avatar_url to its key.
-        prefix = f"avatars/{user_id}/"
-        if body.avatar_url != "" and not body.avatar_url.startswith(prefix):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"avatar_url must be an S3 key under {prefix} (or empty to clear)",
-            )
-        user.avatar_url = body.avatar_url or None
+        user.avatar_url = body.avatar_url
     db.commit()
     db.refresh(user)
     return user

--- a/apps/api/schemas/auth.py
+++ b/apps/api/schemas/auth.py
@@ -28,10 +28,18 @@ class UserResponse(BaseModel):
     status: UserStatus
     email_verified: bool = False
     is_superadmin: bool = False
-    invite_token: str | None = None
     preferences: dict = {}
 
     model_config = {"from_attributes": True}
+
+
+class AdminUserResponse(UserResponse):
+    """Admin-scoped user view. Extends UserResponse with the invite token,
+    which is a credential — it must never be exposed to non-admin callers
+    (see SECURITY_AUDIT C1: any-authenticated-user endpoints that returned
+    UserResponse leaked invite tokens, enabling account takeover via
+    /auth/accept-invite)."""
+    invite_token: str | None = None
 
 class InviteRequest(BaseModel):
     email: EmailStr

--- a/apps/api/schemas/auth.py
+++ b/apps/api/schemas/auth.py
@@ -87,3 +87,14 @@ class UpdateUserRoleRequest(BaseModel):
 class DeactivateUserRequest(BaseModel):
     user_id: uuid.UUID
 
+
+class PreferencesUpdate(BaseModel):
+    """Schema-constrained preferences update.
+
+    Replaces the previous `body: dict` signature on PATCH /auth/me/preferences
+    so users can't store arbitrary giant/nested values (which would also be a
+    stored-XSS surface if any preference is rendered back without escaping).
+    Known keys only, primitive values only.
+    """
+    theme: str | None = None
+

--- a/apps/api/schemas/auth.py
+++ b/apps/api/schemas/auth.py
@@ -1,15 +1,22 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 import uuid
 from ..models.user import UserStatus
+
+# Password constraints. bcrypt silently truncates at 72 bytes; surface
+# that as a 400 instead of letting longer passwords authenticate against
+# only their first 72 bytes. The 8-char floor closes the empty/1-char
+# password hole that let accounts be created with trivially-guessable
+# credentials.
+_PASSWORD_FIELD = Field(min_length=8, max_length=72)
 
 class RegisterRequest(BaseModel):
     email: EmailStr
     name: str
-    password: str
+    password: str = _PASSWORD_FIELD
 
 class LoginRequest(BaseModel):
     email: EmailStr
-    password: str
+    password: str = _PASSWORD_FIELD
 
 class TokenResponse(BaseModel):
     access_token: str
@@ -58,12 +65,12 @@ class VerifyMagicCodeRequest(BaseModel):
     code: str
 
 class SetPasswordRequest(BaseModel):
-    password: str
+    password: str = _PASSWORD_FIELD
 
 # Invite flow
 class AcceptInviteRequest(BaseModel):
     token: str
-    password: str
+    password: str = _PASSWORD_FIELD
 
 class InviteInfoResponse(BaseModel):
     email: str

--- a/apps/api/schemas/share.py
+++ b/apps/api/schemas/share.py
@@ -90,6 +90,17 @@ class ShareLinkValidateResponse(BaseModel):
     share_session: Optional[str] = None  # Session token for password-protected links
 
 
+class ShareVerifyRequest(BaseModel):
+    """Body for POST /share/{token}/verify.
+
+    Carries the share-link password in the request body instead of as a
+    query string parameter so it isn't logged in nginx access logs,
+    browser history, Referer headers, or proxy/tunnel logs.
+    """
+    password: str
+    log_open: bool = False
+
+
 class ShareLinkUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -104,15 +103,32 @@ def ensure_bucket_exists():
 
     # Set CORS for browser-based uploads (presigned PUT)
     if not _is_aws_s3():
+        # Browser Origin headers never include a path, so strip any path
+        # from FRONTEND_URL before adding it to AllowedOrigins (e.g.
+        # https://host/freeframe -> https://host). Mirror the CORS origin
+        # strip in main.py.
+        from urllib.parse import urlparse as _urlparse
+        _fe = (settings.frontend_url or "").strip()
+        _cors_origin = f"{_urlparse(_fe).scheme}://{_urlparse(_fe).netloc}" if _fe else None
+        _allowed_origins = [o for o in [_cors_origin, "http://localhost:3000"] if o]
         try:
             s3.put_bucket_cors(
                 Bucket=settings.s3_bucket,
                 CORSConfiguration={
                     "CORSRules": [
                         {
-                            "AllowedHeaders": ["*"],
-                            "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
-                            "AllowedOrigins": [settings.frontend_url, "http://localhost:3000"],
+                            # Tighten from ["*"] to only the headers the
+                            # browser upload + multipart flows actually send.
+                            "AllowedHeaders": [
+                                "Content-Type",
+                                "Content-MD5",
+                                "x-amz-content-sha256",
+                                "x-amz-date",
+                                "x-amz-decoded-content-length",
+                            ],
+                            # Drop DELETE: no presigned-DELETE flow exists.
+                            "AllowedMethods": ["GET", "PUT", "POST", "HEAD"],
+                            "AllowedOrigins": _allowed_origins,
                             "ExposeHeaders": ["ETag", "Content-Length", "x-amz-request-id"],
                             "MaxAgeSeconds": 3600,
                         }
@@ -133,27 +149,14 @@ def ensure_bucket_exists():
                 settings.s3_bucket, e,
             )
 
-        # Set public-read policy on processed/ prefix so HLS sub-playlists
-        # and .ts segments can be fetched without presigned URLs
-        try:
-            policy = {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Sid": "PublicReadProcessed",
-                        "Effect": "Allow",
-                        "Principal": "*",
-                        "Action": "s3:GetObject",
-                        "Resource": f"arn:aws:s3:::{settings.s3_bucket}/processed/*",
-                    }
-                ],
-            }
-            s3.put_bucket_policy(
-                Bucket=settings.s3_bucket,
-                Policy=json.dumps(policy),
-            )
-        except ClientError:
-            pass  # Policy config failed, non-critical
+        # NOTE: a public-read bucket policy on processed/* used to be set
+        # here so HLS sub-playlists and .ts segments could be fetched
+        # without presigned URLs. The HLS proxy in routers/hls_proxy.py
+        # already rewrites .ts URLs to presigned S3 URLs, so the public
+        # policy was dead weight and leaked any processed object to anyone
+        # who guessed a key (UUIDs aren't secret — share-link presigned
+        # GETs expose them). Removed for defense-in-depth; the bucket can
+        # stay fully private.
 
 
 def run_startup_bucket_setup(attempts: int = 5, base_delay: float = 3.0, _sleep=time.sleep) -> None:

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -105,7 +105,7 @@ def test_login_wrong_password(client, mock_db):
     with patch(_VERIFY_PATCH, return_value=False):
         resp = client.post(
             "/auth/login",
-            json={"email": "wp@example.com", "password": "wrong"},
+            json={"email": "wp@example.com", "password": "wrongpass"},
         )
 
     assert resp.status_code == 401

--- a/apps/api/tests/test_share_comments.py
+++ b/apps/api/tests/test_share_comments.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 
 @patch("apps.api.routers.comments._build_comment_response")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_returns_array_for_asset_share(
     mock_validate,
     mock_build_comment_response,
@@ -32,7 +32,7 @@ def test_share_comments_returns_array_for_asset_share(
 
 
 @patch("apps.api.routers.comments._build_comment_response")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_returns_array_for_folder_or_project_share_asset(
     mock_validate,
     mock_build_comment_response,
@@ -60,7 +60,7 @@ def test_share_comments_returns_array_for_folder_or_project_share_asset(
     mock_build_comment_response.assert_called_once_with(comment, mock_db)
 
 
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_returns_empty_array_without_target_asset(
     mock_validate,
     client,

--- a/apps/api/tests/test_share_versions.py
+++ b/apps/api/tests/test_share_versions.py
@@ -77,7 +77,7 @@ def test_guest_versions_returns_latest_only_when_hidden(
 
 
 @patch("apps.api.routers.comments._build_comment_response")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_accepts_version_id(
     mock_validate_link, mock_build, client, mock_db
 ):
@@ -98,7 +98,7 @@ def test_share_comments_accepts_version_id(
 
 
 @patch("apps.api.routers.comments._build_comment_response")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_accepts_latest_only(
     mock_validate_link, mock_build, client, mock_db
 ):

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -84,12 +84,6 @@ async function fetchShareInfo(
   password?: string,
   logOpen?: boolean,
 ): Promise<ShareValidateResponse> {
-  const params = new URLSearchParams()
-  if (password) params.set('password', password)
-  if (logOpen) params.set('log_open', 'true')
-  const qs = params.toString() ? `?${params.toString()}` : ''
-  const url = `${API_URL}/share/${token}${qs}`
-
   // Include auth token if user is already logged in (for secure links)
   const headers: Record<string, string> = {}
   let accessToken: string | null = null
@@ -102,15 +96,36 @@ async function fetchShareInfo(
     headers['Authorization'] = `Bearer ${accessToken}`
   }
 
-  const response = await fetch(url, { headers })
-  if (!response.ok) {
-    if (response.status === 403) {
-      const data = await response.json().catch(() => ({}))
-      if (data.detail === 'Incorrect password') {
+  // When a password is supplied, use POST /share/{token}/verify so the
+  // password travels in the request body — not as a query string, which
+  // would be logged by nginx, browser history, Referer headers, and
+  // proxy/tunnel logs (SECURITY_AUDIT H3).
+  if (password) {
+    headers['Content-Type'] = 'application/json'
+    const body = JSON.stringify({ password, log_open: !!logOpen })
+    const resp = await fetch(`${API_URL}/share/${token}/verify`, {
+      method: 'POST',
+      headers,
+      body,
+    })
+    if (!resp.ok) {
+      if (resp.status === 403) {
         return { requires_password: true, error: 'Incorrect password' }
       }
-      return { requires_password: true }
+      if (resp.status === 410) return { expired: true }
+      return {}
     }
+    return resp.json()
+  }
+
+  // No password — GET validates the link and either returns the full
+  // response (no password set / authenticated creator) or
+  // requires_password:true (password-protected, not yet verified).
+  const params = new URLSearchParams()
+  if (logOpen) params.set('log_open', 'true')
+  const qs = params.toString() ? `?${params.toString()}` : ''
+  const response = await fetch(`${API_URL}/share/${token}${qs}`, { headers })
+  if (!response.ok) {
     if (response.status === 410) return { expired: true }
     return {}
   }

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -29,7 +29,12 @@ export function clearTokens(): void {
   // Clear auth cookies
   document.cookie = `${ACCESS_TOKEN_KEY}=; path=/; max-age=0`
   document.cookie = `${REFRESH_TOKEN_KEY}=; path=/; max-age=0`
-  window.location.href = '/login'
+  // Respect the configured basePath so deployments mounted at a sub-path
+  // (e.g. /freeframe/) don't bounce to the bare /login and trigger the
+  // nginx catch-all 302 chain. Falls back to '/login' when basePath isn't
+  // set (the upstream default).
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+  window.location.href = `${basePath}/login`
 }
 
 // Deduplicate concurrent refresh calls — when access token expires, multiple


### PR DESCRIPTION
## Summary

Independent security audit of FreeFrame against `upstream/main` (84a3b63). Each commit fixes one finding; commit messages contain the finding ID, severity, and rationale. Findings cataloged in `SECURITY_AUDIT.md` (added in a separate doc PR to the fork — not pushed here to keep the diff to source-only).

Full per-finding write-ups live in the commit messages; the audit doc itself is at https://github.com/rubenxyz/freeframe/blob/feature/security-fixes/SECURITY_AUDIT.md.

## Findings fixed (15 commits, 11 files)

### Critical
- **C1** — `invite_token` leaked via `UserResponse` to any-authenticated-user endpoints (`GET /users?ids=`, `GET /users/search`) → account takeover via `POST /auth/accept-invite`. Added admin-scoped `AdminUserResponse`; dropped `invite_token` from the public serializer. (`schemas/auth.py`, `routers/users.py`, `routers/admin.py`)
- **C2** — `GET /share/{token}/comments` and `POST /share/{token}/comment` used `validate_share_link` (token/expiry only), skipping the share-link password. A guest could read/post comments on password-protected links without ever supplying the password. Switched both to `validate_share_link_with_session`. (`routers/comments.py`)

### High
- **H1** — `POST /auth/send-magic-code` auto-created a `pending_verification` user for any email submitted, and the first such user became the superadmin → enumeration, Resend-quota abuse, and takeover of a fresh install. Unknown emails now get a constant-shape response; nothing is sent, no account is created. `verify-magic-code` also returns `401 'Invalid code'` (matching bad-code) for unknown emails instead of `404 'User not found'`. (`routers/auth.py`)
- **H2** — `/docs`, `/redoc`, `/openapi.json` are enabled by default and enumerate the entire attack surface. Added a startup warning when `DISABLE_DOCS` is unset and `FRONTEND_URL` is non-localhost. (`main.py`)
- **H3** — Share-link password was a query parameter on `GET /share/{token}`, leaking it into nginx logs, browser history, Referer headers, and proxy logs. New `POST /share/{token}/verify` takes `{password, log_open}` in the body; GET drops the param and short-circuits to `requires_password=true` for password-protected links (creator bypass preserved). Frontend share page migrates to POST. (`routers/share.py`, `schemas/share.py`, `apps/web/app/share/[token]/page.tsx`)

### Medium
- **M1** — No password strength/min-length validation on any auth schema. `Field(min_length=8, max_length=72)` on `RegisterRequest`, `LoginRequest`, `SetPasswordRequest`, `AcceptInviteRequest`, `CreateSuperAdminRequest`. (`schemas/auth.py`, `routers/setup.py`)
- **M2** — Public-read S3 bucket policy on `processed/*` was dead weight (the HLS proxy already presigns .ts URLs) and leaked any processed object to anyone who guessed/leaked a key. Removed. (`services/s3_service.py`)
- **M4** — Documented as a PR #93 follow-up (`avatar_url` IDOR); reverted on this branch — the fix only makes sense once PR #93's field_validator presigning lands.
- **M5** — Comment-attachment presign used `get_s3_client().generate_presigned_url()` (internal endpoint, unreachable from browser, leaks internal hostname). Switched to `generate_presigned_put_url()`; sanitized `file_name` before interpolating into the S3 key. (`routers/comments.py`)
- **M6** — Comment-attachment GET URLs served inline (stored-XSS surface via `text/html` attachments on the S3 origin). Now pass `download_filename` so S3 returns `Content-Disposition: attachment`. (`routers/comments.py`)
- **M7** — S3 bucket CORS used `FRONTEND_URL` verbatim (with path) so deployments with `FRONTEND_URL=https://host/freeframe` produced CORS-rejected uploads. Same `urlparse` strip `main.py` already uses. (`services/s3_service.py`)
- **M8** — `PATCH /auth/me/preferences` accepted `body: dict` with no constraints. New `PreferencesUpdate` schema (known keys only, primitive values only). (`schemas/auth.py`, `routers/auth.py`)
- **M9** — `/auth/refresh` had no rate limit. Added 30/60s per-IP. (`routers/auth.py`)

### Low
- **L1** — LIKE patterns in `/users/search`, `/me/assets?q=`, `/me/folders?q=` weren't escaping `%`/`_`. Not SQL injection (parameterized) but wildcard-spoofing. Applied the existing `_escape_like` helper. (`routers/users.py`, `routers/me.py`)
- **L2** — S3 bucket CORS `AllowedHeaders: ["*"]` + `DELETE` in `AllowedMethods` was a broader cross-origin surface than the presigned PUT/GET flows need. Tightened to the headers actually sent; dropped `DELETE`. (`services/s3_service.py`)
- **L3** — `clearTokens()` in the frontend redirected to bare `/login`, hitting the nginx catch-all 302 on basePath deployments. Now prepends `NEXT_PUBLIC_BASE_PATH`. (`apps/web/lib/auth.ts`)

## Not fixed (recommendations, documented in the audit doc)
- **M10** — JWTs in `localStorage` + non-HttpOnly/non-Secure cookies. Migrating to HttpOnly cookies requires API Set-Cookie handling + a non-Bearer auth scheme — sizable refactor, deferred.
- **M3** — `InstanceBranding.logo_*_key` accepts arbitrary S3 keys. The `instance_branding` router doesn't exist on upstream main (it's PR #90). The fix belongs in PR #90.
- **Refresh-token rotation (one-time-use)** — deferred; M9's rate limit is the ceiling on the unauthenticated abuse path.
- Instance-side hardening (nginx security headers, `X-Forwarded-Proto: https`, systemd `User=`, `.env` perms, MinIO console bind) — applied separately to the live instance.

## Test plan
- [x] All 115 mock-based tests in `apps/api/tests/` pass on Python 3.12 + FastAPI 0.115 + pydantic 2.9.2. The 7 pre-existing real-Postgres errors (`test_cleanup_soft_deleted`, `test_orphan_sweep`, `test_reap_stale_uploads`, `test_share_link_expiry`, `test_storage_usage_integration`) reproduce identically on upstream `main` — they require a configured Postgres DB the test environment doesn't have.
- [x] Frontend: `pnpm lint` clean (only pre-existing warnings). `pnpm test` — 124/131 pass; the 7 failures in `lib/__tests__/auth.test.ts` (`localStorage.clear is not a function` jsdom setup) reproduce identically on upstream `main`.
- [x] Live instance (`https://www.kamiko.xyz/freeframe/`): verified pre-audit behavior (docs reachable, magic-code auto-create, etc.) and the audit branch imports cleanly against the existing venv.

## Audit report
Full per-finding write-up with severity, code references, and fix plan: https://github.com/rubenxyz/freeframe/blob/feature/security-fixes/SECURITY_AUDIT.md