### PR TITLE
fix: persist media metadata (duration/resolution/fps) on transcode + backfill (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Transcode pipeline now persists media metadata** ([#124](https://github.com/Techiebutler/freeframe/issues/124)) — `duration_seconds`, `width`, `height`, and `fps` are stored on every new video/audio transcode (previously always NULL, breaking duration display). Existing files: run the one-off backfill — `docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata`.
+
 ## [1.4.1] - 2026-07-09
 
 ### Fixed

--- a/apps/api/scripts/backfill_media_metadata.py
+++ b/apps/api/scripts/backfill_media_metadata.py
@@ -1,0 +1,14 @@
+"""Enqueue the one-off media-metadata backfill (#124).
+
+Usage (inside the api container):
+    docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata
+Then watch the worker: docker logs -f freeframe-worker-1
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from apps.api.tasks.transcode_tasks import backfill_media_metadata
+
+if __name__ == "__main__":
+    res = backfill_media_metadata.delay()
+    print(f"Backfill enqueued on the 'transcoding' queue (task id {res.id}).")

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -118,6 +118,8 @@ def _process_audio(db, asset, version, media_file, s3, output_prefix):
     media_file.s3_key_processed = result.get("mp3_key")
     if result.get("waveform_key"):
         media_file.s3_key_thumbnail = result["waveform_key"]
+    if result.get("duration_seconds"):
+        media_file.duration_seconds = result["duration_seconds"]
     db.flush()
 
 

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -101,6 +101,14 @@ def _process_video(db, asset, version, media_file, s3, output_prefix):
     media_file.s3_key_processed = result.hls_prefix
     if result.thumbnail_keys:
         media_file.s3_key_thumbnail = result.thumbnail_keys[0]
+    if result.duration_seconds:
+        media_file.duration_seconds = result.duration_seconds
+    if result.width:
+        media_file.width = result.width
+    if result.height:
+        media_file.height = result.height
+    if result.fps:
+        media_file.fps = result.fps
     db.flush()
 
 

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -3,6 +3,7 @@ import sys
 import os
 import asyncio
 import json
+import logging
 
 # Ensure the workspace root is on the path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
@@ -13,6 +14,8 @@ from ..models.asset import AssetVersion, MediaFile, ProcessingStatus, AssetType
 from ..models.asset import Asset
 from ..services.s3_service import get_s3_client
 from ..config import settings
+
+log = logging.getLogger("celery.transcode")
 
 
 def _run_async(coro):
@@ -143,6 +146,22 @@ def _publish_event(project_id: str, event_type: str, payload: dict):
         pass  # SSE publish is best-effort
 
 
+def _eligible_media_rows(db):
+    """Rows the #124 backfill still needs: (MediaFile, asset_type) pairs."""
+    return (
+        db.query(MediaFile, Asset.asset_type)
+        .join(AssetVersion, MediaFile.version_id == AssetVersion.id)
+        .join(Asset, AssetVersion.asset_id == Asset.id)
+        .filter(
+            AssetVersion.processing_status == ProcessingStatus.ready,
+            AssetVersion.deleted_at.is_(None),
+            MediaFile.duration_seconds.is_(None),
+            Asset.asset_type.in_([AssetType.video, AssetType.audio]),
+        )
+        .all()
+    )
+
+
 @celery_app.task(bind=True)
 def backfill_media_metadata(self):
     """One-off backfill for #124: probe raw S3 files to populate missing
@@ -154,51 +173,45 @@ def backfill_media_metadata(self):
     db = SessionLocal()
     updated = skipped = 0
     try:
-        rows = (
-            db.query(MediaFile, Asset.asset_type)
-            .join(AssetVersion, MediaFile.version_id == AssetVersion.id)
-            .join(Asset, AssetVersion.asset_id == Asset.id)
-            .filter(
-                AssetVersion.processing_status == ProcessingStatus.ready,
-                AssetVersion.deleted_at.is_(None),
-                MediaFile.duration_seconds.is_(None),
-                Asset.asset_type.in_([AssetType.video, AssetType.audio]),
-            )
-            .all()
-        )
+        rows = _eligible_media_rows(db)
         s3 = get_s3_client()
         for media_file, asset_type in rows:
-            url = s3.generate_presigned_url(
-                "get_object",
-                Params={"Bucket": settings.s3_bucket, "Key": media_file.s3_key_raw},
-                ExpiresIn=3600,
-            )
-            cmd = ["ffprobe", "-v", "error", "-print_format", "json", "-show_format"]
-            if asset_type == AssetType.video:
-                cmd += ["-show_streams", "-select_streams", "v:0"]
-            probe = subprocess.run(cmd + [url], capture_output=True, text=True, timeout=300)
-            if probe.returncode != 0:
-                skipped += 1
-                continue
             try:
-                data = json.loads(probe.stdout)
-            except json.JSONDecodeError:
-                skipped += 1
-                continue
-            if asset_type == AssetType.video:
-                meta = parse_probe_metadata(data)
-                if meta is None:
+                url = s3.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": settings.s3_bucket, "Key": media_file.s3_key_raw},
+                    ExpiresIn=3600,
+                )
+                cmd = ["ffprobe", "-v", "error", "-print_format", "json", "-show_format"]
+                if asset_type == AssetType.video:
+                    cmd += ["-show_streams", "-select_streams", "v:0"]
+                probe = subprocess.run(cmd + [url], capture_output=True, text=True, timeout=300)
+                if probe.returncode != 0:
                     skipped += 1
                     continue
-                media_file.duration_seconds = meta.duration_seconds or None
-                media_file.width = meta.width or None
-                media_file.height = meta.height or None
-                media_file.fps = meta.fps or None
-            else:
-                duration = float((data.get("format") or {}).get("duration") or 0)
-                media_file.duration_seconds = duration or None
-            db.commit()
-            updated += 1
+                try:
+                    data = json.loads(probe.stdout)
+                except json.JSONDecodeError:
+                    skipped += 1
+                    continue
+                if asset_type == AssetType.video:
+                    meta = parse_probe_metadata(data)
+                    if meta is None:
+                        skipped += 1
+                        continue
+                    media_file.duration_seconds = meta.duration_seconds or None
+                    media_file.width = meta.width or None
+                    media_file.height = meta.height or None
+                    media_file.fps = meta.fps or None
+                else:
+                    duration = float((data.get("format") or {}).get("duration") or 0)
+                    media_file.duration_seconds = duration or None
+                db.commit()
+                updated += 1
+            except Exception as exc:
+                skipped += 1
+                log.warning("backfill: skipping media_file %s: %s", media_file.id, exc)
+                continue
         return {"updated": updated, "skipped": skipped}
     finally:
         db.close()

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -155,6 +155,7 @@ def _eligible_media_rows(db):
         .filter(
             AssetVersion.processing_status == ProcessingStatus.ready,
             AssetVersion.deleted_at.is_(None),
+            Asset.deleted_at.is_(None),
             MediaFile.duration_seconds.is_(None),
             Asset.asset_type.in_([AssetType.video, AssetType.audio]),
         )
@@ -176,6 +177,7 @@ def backfill_media_metadata(self):
         rows = _eligible_media_rows(db)
         s3 = get_s3_client()
         for media_file, asset_type in rows:
+            row_id = media_file.id
             try:
                 url = s3.generate_presigned_url(
                     "get_object",
@@ -209,8 +211,9 @@ def backfill_media_metadata(self):
                 db.commit()
                 updated += 1
             except Exception as exc:
+                db.rollback()
                 skipped += 1
-                log.warning("backfill: skipping media_file %s: %s", media_file.id, exc)
+                log.warning("backfill: skipping media_file %s: %s", row_id, exc)
                 continue
         return {"updated": updated, "skipped": skipped}
     finally:

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -141,3 +141,64 @@ def _publish_event(project_id: str, event_type: str, payload: dict):
         r.close()
     except Exception:
         pass  # SSE publish is best-effort
+
+
+@celery_app.task(bind=True)
+def backfill_media_metadata(self):
+    """One-off backfill for #124: probe raw S3 files to populate missing
+    duration/width/height/fps on already-processed media. Idempotent —
+    only touches rows where duration_seconds IS NULL."""
+    import subprocess
+    from packages.transcoder.ffmpeg_transcoder import parse_probe_metadata
+
+    db = SessionLocal()
+    updated = skipped = 0
+    try:
+        rows = (
+            db.query(MediaFile, Asset.asset_type)
+            .join(AssetVersion, MediaFile.version_id == AssetVersion.id)
+            .join(Asset, AssetVersion.asset_id == Asset.id)
+            .filter(
+                AssetVersion.processing_status == ProcessingStatus.ready,
+                AssetVersion.deleted_at.is_(None),
+                MediaFile.duration_seconds.is_(None),
+                Asset.asset_type.in_([AssetType.video, AssetType.audio]),
+            )
+            .all()
+        )
+        s3 = get_s3_client()
+        for media_file, asset_type in rows:
+            url = s3.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": settings.s3_bucket, "Key": media_file.s3_key_raw},
+                ExpiresIn=3600,
+            )
+            cmd = ["ffprobe", "-v", "error", "-print_format", "json", "-show_format"]
+            if asset_type == AssetType.video:
+                cmd += ["-show_streams", "-select_streams", "v:0"]
+            probe = subprocess.run(cmd + [url], capture_output=True, text=True, timeout=300)
+            if probe.returncode != 0:
+                skipped += 1
+                continue
+            try:
+                data = json.loads(probe.stdout)
+            except json.JSONDecodeError:
+                skipped += 1
+                continue
+            if asset_type == AssetType.video:
+                meta = parse_probe_metadata(data)
+                if meta is None:
+                    skipped += 1
+                    continue
+                media_file.duration_seconds = meta.duration_seconds or None
+                media_file.width = meta.width or None
+                media_file.height = meta.height or None
+                media_file.fps = meta.fps or None
+            else:
+                duration = float((data.get("format") or {}).get("duration") or 0)
+                media_file.duration_seconds = duration or None
+            db.commit()
+            updated += 1
+        return {"updated": updated, "skipped": skipped}
+    finally:
+        db.close()

--- a/apps/api/tests/test_backfill_media_metadata.py
+++ b/apps/api/tests/test_backfill_media_metadata.py
@@ -1,0 +1,73 @@
+"""Backfill task (#124): probes raw files and fills missing metadata."""
+import json
+from unittest.mock import MagicMock, patch
+
+from apps.api.models.asset import AssetType
+
+
+def _mock_db(rows):
+    db = MagicMock()
+    db.query.return_value = db
+    db.join.return_value = db
+    db.filter.return_value = db
+    db.all.return_value = rows
+    return db
+
+
+def _video_probe():
+    return json.dumps({
+        "streams": [{"r_frame_rate": "30000/1001", "width": 3840, "height": 2160, "duration": "12.0"}],
+        "format": {"duration": "12.0"},
+    })
+
+
+def test_backfill_updates_video_row():
+    from apps.api.tasks.transcode_tasks import backfill_media_metadata
+
+    media_file = MagicMock(duration_seconds=None, s3_key_raw="raw/key.mp4")
+    db = _mock_db([(media_file, AssetType.video)])
+    probe = MagicMock(returncode=0, stdout=_video_probe())
+
+    with patch("apps.api.tasks.transcode_tasks.SessionLocal", return_value=db), \
+         patch("apps.api.tasks.transcode_tasks.get_s3_client") as s3, \
+         patch("subprocess.run", return_value=probe):
+        s3.return_value.generate_presigned_url.return_value = "https://example/presigned"
+        result = backfill_media_metadata.apply().get()
+
+    assert result == {"updated": 1, "skipped": 0}
+    assert media_file.width == 3840
+    assert abs(media_file.fps - 29.97002997) < 0.001
+    db.commit.assert_called()
+
+
+def test_backfill_skips_failed_probe():
+    from apps.api.tasks.transcode_tasks import backfill_media_metadata
+
+    media_file = MagicMock(duration_seconds=None, s3_key_raw="raw/bad.mp4")
+    db = _mock_db([(media_file, AssetType.video)])
+    probe = MagicMock(returncode=1, stdout="", stderr="boom")
+
+    with patch("apps.api.tasks.transcode_tasks.SessionLocal", return_value=db), \
+         patch("apps.api.tasks.transcode_tasks.get_s3_client") as s3, \
+         patch("subprocess.run", return_value=probe):
+        s3.return_value.generate_presigned_url.return_value = "https://example/presigned"
+        result = backfill_media_metadata.apply().get()
+
+    assert result == {"updated": 0, "skipped": 1}
+
+
+def test_backfill_audio_uses_format_duration():
+    from apps.api.tasks.transcode_tasks import backfill_media_metadata
+
+    media_file = MagicMock(duration_seconds=None, s3_key_raw="raw/a.wav")
+    db = _mock_db([(media_file, AssetType.audio)])
+    probe = MagicMock(returncode=0, stdout=json.dumps({"format": {"duration": "33.3"}}))
+
+    with patch("apps.api.tasks.transcode_tasks.SessionLocal", return_value=db), \
+         patch("apps.api.tasks.transcode_tasks.get_s3_client") as s3, \
+         patch("subprocess.run", return_value=probe):
+        s3.return_value.generate_presigned_url.return_value = "https://example/presigned"
+        result = backfill_media_metadata.apply().get()
+
+    assert result == {"updated": 1, "skipped": 0}
+    assert media_file.duration_seconds == 33.3

--- a/apps/api/tests/test_backfill_media_metadata.py
+++ b/apps/api/tests/test_backfill_media_metadata.py
@@ -2,6 +2,7 @@
 import json
 import subprocess
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from apps.api.models.asset import AssetType
@@ -141,7 +142,12 @@ def _media(db, version, duration_seconds=None):
 
 def test_eligible_media_rows_scopes_to_ready_nondeleted_null_duration_video_or_audio(real_db):
     """Finding 2: exercise the real query — only the (video|audio, ready, non-deleted,
-    duration_seconds IS NULL) row should come back."""
+    duration_seconds IS NULL) row should come back.
+
+    Uses membership assertions (not exact-equality on the full result set) because this
+    runs against the shared dev Postgres via `real_db`, which may already contain other
+    eligible rows left over from manual testing/other suites — asserting the full result
+    set would make this test fragile against that shared state."""
     from apps.api.models.asset import ProcessingStatus
     from apps.api.tasks.transcode_tasks import _eligible_media_rows
 
@@ -156,18 +162,37 @@ def test_eligible_media_rows_scopes_to_ready_nondeleted_null_duration_video_or_a
     # excluded: same shape but duration_seconds already set (idempotency)
     filled_asset = _asset(real_db, project, owner, asset_type=AssetType.video)
     filled_version = _version(real_db, filled_asset, owner, status=ProcessingStatus.ready)
-    _media(real_db, filled_version, duration_seconds=12.5)
+    filled_media = _media(real_db, filled_version, duration_seconds=12.5)
 
     # excluded: image asset
     image_asset = _asset(real_db, project, owner, asset_type=AssetType.image)
     image_version = _version(real_db, image_asset, owner, status=ProcessingStatus.ready)
-    _media(real_db, image_version, duration_seconds=None)
+    image_media = _media(real_db, image_version, duration_seconds=None)
 
     # excluded: soft-deleted version
+    deleted_version_asset = _asset(real_db, project, owner, asset_type=AssetType.video)
+    deleted_version = _version(real_db, deleted_version_asset, owner, status=ProcessingStatus.ready, deleted=True)
+    deleted_version_media = _media(real_db, deleted_version, duration_seconds=None)
+
+    # excluded: version not yet ready (still processing)
+    processing_asset = _asset(real_db, project, owner, asset_type=AssetType.video)
+    processing_version = _version(real_db, processing_asset, owner, status=ProcessingStatus.processing)
+    processing_media = _media(real_db, processing_version, duration_seconds=None)
+
+    # excluded: soft-deleted ASSET, version itself still alive (locks fix 2 — asset
+    # soft-delete does not cascade to versions, so the query must filter on the asset too)
     deleted_asset = _asset(real_db, project, owner, asset_type=AssetType.video)
-    deleted_version = _version(real_db, deleted_asset, owner, status=ProcessingStatus.ready, deleted=True)
-    _media(real_db, deleted_version, duration_seconds=None)
+    deleted_asset_version = _version(real_db, deleted_asset, owner, status=ProcessingStatus.ready)
+    deleted_asset_media = _media(real_db, deleted_asset_version, duration_seconds=None)
+    deleted_asset.deleted_at = datetime.now(timezone.utc)
+    real_db.flush()
 
     rows = _eligible_media_rows(real_db)
+    result_ids = [mf.id for mf, _asset_type in rows]
 
-    assert [mf.id for mf, _asset_type in rows] == [eligible_media.id]
+    assert eligible_media.id in result_ids
+    assert filled_media.id not in result_ids
+    assert image_media.id not in result_ids
+    assert deleted_version_media.id not in result_ids
+    assert processing_media.id not in result_ids
+    assert deleted_asset_media.id not in result_ids

--- a/apps/api/tests/test_backfill_media_metadata.py
+++ b/apps/api/tests/test_backfill_media_metadata.py
@@ -1,5 +1,7 @@
 """Backfill task (#124): probes raw files and fills missing metadata."""
 import json
+import subprocess
+import uuid
 from unittest.mock import MagicMock, patch
 
 from apps.api.models.asset import AssetType
@@ -71,3 +73,101 @@ def test_backfill_audio_uses_format_duration():
 
     assert result == {"updated": 1, "skipped": 0}
     assert media_file.duration_seconds == 33.3
+
+
+def test_backfill_skips_row_when_probe_raises_and_continues_batch():
+    """Finding 1: an unhandled exception (TimeoutExpired, botocore error, etc.) from presign/probe
+    must skip only that row and continue the batch — never abort it."""
+    from apps.api.tasks.transcode_tasks import backfill_media_metadata
+
+    bad_file = MagicMock(duration_seconds=None, s3_key_raw="raw/bad.mp4")
+    good_file = MagicMock(duration_seconds=None, s3_key_raw="raw/good.mp4")
+    db = _mock_db([(bad_file, AssetType.video), (good_file, AssetType.video)])
+    good_probe = MagicMock(returncode=0, stdout=_video_probe())
+
+    with patch("apps.api.tasks.transcode_tasks.SessionLocal", return_value=db), \
+         patch("apps.api.tasks.transcode_tasks.get_s3_client") as s3, \
+         patch("subprocess.run", side_effect=[
+             subprocess.TimeoutExpired(cmd="ffprobe", timeout=300),
+             good_probe,
+         ]):
+        s3.return_value.generate_presigned_url.return_value = "https://example/presigned"
+        result = backfill_media_metadata.apply().get()
+
+    assert result == {"updated": 1, "skipped": 1}
+    assert good_file.width == 3840
+
+
+def _user(db):
+    from apps.api.models.user import User
+    u = User(email=f"backfill-{uuid.uuid4()}@t.local", name="t")
+    db.add(u); db.flush()
+    return u
+
+
+def _project(db, owner):
+    from apps.api.models.project import Project, ProjectType
+    p = Project(name="t", project_type=ProjectType.personal, created_by=owner.id)
+    db.add(p); db.flush()
+    return p
+
+
+def _asset(db, project, owner, asset_type=AssetType.video):
+    from apps.api.models.asset import Asset
+    a = Asset(project_id=project.id, name="t", asset_type=asset_type, created_by=owner.id)
+    db.add(a); db.flush()
+    return a
+
+
+def _version(db, asset, owner, status, deleted=False):
+    from datetime import datetime, timezone
+    from apps.api.models.asset import AssetVersion
+    v = AssetVersion(asset_id=asset.id, version_number=1, processing_status=status, created_by=owner.id)
+    db.add(v); db.flush()
+    if deleted:
+        v.deleted_at = datetime.now(timezone.utc)
+        db.flush()
+    return v
+
+
+def _media(db, version, duration_seconds=None):
+    from apps.api.models.asset import MediaFile, FileType
+    mf = MediaFile(version_id=version.id, file_type=FileType.video, original_filename="f.mp4",
+                   mime_type="video/mp4", file_size_bytes=10, s3_key_raw=f"raw/{version.id}",
+                   duration_seconds=duration_seconds)
+    db.add(mf); db.flush()
+    return mf
+
+
+def test_eligible_media_rows_scopes_to_ready_nondeleted_null_duration_video_or_audio(real_db):
+    """Finding 2: exercise the real query — only the (video|audio, ready, non-deleted,
+    duration_seconds IS NULL) row should come back."""
+    from apps.api.models.asset import ProcessingStatus
+    from apps.api.tasks.transcode_tasks import _eligible_media_rows
+
+    owner = _user(real_db)
+    project = _project(real_db, owner)
+
+    # eligible: video asset, ready non-deleted version, duration_seconds NULL
+    eligible_asset = _asset(real_db, project, owner, asset_type=AssetType.video)
+    eligible_version = _version(real_db, eligible_asset, owner, status=ProcessingStatus.ready)
+    eligible_media = _media(real_db, eligible_version, duration_seconds=None)
+
+    # excluded: same shape but duration_seconds already set (idempotency)
+    filled_asset = _asset(real_db, project, owner, asset_type=AssetType.video)
+    filled_version = _version(real_db, filled_asset, owner, status=ProcessingStatus.ready)
+    _media(real_db, filled_version, duration_seconds=12.5)
+
+    # excluded: image asset
+    image_asset = _asset(real_db, project, owner, asset_type=AssetType.image)
+    image_version = _version(real_db, image_asset, owner, status=ProcessingStatus.ready)
+    _media(real_db, image_version, duration_seconds=None)
+
+    # excluded: soft-deleted version
+    deleted_asset = _asset(real_db, project, owner, asset_type=AssetType.video)
+    deleted_version = _version(real_db, deleted_asset, owner, status=ProcessingStatus.ready, deleted=True)
+    _media(real_db, deleted_version, duration_seconds=None)
+
+    rows = _eligible_media_rows(real_db)
+
+    assert [mf.id for mf, _asset_type in rows] == [eligible_media.id]

--- a/apps/api/tests/test_ffmpeg_transcoder.py
+++ b/apps/api/tests/test_ffmpeg_transcoder.py
@@ -187,3 +187,26 @@ def test_run_returns_stdout():
 
         result = FFmpegTranscoder._run(["echo", "hello"], label="test")
         assert result == "output data"
+
+
+def test_transcode_returns_probe_metadata():
+    t = FFmpegTranscoder(MagicMock(), "bucket")
+    video_probe = json.dumps({
+        "streams": [{"r_frame_rate": "25/1", "width": 1920, "height": 1080, "duration": "8.0"}],
+        "format": {"duration": "8.0"},
+    })
+    audio_probe = json.dumps({"streams": []})
+
+    def fake_run(cmd, timeout=None, label="ffmpeg"):
+        if label == "ffprobe":
+            return video_probe if "v:0" in cmd else audio_probe
+        return ""
+
+    with patch.object(FFmpegTranscoder, "_run", side_effect=fake_run), \
+         patch.object(FFmpegTranscoder, "_get_presigned_url", return_value="http://in"):
+        result = asyncio.run(t.transcode(_make_job()))
+
+    assert result.success is True
+    assert result.fps == 25.0
+    assert result.width == 1920
+    assert result.duration_seconds == 8.0

--- a/apps/api/tests/test_probe_metadata.py
+++ b/apps/api/tests/test_probe_metadata.py
@@ -1,0 +1,34 @@
+"""parse_probe_metadata (#124): fps fraction handling, 0/0 guard, duration fallback."""
+from packages.transcoder.ffmpeg_transcoder import parse_probe_metadata
+
+
+def test_fractional_ntsc_rate():
+    meta = parse_probe_metadata({
+        "streams": [{"r_frame_rate": "30000/1001", "width": 1920, "height": 1080, "duration": "10.5"}],
+        "format": {"duration": "10.5"},
+    })
+    assert abs(meta.fps - 29.97002997) < 1e-6
+    assert meta.width == 1920 and meta.height == 1080
+    assert meta.duration_seconds == 10.5
+
+
+def test_zero_denominator_rate_is_guarded():
+    meta = parse_probe_metadata({"streams": [{"r_frame_rate": "0/0", "width": 640, "height": 480}]})
+    assert meta.fps == 0.0
+
+
+def test_missing_stream_duration_falls_back_to_format():
+    meta = parse_probe_metadata({
+        "streams": [{"r_frame_rate": "25/1", "width": 1280, "height": 720}],
+        "format": {"duration": "42.25"},
+    })
+    assert meta.duration_seconds == 42.25
+
+
+def test_no_video_stream_returns_none():
+    assert parse_probe_metadata({"streams": [], "format": {"duration": "5"}}) is None
+
+
+def test_missing_rate_yields_zero_fps_not_fabricated_30():
+    meta = parse_probe_metadata({"streams": [{"width": 10, "height": 10, "duration": "1"}]})
+    assert meta.fps == 0.0

--- a/apps/api/tests/test_transcode_metadata_persist.py
+++ b/apps/api/tests/test_transcode_metadata_persist.py
@@ -34,3 +34,15 @@ def test_process_video_leaves_fields_untouched_when_metadata_missing():
 
     assert media_file.duration_seconds is None
     assert media_file.fps is None
+
+
+def test_process_audio_persists_duration():
+    from apps.api.tasks.transcode_tasks import _process_audio
+
+    media_file = MagicMock(duration_seconds=None)
+    with patch("packages.transcoder.image_processor.process_audio",
+               return_value={"mp3_key": "k.mp3", "waveform_key": "w.json", "duration_seconds": 12.5}):
+        _process_audio(MagicMock(), MagicMock(), MagicMock(), media_file, MagicMock(), "prefix")
+
+    assert media_file.duration_seconds == 12.5
+    assert media_file.s3_key_processed == "k.mp3"

--- a/apps/api/tests/test_transcode_metadata_persist.py
+++ b/apps/api/tests/test_transcode_metadata_persist.py
@@ -1,0 +1,36 @@
+"""#124: _process_video persists probe metadata onto MediaFile."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from packages.transcoder.base import TranscodeResult
+
+
+def test_process_video_persists_metadata():
+    from apps.api.tasks.transcode_tasks import _process_video
+
+    media_file = MagicMock(duration_seconds=None, width=None, height=None, fps=None,
+                           s3_key_raw="raw/x.mp4")
+    result = TranscodeResult(
+        success=True, hls_prefix="processed/p/a/v", thumbnail_keys=["t.jpg"],
+        duration_seconds=71.5, width=3840, height=2160, fps=59.94,
+    )
+    with patch("packages.transcoder.ffmpeg_transcoder.FFmpegTranscoder") as MockT:
+        MockT.return_value.transcode = AsyncMock(return_value=result)
+        _process_video(MagicMock(), MagicMock(), MagicMock(), media_file, MagicMock(), "processed/p/a/v")
+
+    assert media_file.duration_seconds == 71.5
+    assert media_file.width == 3840
+    assert media_file.height == 2160
+    assert media_file.fps == 59.94
+
+
+def test_process_video_leaves_fields_untouched_when_metadata_missing():
+    from apps.api.tasks.transcode_tasks import _process_video
+
+    media_file = MagicMock(duration_seconds=None, width=None, height=None, fps=None)
+    result = TranscodeResult(success=True, hls_prefix="p", thumbnail_keys=[])
+    with patch("packages.transcoder.ffmpeg_transcoder.FFmpegTranscoder") as MockT:
+        MockT.return_value.transcode = AsyncMock(return_value=result)
+        _process_video(MagicMock(), MagicMock(), MagicMock(), media_file, MagicMock(), "p")
+
+    assert media_file.duration_seconds is None
+    assert media_file.fps is None

--- a/apps/api/tests/test_transcode_metadata_persist.py
+++ b/apps/api/tests/test_transcode_metadata_persist.py
@@ -1,4 +1,4 @@
-"""#124: _process_video persists probe metadata onto MediaFile."""
+"""#124: _process_video and _process_audio persist probe metadata onto MediaFile."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from packages.transcoder.base import TranscodeResult

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -379,7 +379,7 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
 
 Database migrations run automatically on API startup. Always check the [CHANGELOG](../CHANGELOG.md) before updating.
 
-If you're upgrading past the media-metadata fix ([#124](https://github.com/Techiebutler/freeframe/issues/124)), backfill missing `duration_seconds`/`width`/`height`/`fps` on already-processed files with: `docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata`.
+If you're upgrading past the media-metadata fix ([#124](https://github.com/Techiebutler/freeframe/issues/124)), backfill missing `duration_seconds`/`width`/`height`/`fps` on already-processed files with: `docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata`. The backfill runs as a Celery task on the `transcoding` queue, so it occupies one worker slot and can run long on large libraries (up to ~300s per file); new uploads keep transcoding normally on the remaining slots.
 
 ### Update Checklist
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -379,6 +379,8 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --build
 
 Database migrations run automatically on API startup. Always check the [CHANGELOG](../CHANGELOG.md) before updating.
 
+If you're upgrading past the media-metadata fix ([#124](https://github.com/Techiebutler/freeframe/issues/124)), backfill missing `duration_seconds`/`width`/`height`/`fps` on already-processed files with: `docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata`.
+
 ### Update Checklist
 
 1. **Read the changelog** — check for breaking changes or new env vars

--- a/packages/transcoder/base.py
+++ b/packages/transcoder/base.py
@@ -17,6 +17,10 @@ class TranscodeResult:
     thumbnail_keys: list[str] = field(default_factory=list)
     waveform_key: Optional[str] = None
     error: Optional[str] = None
+    duration_seconds: Optional[float] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    fps: Optional[float] = None
 
 @dataclass
 class VideoMetadata:

--- a/packages/transcoder/ffmpeg_transcoder.py
+++ b/packages/transcoder/ffmpeg_transcoder.py
@@ -11,6 +11,37 @@ from botocore.config import Config
 from .base import BaseTranscoder, TranscodeJob, TranscodeResult, VideoMetadata
 
 
+def parse_probe_metadata(data: dict) -> Optional[VideoMetadata]:
+    """Parse ffprobe JSON (-show_streams -show_format) into VideoMetadata.
+
+    Returns None when there is no video stream. Guards r_frame_rate "0/0"
+    (fps stays 0.0 — never fabricate a rate) and falls back to format-level
+    duration when the stream lacks one (common for MKV/WebM).
+    """
+    streams = data.get("streams") or []
+    if not streams:
+        return None
+    stream = streams[0]
+    fps = 0.0
+    raw_rate = stream.get("r_frame_rate", "")
+    if "/" in raw_rate:
+        num, _, den = raw_rate.partition("/")
+        try:
+            if float(den) != 0:
+                fps = float(num) / float(den)
+        except ValueError:
+            fps = 0.0
+    duration = float(stream.get("duration") or 0)
+    if not duration:
+        duration = float((data.get("format") or {}).get("duration") or 0)
+    return VideoMetadata(
+        duration_seconds=duration,
+        width=int(stream.get("width") or 0),
+        height=int(stream.get("height") or 0),
+        fps=fps,
+    )
+
+
 class FFmpegTranscoder(BaseTranscoder):
     def __init__(self, s3_client, bucket: str, s3_endpoint: str = None):
         self.s3 = s3_client
@@ -47,19 +78,13 @@ class FFmpegTranscoder(BaseTranscoder):
         input_url = self._get_presigned_url(s3_key)
         cmd = [
             "ffprobe", "-v", "error", "-print_format", "json",
-            "-show_streams", "-select_streams", "v:0", input_url,
+            "-show_streams", "-select_streams", "v:0", "-show_format", input_url,
         ]
         stdout = self._run(cmd, timeout=120, label="ffprobe")
-        data = json.loads(stdout)
-        stream = data["streams"][0]
-        fps_parts = stream.get("r_frame_rate", "30/1").split("/")
-        fps = float(fps_parts[0]) / float(fps_parts[1])
-        return VideoMetadata(
-            duration_seconds=float(stream.get("duration", 0)),
-            width=int(stream.get("width", 0)),
-            height=int(stream.get("height", 0)),
-            fps=fps,
-        )
+        meta = parse_probe_metadata(json.loads(stdout))
+        if meta is None:
+            raise RuntimeError(f"No video stream found in {s3_key}")
+        return meta
 
     async def generate_thumbnails(self, s3_key: str, count: int) -> list[str]:
         """Generate thumbnails at 1 per 10 seconds using streaming input."""

--- a/packages/transcoder/ffmpeg_transcoder.py
+++ b/packages/transcoder/ffmpeg_transcoder.py
@@ -121,13 +121,12 @@ class FFmpegTranscoder(BaseTranscoder):
 
         try:
             # 1. Get video metadata via streaming (no download)
-            # Note: ffprobe result is used for metadata logging only;
-            # _run() already fail-fasts on non-zero exit.
             cmd = [
                 "ffprobe", "-v", "error", "-print_format", "json",
-                "-show_streams", "-select_streams", "v:0", input_url,
+                "-show_streams", "-select_streams", "v:0", "-show_format", input_url,
             ]
             vid_info = self._run(cmd, timeout=120, label="ffprobe")
+            meta = parse_probe_metadata(json.loads(vid_info))
 
             # 2. Check if input has an audio stream
             audio_cmd = [
@@ -228,6 +227,10 @@ class FFmpegTranscoder(BaseTranscoder):
                 success=True,
                 hls_prefix=job.output_s3_prefix,
                 thumbnail_keys=[thumbnail_key],
+                duration_seconds=(meta.duration_seconds or None) if meta else None,
+                width=(meta.width or None) if meta else None,
+                height=(meta.height or None) if meta else None,
+                fps=(meta.fps or None) if meta else None,
             )
 
         except Exception as e:

--- a/packages/transcoder/ffmpeg_transcoder.py
+++ b/packages/transcoder/ffmpeg_transcoder.py
@@ -23,7 +23,7 @@ def parse_probe_metadata(data: dict) -> Optional[VideoMetadata]:
         return None
     stream = streams[0]
     fps = 0.0
-    raw_rate = stream.get("r_frame_rate", "")
+    raw_rate = stream.get("r_frame_rate") or ""
     if "/" in raw_rate:
         num, _, den = raw_rate.partition("/")
         try:

--- a/packages/transcoder/image_processor.py
+++ b/packages/transcoder/image_processor.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 
 def process_image(s3_client, bucket: str, input_s3_key: str, output_prefix: str) -> dict:
@@ -42,7 +45,10 @@ def process_image(s3_client, bucket: str, input_s3_key: str, output_prefix: str)
 
 
 def process_audio(s3_client, bucket: str, input_s3_key: str, output_prefix: str) -> dict:
-    """Normalize audio to MP3 + generate waveform JSON. Returns dict of S3 keys."""
+    """Normalize audio to MP3 + generate waveform JSON.
+
+    Returns dict of S3 keys plus a `duration_seconds` key (probed from the
+    input via ffprobe; None if the probe fails)."""
     with tempfile.NamedTemporaryFile(suffix=".audio", delete=False) as f:
         tmp_input = f.name
     work_dir = tempfile.mkdtemp()
@@ -58,8 +64,8 @@ def process_audio(s3_client, bucket: str, input_s3_key: str, output_prefix: str)
                 check=True, capture_output=True, text=True, timeout=120,
             )
             duration_seconds = float(json.loads(probe.stdout).get("format", {}).get("duration") or 0) or None
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, json.JSONDecodeError, OSError, AttributeError):
-            pass  # a failed probe must not fail audio processing
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, json.JSONDecodeError, OSError, AttributeError) as exc:
+            log.warning("audio duration probe failed for %s: %s", input_s3_key, exc)  # a failed probe must not fail audio processing
         result["duration_seconds"] = duration_seconds
 
         # Normalize and convert to MP3

--- a/packages/transcoder/image_processor.py
+++ b/packages/transcoder/image_processor.py
@@ -58,7 +58,7 @@ def process_audio(s3_client, bucket: str, input_s3_key: str, output_prefix: str)
                 check=True, capture_output=True, text=True, timeout=120,
             )
             duration_seconds = float(json.loads(probe.stdout).get("format", {}).get("duration") or 0) or None
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, json.JSONDecodeError):
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, json.JSONDecodeError, OSError, AttributeError):
             pass  # a failed probe must not fail audio processing
         result["duration_seconds"] = duration_seconds
 

--- a/packages/transcoder/image_processor.py
+++ b/packages/transcoder/image_processor.py
@@ -50,6 +50,18 @@ def process_audio(s3_client, bucket: str, input_s3_key: str, output_prefix: str)
     try:
         s3_client.download_file(bucket, input_s3_key, tmp_input)
 
+        # Probe duration before processing (#124)
+        duration_seconds = None
+        try:
+            probe = subprocess.run(
+                ["ffprobe", "-v", "error", "-print_format", "json", "-show_format", tmp_input],
+                check=True, capture_output=True, text=True, timeout=120,
+            )
+            duration_seconds = float(json.loads(probe.stdout).get("format", {}).get("duration") or 0) or None
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, json.JSONDecodeError):
+            pass  # a failed probe must not fail audio processing
+        result["duration_seconds"] = duration_seconds
+
         # Normalize and convert to MP3
         mp3_path = os.path.join(work_dir, "processed.mp3")
         subprocess.run(


### PR DESCRIPTION
## Summary

Every video/audio `MediaFile` had `duration_seconds`, `width`, `height`, and `fps` = NULL even after a successful transcode — the pipeline ran ffprobe but threw the result away. This PR persists that metadata for new transcodes and adds a one-off backfill for existing files.

## Changes

- **Safe probe parsing** — new `parse_probe_metadata()` in the transcoder: guards `r_frame_rate: "0/0"` (previously a `ZeroDivisionError` path), falls back to format-level duration when the stream lacks one (MKV/WebM), and never fabricates a frame rate (unknown → NULL, not a silent 30fps default).
- **Pipeline persistence** — `transcode()` now returns the metadata it was already probing; `_process_video` / `_process_audio` write it to `MediaFile` (truthy-gated, so bogus zeros are never stored).
- **Backfill for existing files** — `backfill_media_metadata` Celery task (auto-routes to the `transcoding` queue) re-probes raw S3 objects for rows still missing metadata. Batch-resilient: any per-row failure rolls back, logs, and continues. Scoped to ready, non-soft-deleted versions/assets. Run with:
  `docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata`
- Docs: CHANGELOG under `[Unreleased]`, deployment note (backfill occupies one transcoding worker slot; safe to re-run).

## Verification

- Full API suite: passing with zero failures (matches pre-branch baseline plus new tests).
- Real end-to-end in the dev stack: generated clip → real ffmpeg transcode → `MediaFile` persisted `12.0s / 320×240 / 25.0fps` → fields nulled → backfill repopulated them (`{'updated': 1, 'skipped': 0}`) → cleanup verified.
- New tests: probe-parsing edge cases, persistence wiring, batch-continuation on probe timeout, and a real-Postgres scoping test covering all five eligibility filters.

Unblocks the share-preview duration chip and the comment-export-to-NLE feature (#84).

Closes #124
