### PR TITLE
feat: export comments as NLE timeline markers — EDL / FCPXML / Premiere XML / CSV (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Export comments as NLE timeline markers** ([#84](https://github.com/Techiebutler/freeframe/issues/84)) — `GET /assets/{id}/comments/export?format=edl|fcpxml|premiere_xml|csv` turns a version's timecoded comments into importable markers for DaVinci Resolve (marker EDL — import via Timelines → Import → Timeline Markers from EDL, matching the timeline start TC, default 01:00:00:00), Final Cut Pro (FCPXML), and Premiere Pro (FCP7 XML — Premiere cannot import FCPXML), plus CSV. Uses the stored frame rate (see #124) with a `?fps=` override. Note: variable-frame-rate sources may land markers ±1 frame.
+
 ### Fixed
 - **Transcode pipeline now persists media metadata** ([#124](https://github.com/Techiebutler/freeframe/issues/124)) — `duration_seconds`, `width`, `height`, and `fps` are stored on every new video/audio transcode (previously always NULL, breaking duration display). Existing files: run the one-off backfill — `docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata`.
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -48,6 +48,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
 )
 app.add_middleware(GlobalRateLimitMiddleware)
 app.add_middleware(SetupGuardMiddleware)

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -648,7 +648,7 @@ def export_comments(
     if format == "csv":
         if not include_resolved:
             rows = [r for r in rows if not r.resolved]
-        content = "﻿" + comment_export.to_csv(rows, spec)  # BOM for Excel
+        content = "\ufeff" + comment_export.to_csv(rows, spec)  # BOM for Excel
     else:
         markers = comment_export.build_markers(rows, spec, include_resolved)
         if format == "edl":

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -4,14 +4,14 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from ..config import settings
 from ..database import get_db
 from ..middleware.auth import get_current_user, get_optional_user
 from ..middleware.share_auth import get_share_link
-from ..models.asset import Asset
+from ..models.asset import Asset, AssetType, AssetVersion, MediaFile, ProcessingStatus
 from ..models.project import ProjectMember, ProjectRole
 from ..models.comment import Annotation, Comment, CommentAttachment, CommentReaction
 from ..models.activity import Mention, Notification, NotificationType, ActivityLog, ActivityAction
@@ -32,11 +32,20 @@ from ..schemas.comment import (
     ReactionResponse,
 )
 from ..services import s3_service
+from ..services import comment_export
 from ..services.permissions import require_asset_access, validate_share_link
 from ..tasks.email_tasks import send_mention_email, send_comment_email
 from ..tasks.celery_app import send_task_safe
 
 router = APIRouter(tags=["comments"])
+
+EXPORT_FORMATS = {
+    "edl": ("text/plain; charset=utf-8", "edl"),
+    "fcpxml": ("application/xml", "fcpxml"),
+    "premiere_xml": ("application/xml", "xml"),
+    "csv": ("text/csv; charset=utf-8", "csv"),
+}
+_START_TC_RE = re.compile(r"^\d{2}[:;]\d{2}[:;]\d{2}[:;]\d{2}$")
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -537,6 +546,127 @@ def comment_deep_link(
 
     url = f"{settings.frontend_url}/assets/{asset_id}?comment={comment_id}"
     return {"url": url}
+
+
+@router.get("/assets/{asset_id}/comments/export")
+def export_comments(
+    asset_id: uuid.UUID,
+    format: str = Query(...),
+    version_id: Optional[uuid.UUID] = Query(default=None),
+    fps: Optional[float] = Query(default=None, gt=0),
+    start_tc: str = Query(default="01:00:00:00"),
+    include_resolved: bool = Query(default=True),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Export a version's comments as NLE timeline markers (#84):
+    Resolve marker EDL, FCPXML (Final Cut), FCP7 XML (Premiere), or CSV."""
+    if format not in EXPORT_FORMATS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported format '{format}'. Use one of: {', '.join(EXPORT_FORMATS)}",
+        )
+
+    asset = _get_asset(db, asset_id)
+    require_asset_access(db, asset, current_user)
+
+    if version_id is not None:
+        version = db.query(AssetVersion).filter(
+            AssetVersion.id == version_id,
+            AssetVersion.asset_id == asset.id,
+            AssetVersion.deleted_at.is_(None),
+        ).first()
+    else:
+        version = db.query(AssetVersion).filter(
+            AssetVersion.asset_id == asset.id,
+            AssetVersion.processing_status == ProcessingStatus.ready,
+            AssetVersion.deleted_at.is_(None),
+        ).order_by(AssetVersion.version_number.desc()).first()
+    if not version:
+        raise HTTPException(status_code=404, detail="Version not found")
+
+    spec = None
+    if format == "csv":
+        media_file = db.query(MediaFile).filter(MediaFile.version_id == version.id).first()
+        stored_fps = media_file.fps if media_file else None
+        if fps or stored_fps:
+            spec = comment_export.snap_fps(fps or stored_fps)  # None is fine for CSV
+    else:
+        if asset.asset_type != AssetType.video:
+            raise HTTPException(
+                status_code=422,
+                detail="EDL/FCPXML/Premiere XML export is only available for video assets; use format=csv",
+            )
+        media_file = db.query(MediaFile).filter(MediaFile.version_id == version.id).first()
+        effective_fps = fps or (media_file.fps if media_file else None)
+        if not effective_fps:
+            raise HTTPException(status_code=422, detail={
+                "code": "fps_required",
+                "message": "Frame rate unknown for this version; pass ?fps= "
+                           "(e.g. 23.976, 24, 25, 29.97, 30, 48, 50, 59.94, 60)",
+            })
+        spec = comment_export.snap_fps(effective_fps)
+        if spec is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unsupported frame rate {effective_fps}; supported: "
+                       + ", ".join(str(round(s.fps, 3)) for s in comment_export.FPS_TABLE),
+            )
+        if format == "edl" and not _START_TC_RE.match(start_tc):
+            raise HTTPException(status_code=422, detail="start_tc must be HH:MM:SS:FF")
+
+    comments = db.query(Comment).filter(
+        Comment.version_id == version.id,
+        Comment.deleted_at.is_(None),
+    ).order_by(Comment.created_at.asc()).all()
+
+    user_ids = {c.author_id for c in comments if c.author_id}
+    guest_ids = {c.guest_author_id for c in comments if c.guest_author_id}
+    users = {u.id: u for u in db.query(User).filter(User.id.in_(user_ids)).all()} if user_ids else {}
+    guests = {g.id: g for g in db.query(GuestUser).filter(GuestUser.id.in_(guest_ids)).all()} if guest_ids else {}
+
+    rows = []
+    for c in comments:
+        author = users.get(c.author_id) or guests.get(c.guest_author_id)
+        rows.append(comment_export.CommentRow(
+            id=str(c.id),
+            parent_id=str(c.parent_id) if c.parent_id else None,
+            author_name=(author.name or author.email) if author else "Unknown",
+            author_email=author.email if author else "",
+            body=c.body,
+            timecode_start=c.timecode_start,
+            timecode_end=c.timecode_end,
+            resolved=bool(c.resolved),
+            created_at=c.created_at,
+            version_number=version.version_number,
+        ))
+
+    duration_frames = 0
+    if spec is not None and media_file is not None and media_file.duration_seconds:
+        duration_frames = comment_export.seconds_to_frames(media_file.duration_seconds, spec)
+
+    if format == "csv":
+        if not include_resolved:
+            rows = [r for r in rows if not r.resolved]
+        content = "﻿" + comment_export.to_csv(rows, spec)  # BOM for Excel
+    else:
+        markers = comment_export.build_markers(rows, spec, include_resolved)
+        if format == "edl":
+            content = comment_export.to_edl(
+                markers, spec, comment_export.tc_to_frames(start_tc, spec), asset.name)
+        elif format == "fcpxml":
+            content = comment_export.to_fcpxml(markers, spec, asset.name, duration_frames)
+        else:
+            content = comment_export.to_premiere_xml(markers, spec, asset.name, duration_frames)
+
+    media_type, ext = EXPORT_FORMATS[format]
+    safe_name = re.sub(r"[^\w\-. ]", "_", asset.name).strip() or "asset"
+    filename = f"{safe_name}_v{version.version_number}_comments.{ext}"
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 # ── Guest comments (via share link) ───────────────────────────────────────────

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -1,8 +1,10 @@
+import logging
 import re
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
@@ -36,6 +38,8 @@ from ..services import comment_export
 from ..services.permissions import require_asset_access, validate_share_link
 from ..tasks.email_tasks import send_mention_email, send_comment_email
 from ..tasks.celery_app import send_task_safe
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["comments"])
 
@@ -612,8 +616,12 @@ def export_comments(
                 detail=f"Unsupported frame rate {effective_fps}; supported: "
                        + ", ".join(str(round(s.fps, 3)) for s in comment_export.FPS_TABLE),
             )
-        if format == "edl" and not _START_TC_RE.match(start_tc):
-            raise HTTPException(status_code=422, detail="start_tc must be HH:MM:SS:FF")
+        if format == "edl":
+            if not _START_TC_RE.match(start_tc):
+                raise HTTPException(status_code=422, detail="start_tc must be HH:MM:SS:FF")
+            hh, mm, ss, ff = (int(p) for p in re.split(r"[:;]", start_tc))
+            if not (hh <= 23 and mm < 60 and ss < 60 and ff < spec.timebase):
+                raise HTTPException(status_code=422, detail="start_tc out of range for the frame rate")
 
     comments = db.query(Comment).filter(
         Comment.version_id == version.id,
@@ -652,6 +660,13 @@ def export_comments(
     else:
         markers = comment_export.build_markers(rows, spec, include_resolved)
         if format == "edl":
+            if len(markers) > comment_export.EDL_MAX_EVENTS:
+                log.warning(
+                    "EDL export for asset %s truncated: %d markers exceed EDL_MAX_EVENTS=%d, "
+                    "%d dropped",
+                    asset_id, len(markers), comment_export.EDL_MAX_EVENTS,
+                    len(markers) - comment_export.EDL_MAX_EVENTS,
+                )
             content = comment_export.to_edl(
                 markers, spec, comment_export.tc_to_frames(start_tc, spec), asset.name)
         elif format == "fcpxml":
@@ -660,12 +675,17 @@ def export_comments(
             content = comment_export.to_premiere_xml(markers, spec, asset.name, duration_frames)
 
     media_type, ext = EXPORT_FORMATS[format]
-    safe_name = re.sub(r"[^\w\-. ]", "_", asset.name).strip() or "asset"
+    safe_name = re.sub(r"[^\w\-. ]", "_", asset.name, flags=re.ASCII).strip() or "asset"
     filename = f"{safe_name}_v{version.version_number}_comments.{ext}"
+    utf8_name = quote(f"{asset.name}_v{version.version_number}_comments.{ext}", safe="")
     return Response(
         content=content,
         media_type=media_type,
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="{filename}"; filename*=UTF-8\'\'{utf8_name}'
+            )
+        },
     )
 
 

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -187,3 +187,33 @@ def to_csv(rows: list[CommentRow], spec: Optional[FpsSpec]) -> str:
             str(r.resolved).lower(), r.created_at.isoformat(),
         ])
     return buf.getvalue()
+
+
+EDL_MAX_EVENTS = 999  # CMX 3600 hard limit
+_EDL_COLOR_OPEN = "ResolveColorBlue"
+_EDL_COLOR_RESOLVED = "ResolveColorGreen"
+
+
+def _edl_sanitize(text: str) -> str:
+    """One line, no pipes; '_' prefix when starting with a digit
+    (Resolve ignores markers whose text starts with an Arabic numeral)."""
+    text = re.sub(r"[\r\n]+", " ", text).replace("|", "/").strip()
+    if text and text[0].isdigit():
+        text = "_" + text
+    return text
+
+
+def to_edl(markers: list[Marker], spec: FpsSpec, start_tc_frames: int, title: str) -> str:
+    """Resolve 'Import Timeline Markers from EDL' flavor of CMX 3600:
+    one event line per marker (out = in + 1 frame always) followed by
+    ' |C:<color> |M:<text> |D:<frames>'."""
+    fcm = "DROP FRAME" if spec.drop_frame else "NON-DROP FRAME"
+    lines = [f"TITLE: {title}", f"FCM: {fcm}", ""]
+    for i, m in enumerate(markers[:EDL_MAX_EVENTS], start=1):
+        rec_in = frames_to_tc(start_tc_frames + m.frames, spec)
+        rec_out = frames_to_tc(start_tc_frames + m.frames + 1, spec)
+        color = _EDL_COLOR_RESOLVED if m.resolved else _EDL_COLOR_OPEN
+        text = _edl_sanitize(f"{m.text} — {m.note}" if m.note else m.text)
+        lines.append(f"{i:03d}  001      V     C        {rec_in} {rec_out} {rec_in} {rec_out}")
+        lines.append(f" |C:{color} |M:{text} |D:{m.duration_frames}")
+    return "\n".join(lines) + "\n"

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -208,6 +208,7 @@ def to_edl(markers: list[Marker], spec: FpsSpec, start_tc_frames: int, title: st
     """Resolve 'Import Timeline Markers from EDL' flavor of CMX 3600:
     one event line per marker (out = in + 1 frame always) followed by
     ' |C:<color> |M:<text> |D:<frames>'."""
+    title = re.sub(r"\s+", " ", title).strip().replace("|", "/")
     fcm = "DROP FRAME" if spec.drop_frame else "NON-DROP FRAME"
     lines = [f"TITLE: {title}", f"FCM: {fcm}", ""]
     for i, m in enumerate(markers[:EDL_MAX_EVENTS], start=1):

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -7,8 +7,11 @@ docs/superpowers/specs/2026-07-13-comment-export-nle-design.md.
 """
 from __future__ import annotations
 
+import csv
+import io
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 
@@ -86,3 +89,101 @@ def tc_to_frames(tc: str, spec: FpsSpec) -> int:
         total_min = hh * 60 + mm
         total -= drop * (total_min - total_min // 10)
     return total
+
+
+@dataclass
+class CommentRow:
+    """One comment, flattened by the router (author already resolved)."""
+    id: str
+    parent_id: Optional[str]
+    author_name: str
+    author_email: str
+    body: str
+    timecode_start: Optional[float]
+    timecode_end: Optional[float]
+    resolved: bool
+    created_at: datetime
+    version_number: int
+
+
+@dataclass
+class Marker:
+    frames: int
+    duration_frames: int
+    text: str    # "{author}: {body}", same-frame comments joined with " — "
+    note: str    # folded replies, one "— {author}: {body}" per line
+    resolved: bool
+
+
+def _descendants(parent_id: str, children_by_parent: dict) -> list[CommentRow]:
+    out: list[CommentRow] = []
+    for child in children_by_parent.get(parent_id, []):
+        out.append(child)
+        out.extend(_descendants(child.id, children_by_parent))
+    return out
+
+
+def build_markers(rows: list[CommentRow], spec: FpsSpec, include_resolved: bool = True) -> list[Marker]:
+    """Top-level timecoded comments -> markers; replies fold into the note;
+    same-frame markers merge (Resolve drops overlapping point markers)."""
+    children_by_parent: dict[str, list[CommentRow]] = {}
+    for r in rows:
+        if r.parent_id is not None:
+            children_by_parent.setdefault(r.parent_id, []).append(r)
+    for kids in children_by_parent.values():
+        kids.sort(key=lambda r: r.created_at)
+
+    by_frame: dict[int, list[tuple[CommentRow, list[CommentRow]]]] = {}
+    for r in rows:
+        if r.parent_id is not None or r.timecode_start is None:
+            continue
+        if not include_resolved and r.resolved:
+            continue
+        frames = seconds_to_frames(r.timecode_start, spec)
+        by_frame.setdefault(frames, []).append((r, _descendants(r.id, children_by_parent)))
+
+    markers: list[Marker] = []
+    for frames in sorted(by_frame):
+        texts, notes, durations, resolved_flags = [], [], [], []
+        for top, replies in by_frame[frames]:
+            texts.append(f"{top.author_name}: {top.body}")
+            notes.extend(f"— {r.author_name}: {r.body}" for r in replies)
+            if top.timecode_end is not None and top.timecode_end > top.timecode_start:
+                durations.append(max(1, seconds_to_frames(top.timecode_end, spec) - frames))
+            else:
+                durations.append(1)
+            resolved_flags.append(top.resolved)
+        markers.append(Marker(
+            frames=frames,
+            duration_frames=max(durations),
+            text=" — ".join(texts),
+            note="\n".join(notes),
+            resolved=all(resolved_flags),
+        ))
+    return markers
+
+
+CSV_COLUMNS = [
+    "comment_id", "parent_id", "version_number", "timecode_smpte",
+    "timecode_start_seconds", "timecode_end_seconds",
+    "author_name", "author_email", "body", "resolved", "created_at",
+]
+
+
+def to_csv(rows: list[CommentRow], spec: Optional[FpsSpec]) -> str:
+    """Flat chronological CSV of ALL comments (replies and untimecoded included)."""
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(CSV_COLUMNS)
+    for r in sorted(rows, key=lambda r: r.created_at):
+        smpte = ""
+        if spec is not None and r.timecode_start is not None:
+            smpte = frames_to_tc(seconds_to_frames(r.timecode_start, spec), spec)
+        w.writerow([
+            r.id, r.parent_id or "", r.version_number, smpte,
+            "" if r.timecode_start is None else r.timecode_start,
+            "" if r.timecode_end is None else r.timecode_end,
+            r.author_name, r.author_email, r.body,
+            str(r.resolved).lower(), r.created_at.isoformat(),
+        ])
+    return buf.getvalue()

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -7,13 +7,9 @@ docs/superpowers/specs/2026-07-13-comment-export-nle-design.md.
 """
 from __future__ import annotations
 
-import csv
-import io
 import re
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Optional
-from xml.etree import ElementTree as ET
 
 
 @dataclass(frozen=True)

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -258,3 +258,37 @@ def to_fcpxml(markers: list[Marker], spec: FpsSpec, asset_name: str, total_durat
         ET.SubElement(gap, "marker", attrs)
     body = ET.tostring(root, encoding="unicode")
     return '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE fcpxml>\n' + body + "\n"
+
+
+def to_premiere_xml(markers: list[Marker], spec: FpsSpec, asset_name: str, total_duration_frames: int) -> str:
+    """FCP7 interchange XML (xmeml) sequence markers — the only file-based
+    marker import path Premiere Pro supports."""
+    last_end = max((m.frames + m.duration_frames for m in markers), default=0)
+    duration = max(total_duration_frames, last_end + spec.timebase * 10)
+
+    def _rate(parent):
+        rate = ET.SubElement(parent, "rate")
+        ET.SubElement(rate, "timebase").text = str(spec.timebase)
+        ET.SubElement(rate, "ntsc").text = "TRUE" if spec.ntsc else "FALSE"
+
+    root = ET.Element("xmeml", version="4")
+    seq = ET.SubElement(root, "sequence")
+    ET.SubElement(seq, "name").text = f"{asset_name} — comments"
+    ET.SubElement(seq, "duration").text = str(duration)
+    _rate(seq)
+    tc = ET.SubElement(seq, "timecode")
+    _rate(tc)
+    ET.SubElement(tc, "string").text = "00:00:00:00"
+    ET.SubElement(tc, "frame").text = "0"
+    ET.SubElement(tc, "displayformat").text = "DF" if spec.drop_frame else "NDF"
+    media = ET.SubElement(seq, "media")
+    video = ET.SubElement(media, "video")
+    ET.SubElement(video, "track")
+    for m in markers:
+        marker = ET.SubElement(seq, "marker")
+        ET.SubElement(marker, "name").text = m.text
+        comment_text = (("[resolved] " if m.resolved else "") + m.note).strip()
+        ET.SubElement(marker, "comment").text = comment_text
+        ET.SubElement(marker, "in").text = str(m.frames)
+        ET.SubElement(marker, "out").text = str(-1 if m.duration_frames <= 1 else m.frames + m.duration_frames)
+    return '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE xmeml>\n' + ET.tostring(root, encoding="unicode") + "\n"

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -1,0 +1,92 @@
+"""Serialize review comments into NLE marker formats (#84).
+
+Pure functions only — no DB, no I/O. The router builds CommentRow objects
+and hands them here. Format research (Resolve EDL quirks, FCPXML DTD,
+Premiere xmeml) is documented in
+docs/superpowers/specs/2026-07-13-comment-export-nle-design.md.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from xml.etree import ElementTree as ET
+
+
+@dataclass(frozen=True)
+class FpsSpec:
+    """One entry of the supported frame-rate table."""
+    fps: float           # exact playback rate (e.g. 29.97002997)
+    frame_dur_num: int   # FCPXML frameDuration numerator
+    frame_dur_den: int   # FCPXML frameDuration denominator
+    timebase: int        # EDL/xmeml integer timebase (frames per TC second)
+    ntsc: bool           # xmeml <ntsc> flag
+    drop_frame: bool     # drop-frame timecode
+
+
+FPS_TABLE: list[FpsSpec] = [
+    FpsSpec(24000 / 1001, 1001, 24000, 24, True, False),   # 23.976
+    FpsSpec(24.0, 1, 24, 24, False, False),
+    FpsSpec(25.0, 1, 25, 25, False, False),
+    FpsSpec(30000 / 1001, 1001, 30000, 30, True, True),    # 29.97 DF
+    FpsSpec(30.0, 1, 30, 30, False, False),
+    FpsSpec(48.0, 1, 48, 48, False, False),
+    FpsSpec(50.0, 1, 50, 50, False, False),
+    FpsSpec(60000 / 1001, 1001, 60000, 60, True, True),    # 59.94 DF
+    FpsSpec(60.0, 1, 60, 60, False, False),
+]
+
+
+def snap_fps(fps: float) -> Optional[FpsSpec]:
+    """Snap a probed/user rate to the nearest supported spec (2% tolerance)."""
+    best = min(FPS_TABLE, key=lambda s: abs(s.fps - fps))
+    if abs(best.fps - fps) > 0.02 * best.fps:
+        return None
+    return best
+
+
+def seconds_to_frames(seconds: float, spec: FpsSpec) -> int:
+    return round(seconds * spec.fps)
+
+
+def frames_to_tc(frames: int, spec: FpsSpec) -> str:
+    """Frame count -> SMPTE timecode. Drop-frame uses ';' before FF."""
+    tb = spec.timebase
+    if spec.drop_frame:
+        drop = 2 if tb == 30 else 4
+        frames_per_min = tb * 60 - drop
+        frames_per_10min = tb * 600 - drop * 9
+        chunks, rem = divmod(frames, frames_per_10min)
+        if rem < tb * 60:
+            minute_in_chunk, frame_in_min = 0, rem
+        else:
+            rem -= tb * 60
+            minute_in_chunk = 1 + rem // frames_per_min
+            frame_in_min = rem % frames_per_min + drop
+        total_min = chunks * 10 + minute_in_chunk
+        hh, mm = divmod(total_min, 60)
+        ss, ff = divmod(frame_in_min, tb)
+    else:
+        ss_total, ff = divmod(frames, tb)
+        mm_total, ss = divmod(ss_total, 60)
+        hh, mm = divmod(mm_total, 60)
+    sep = ";" if spec.drop_frame else ":"
+    return f"{hh:02d}:{mm:02d}:{ss:02d}{sep}{ff:02d}"
+
+
+def tc_to_frames(tc: str, spec: FpsSpec) -> int:
+    """SMPTE timecode -> frame count. Accepts ':' or ';' separators."""
+    parts = re.split(r"[:;]", tc)
+    if len(parts) != 4:
+        raise ValueError(f"Bad timecode: {tc!r}")
+    hh, mm, ss, ff = (int(p) for p in parts)
+    tb = spec.timebase
+    total = (hh * 3600 + mm * 60 + ss) * tb + ff
+    if spec.drop_frame:
+        drop = 2 if tb == 30 else 4
+        total_min = hh * 60 + mm
+        total -= drop * (total_min - total_min // 10)
+    return total

--- a/apps/api/services/comment_export.py
+++ b/apps/api/services/comment_export.py
@@ -13,6 +13,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
+from xml.etree import ElementTree as ET
 
 
 @dataclass(frozen=True)
@@ -217,3 +218,43 @@ def to_edl(markers: list[Marker], spec: FpsSpec, start_tc_frames: int, title: st
         lines.append(f"{i:03d}  001      V     C        {rec_in} {rec_out} {rec_in} {rec_out}")
         lines.append(f" |C:{color} |M:{text} |D:{m.duration_frames}")
     return "\n".join(lines) + "\n"
+
+
+def _rational(frames: int, spec: FpsSpec) -> str:
+    """Frame count -> FCPXML rational seconds, always a multiple of frameDuration."""
+    return f"{frames * spec.frame_dur_num}/{spec.frame_dur_den}s"
+
+
+def to_fcpxml(markers: list[Marker], spec: FpsSpec, asset_name: str, total_duration_frames: int) -> str:
+    """FCPXML 1.9 with markers on a media-less gap (importable by FCP 10.4+)."""
+    last_end = max((m.frames + m.duration_frames for m in markers), default=0)
+    gap_frames = max(total_duration_frames, last_end + spec.timebase * 10)
+
+    root = ET.Element("fcpxml", version="1.9")
+    resources = ET.SubElement(root, "resources")
+    ET.SubElement(resources, "format", id="r1",
+                  frameDuration=f"{spec.frame_dur_num}/{spec.frame_dur_den}s",
+                  width="1920", height="1080")
+    library = ET.SubElement(root, "library")
+    event = ET.SubElement(library, "event", name="FreeFrame Comments")
+    project = ET.SubElement(event, "project", name=f"{asset_name} — comments")
+    sequence = ET.SubElement(project, "sequence", format="r1",
+                             duration=_rational(gap_frames, spec),
+                             tcStart="0s",
+                             tcFormat="DF" if spec.drop_frame else "NDF")
+    spine = ET.SubElement(sequence, "spine")
+    gap = ET.SubElement(spine, "gap", name="Gap", offset="0s", start="0s",
+                        duration=_rational(gap_frames, spec))
+    for m in markers:
+        attrs = {
+            "start": _rational(m.frames, spec),
+            "duration": _rational(m.duration_frames, spec),
+            "value": m.text,
+        }
+        if m.note:
+            attrs["note"] = m.note
+        if m.resolved:
+            attrs["completed"] = "1"
+        ET.SubElement(gap, "marker", attrs)
+    body = ET.tostring(root, encoding="unicode")
+    return '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE fcpxml>\n' + body + "\n"

--- a/apps/api/tests/test_comment_export_formats.py
+++ b/apps/api/tests/test_comment_export_formats.py
@@ -85,3 +85,32 @@ def test_fcpxml_gap_extends_past_last_marker_when_duration_unknown():
     xml = to_fcpxml([_marker(frames=1000)], SPEC25, "D", total_duration_frames=0)
     gap = _fcpxml_root(xml).find(".//gap")
     assert gap.get("duration") == f"{1000 + 1 + 250}/25s"
+
+
+from apps.api.services.comment_export import to_premiere_xml
+
+
+def _xmeml_seq(xml: str):
+    assert xml.startswith('<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE xmeml>\n')
+    return ET.fromstring(xml.split("<!DOCTYPE xmeml>\n", 1)[1]).find("sequence")
+
+
+def test_xmeml_point_marker_and_rate():
+    seq = _xmeml_seq(to_premiere_xml([_marker()], SPEC25, "Demo", 1500))
+    assert seq.find("rate/timebase").text == "25"
+    assert seq.find("rate/ntsc").text == "FALSE"
+    marker = seq.find("marker")
+    assert marker.find("name").text == "Jane: Fix the logo"
+    assert marker.find("in").text == "63"
+    assert marker.find("out").text == "-1"
+
+
+def test_xmeml_ntsc_range_and_resolved_prefix():
+    df = snap_fps(29.97)
+    seq = _xmeml_seq(to_premiere_xml(
+        [_marker(frames=100, duration=30, resolved=True, note="— Bob: ok")], df, "D", 0))
+    assert seq.find("rate/timebase").text == "30"
+    assert seq.find("rate/ntsc").text == "TRUE"
+    marker = seq.find("marker")
+    assert marker.find("out").text == "130"
+    assert marker.find("comment").text == "[resolved] — Bob: ok"

--- a/apps/api/tests/test_comment_export_formats.py
+++ b/apps/api/tests/test_comment_export_formats.py
@@ -2,7 +2,7 @@
 from xml.etree import ElementTree as ET
 
 from apps.api.services.comment_export import (
-    Marker, snap_fps, tc_to_frames, to_edl,
+    Marker, snap_fps, tc_to_frames, to_edl, to_fcpxml,
 )
 
 SPEC25 = snap_fps(25.0)
@@ -48,3 +48,40 @@ def test_edl_caps_at_999_events():
     markers = [_marker(frames=i * 10) for i in range(1200)]
     edl = to_edl(markers, SPEC25, 0, "T")
     assert edl.count("|M:") == 999
+
+
+def _fcpxml_root(xml: str):
+    assert xml.startswith('<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE fcpxml>\n')
+    return ET.fromstring(xml.split("<!DOCTYPE fcpxml>\n", 1)[1])
+
+
+def test_fcpxml_structure_and_rational_times():
+    xml = to_fcpxml([_marker()], SPEC25, "Demo", total_duration_frames=1500)
+    root = _fcpxml_root(xml)
+    assert root.tag == "fcpxml" and root.get("version") == "1.9"
+    fmt = root.find("./resources/format")
+    assert fmt.get("frameDuration") == "1/25s"
+    gap = root.find("./library/event/project/sequence/spine/gap")
+    assert gap.get("duration") == "1500/25s"
+    marker = gap.find("marker")
+    assert marker.get("start") == "63/25s"
+    assert marker.get("duration") == "1/25s"
+    assert marker.get("value") == "Jane: Fix the logo"
+    assert marker.get("completed") is None
+
+
+def test_fcpxml_ntsc_frame_duration_and_completed():
+    df = snap_fps(29.97)
+    xml = to_fcpxml([_marker(frames=100, resolved=True, note="— Bob: ok")], df, "D", 0)
+    root = _fcpxml_root(xml)
+    assert root.find("./resources/format").get("frameDuration") == "1001/30000s"
+    marker = root.find(".//marker")
+    assert marker.get("start") == "100100/30000s"
+    assert marker.get("completed") == "1"
+    assert marker.get("note") == "— Bob: ok"
+
+
+def test_fcpxml_gap_extends_past_last_marker_when_duration_unknown():
+    xml = to_fcpxml([_marker(frames=1000)], SPEC25, "D", total_duration_frames=0)
+    gap = _fcpxml_root(xml).find(".//gap")
+    assert gap.get("duration") == f"{1000 + 1 + 250}/25s"

--- a/apps/api/tests/test_comment_export_formats.py
+++ b/apps/api/tests/test_comment_export_formats.py
@@ -1,0 +1,50 @@
+"""Format serializers for comment export (#84): EDL, FCPXML, xmeml."""
+from xml.etree import ElementTree as ET
+
+from apps.api.services.comment_export import (
+    Marker, snap_fps, tc_to_frames, to_edl,
+)
+
+SPEC25 = snap_fps(25.0)
+START = "01:00:00:00"
+
+
+def _marker(frames=63, duration=1, text="Jane: Fix the logo", note="", resolved=False):
+    return Marker(frames=frames, duration_frames=duration, text=text, note=note, resolved=resolved)
+
+
+def test_edl_golden_25fps():
+    edl = to_edl([_marker()], SPEC25, tc_to_frames(START, SPEC25), "Demo Asset")
+    assert edl == (
+        "TITLE: Demo Asset\n"
+        "FCM: NON-DROP FRAME\n"
+        "\n"
+        "001  001      V     C        01:00:02:13 01:00:02:14 01:00:02:13 01:00:02:14\n"
+        " |C:ResolveColorBlue |M:Jane: Fix the logo |D:1\n"
+    )
+
+
+def test_edl_drop_frame_header_and_semicolons():
+    df = snap_fps(29.97)
+    edl = to_edl([_marker(frames=1800)], df, 0, "T")
+    assert "FCM: DROP FRAME" in edl
+    assert "00:01:00;02" in edl
+
+
+def test_edl_sanitizes_pipes_newlines_and_leading_digit():
+    edl = to_edl([_marker(text="2nd pass | fix\nthis", note="— Bob: ok")], SPEC25, 0, "T")
+    marker_line = [l for l in edl.splitlines() if l.startswith(" |C:")][0]
+    assert "|M:_2nd pass / fix this — — Bob: ok " in marker_line
+    assert marker_line.count("|") == 3  # only the three field separators
+
+
+def test_edl_resolved_marker_is_green_and_range_keeps_duration():
+    edl = to_edl([_marker(duration=50, resolved=True)], SPEC25, 0, "T")
+    assert "|C:ResolveColorGreen" in edl
+    assert "|D:50" in edl
+
+
+def test_edl_caps_at_999_events():
+    markers = [_marker(frames=i * 10) for i in range(1200)]
+    edl = to_edl(markers, SPEC25, 0, "T")
+    assert edl.count("|M:") == 999

--- a/apps/api/tests/test_comment_export_markers.py
+++ b/apps/api/tests/test_comment_export_markers.py
@@ -1,0 +1,56 @@
+"""Marker building for comment export (#84): folding, merging, CSV."""
+from datetime import datetime, timezone
+
+from apps.api.services.comment_export import CommentRow, build_markers, snap_fps, to_csv
+
+SPEC = snap_fps(25.0)
+
+
+def _row(i, *, parent=None, tc=None, tc_end=None, resolved=False, body="Note", author="Jane"):
+    return CommentRow(
+        id=f"c{i}", parent_id=parent, author_name=author,
+        author_email=f"{author.lower()}@x.io", body=body,
+        timecode_start=tc, timecode_end=tc_end, resolved=resolved,
+        created_at=datetime(2026, 7, 13, 12, 0, i, tzinfo=timezone.utc),
+        version_number=2,
+    )
+
+
+def test_marker_with_folded_nested_replies():
+    rows = [
+        _row(1, tc=2.52, body="Fix the logo"),
+        _row(2, parent="c1", author="Bob", body="Agreed"),
+        _row(3, parent="c2", author="Jane", body="Done"),
+    ]
+    (m,) = build_markers(rows, SPEC)
+    assert m.frames == 63
+    assert m.text == "Jane: Fix the logo"
+    assert m.note == "— Bob: Agreed\n— Jane: Done"
+
+
+def test_same_frame_comments_merge_into_one_marker():
+    rows = [_row(1, tc=1.0, body="A"), _row(2, tc=1.0, body="B")]
+    (m,) = build_markers(rows, SPEC)
+    assert m.text == "Jane: A — Jane: B"
+
+
+def test_range_duration_and_resolved_filter():
+    rows = [_row(1, tc=1.0, tc_end=3.0), _row(2, tc=5.0, resolved=True)]
+    markers = build_markers(rows, SPEC, include_resolved=False)
+    assert len(markers) == 1
+    assert markers[0].duration_frames == 50
+
+
+def test_untimecoded_excluded_from_markers_but_in_csv():
+    rows = [_row(1, tc=None, body="General note")]
+    assert build_markers(rows, SPEC) == []
+    csv_text = to_csv(rows, SPEC)
+    assert "General note" in csv_text
+    assert csv_text.splitlines()[0].startswith("comment_id,")
+
+
+def test_csv_smpte_column_blank_without_spec():
+    csv_text = to_csv([_row(1, tc=2.0)], None)
+    line = csv_text.splitlines()[1]
+    assert ",2.0," in line       # seconds still present
+    assert ",00:00:" not in line  # no SMPTE without fps

--- a/apps/api/tests/test_comment_export_timecode.py
+++ b/apps/api/tests/test_comment_export_timecode.py
@@ -37,3 +37,12 @@ def test_snap_fps():
 def test_seconds_to_frames():
     assert seconds_to_frames(10.0, spec_for(60, False)) == 600
     assert seconds_to_frames(2.52, spec_for(25, False)) == 63
+
+
+def test_df_5994_known_vectors():
+    df = spec_for(60, True)
+    assert frames_to_tc(3600, df) == "00:01:00;04"
+    assert tc_to_frames("00:01:00;04", df) == 3600
+    # one hour @ 59.94 DF = 215,784 frames (industry reference constant)
+    assert tc_to_frames("01:00:00;00", df) == 215784
+    assert frames_to_tc(215784, df) == "01:00:00;00"

--- a/apps/api/tests/test_comment_export_timecode.py
+++ b/apps/api/tests/test_comment_export_timecode.py
@@ -1,0 +1,39 @@
+"""Timecode math for comment export (#84): NDF/DF conversion, fps snapping."""
+from apps.api.services.comment_export import (
+    FPS_TABLE, frames_to_tc, seconds_to_frames, snap_fps, tc_to_frames,
+)
+
+
+def spec_for(timebase, drop):
+    return next(s for s in FPS_TABLE if s.timebase == timebase and s.drop_frame == drop)
+
+
+def test_ndf_25fps_one_hour():
+    assert frames_to_tc(90000, spec_for(25, False)) == "01:00:00:00"
+
+
+def test_df_2997_known_vectors():
+    df = spec_for(30, True)
+    assert frames_to_tc(1799, df) == "00:00:59;29"
+    assert frames_to_tc(1800, df) == "00:01:00;02"
+    assert frames_to_tc(17982, df) == "00:10:00;00"
+
+
+def test_tc_to_frames_roundtrip_df():
+    df = spec_for(30, True)
+    assert tc_to_frames("00:01:00;02", df) == 1800
+    assert tc_to_frames("01:00:00:00", df) == tc_to_frames("01:00:00;00", df)
+    assert frames_to_tc(tc_to_frames("01:00:00;00", df), df) == "01:00:00;00"
+
+
+def test_snap_fps():
+    assert snap_fps(29.97).drop_frame is True
+    assert snap_fps(23.976).frame_dur_den == 24000
+    assert snap_fps(25.0).timebase == 25
+    assert snap_fps(12.0) is None
+    assert snap_fps(120.0) is None
+
+
+def test_seconds_to_frames():
+    assert seconds_to_frames(10.0, spec_for(60, False)) == 600
+    assert seconds_to_frames(2.52, spec_for(25, False)) == 63

--- a/apps/api/tests/test_comments_export_endpoint.py
+++ b/apps/api/tests/test_comments_export_endpoint.py
@@ -1,0 +1,117 @@
+"""Export endpoint (#84): dispatch, fps precedence, errors."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from apps.api.models.asset import AssetType, ProcessingStatus
+
+
+def _asset(asset_type=AssetType.video):
+    a = MagicMock()
+    a.id = uuid.uuid4()
+    a.name = "Demo Asset"
+    a.asset_type = asset_type
+    a.deleted_at = None
+    return a
+
+
+def _version(n=2):
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.version_number = n
+    v.processing_status = ProcessingStatus.ready
+    v.deleted_at = None
+    return v
+
+
+def _media(fps=25.0, duration=60.0):
+    m = MagicMock()
+    m.fps = fps
+    m.duration_seconds = duration
+    return m
+
+
+def _comment(body="Fix logo", tc=2.52):
+    c = MagicMock()
+    c.id = uuid.uuid4()
+    c.parent_id = None
+    c.author_id = None
+    c.guest_author_id = None
+    c.body = body
+    c.timecode_start = tc
+    c.timecode_end = None
+    c.resolved = False
+    c.created_at = datetime(2026, 7, 13, tzinfo=timezone.utc)
+    return c
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_edl_export_happy_path(_, client, mock_db, auth_headers):
+    asset, version = _asset(), _version()
+    mock_db.first.side_effect = [asset, version, _media()]
+    mock_db.order_by.return_value = mock_db
+    mock_db.all.side_effect = [[_comment()]]
+
+    r = client.get(f"/assets/{asset.id}/comments/export?format=edl&version_id={version.id}",
+                   headers=auth_headers)
+
+    assert r.status_code == 200
+    assert r.headers["content-disposition"] == 'attachment; filename="Demo Asset_v2_comments.edl"'
+    assert "TITLE: Demo Asset" in r.text
+    assert "|M:Unknown: Fix logo" in r.text
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_fps_required_when_unknown(_, client, mock_db, auth_headers):
+    asset, version = _asset(), _version()
+    mock_db.first.side_effect = [asset, version, _media(fps=None)]
+
+    r = client.get(f"/assets/{asset.id}/comments/export?format=edl&version_id={version.id}",
+                   headers=auth_headers)
+
+    assert r.status_code == 422
+    assert r.json()["detail"]["code"] == "fps_required"
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_fps_override_beats_missing_stored_fps(_, client, mock_db, auth_headers):
+    asset, version = _asset(), _version()
+    mock_db.first.side_effect = [asset, version, _media(fps=None)]
+    mock_db.order_by.return_value = mock_db
+    mock_db.all.side_effect = [[_comment()]]
+
+    r = client.get(f"/assets/{asset.id}/comments/export?format=edl&version_id={version.id}&fps=25",
+                   headers=auth_headers)
+    assert r.status_code == 200
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_nle_rejected_for_audio_but_csv_allowed(_, client, mock_db, auth_headers):
+    asset, version = _asset(AssetType.audio), _version()
+    mock_db.first.side_effect = [asset, version]
+    r = client.get(f"/assets/{asset.id}/comments/export?format=edl&version_id={version.id}",
+                   headers=auth_headers)
+    assert r.status_code == 422
+
+    mock_db.first.side_effect = [asset, version, _media(fps=None, duration=None)]
+    mock_db.order_by.return_value = mock_db
+    mock_db.all.side_effect = [[_comment()]]
+    r = client.get(f"/assets/{asset.id}/comments/export?format=csv&version_id={version.id}",
+                   headers=auth_headers)
+    assert r.status_code == 200
+    assert r.text.lstrip("﻿").startswith("comment_id,")
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_unknown_format_422(_, client, mock_db, auth_headers):
+    r = client.get(f"/assets/{uuid.uuid4()}/comments/export?format=avid", headers=auth_headers)
+    assert r.status_code == 422
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_version_not_found_404(_, client, mock_db, auth_headers):
+    asset = _asset()
+    mock_db.first.side_effect = [asset, None]
+    r = client.get(f"/assets/{asset.id}/comments/export?format=edl&version_id={uuid.uuid4()}",
+                   headers=auth_headers)
+    assert r.status_code == 404

--- a/apps/api/tests/test_comments_export_endpoint.py
+++ b/apps/api/tests/test_comments_export_endpoint.py
@@ -156,3 +156,26 @@ def test_start_tc_out_of_range_422(_, client, mock_db, auth_headers):
 
     assert r.status_code == 422
     assert "out of range" in r.json()["detail"]
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_cors_exposes_content_disposition(_, client, mock_db, auth_headers):
+    """Cross-origin JS can only read the export filename if CORS exposes the header.
+    Verify via a live CORS preflight/response with Origin header."""
+    asset, version = _asset(), _version()
+    mock_db.first.side_effect = [asset, version, _media()]
+    mock_db.order_by.return_value = mock_db
+    mock_db.all.side_effect = [[_comment()]]
+
+    # Send request with Origin header (simulates cross-origin fetch)
+    r = client.get(
+        f"/assets/{asset.id}/comments/export?format=edl&version_id={version.id}",
+        headers={**auth_headers, "Origin": "http://localhost:3000"},
+    )
+
+    assert r.status_code == 200
+    # Content-Disposition is set by the endpoint
+    assert "content-disposition" in r.headers
+    # CORS expose-headers makes it readable by cross-origin JS
+    assert "access-control-expose-headers" in r.headers
+    assert "Content-Disposition" in r.headers["access-control-expose-headers"]

--- a/apps/api/tests/test_comments_export_endpoint.py
+++ b/apps/api/tests/test_comments_export_endpoint.py
@@ -56,7 +56,10 @@ def test_edl_export_happy_path(_, client, mock_db, auth_headers):
                    headers=auth_headers)
 
     assert r.status_code == 200
-    assert r.headers["content-disposition"] == 'attachment; filename="Demo Asset_v2_comments.edl"'
+    assert r.headers["content-disposition"] == (
+        'attachment; filename="Demo Asset_v2_comments.edl"; '
+        "filename*=UTF-8''Demo%20Asset_v2_comments.edl"
+    )
     assert "TITLE: Demo Asset" in r.text
     assert "|M:Unknown: Fix logo" in r.text
 
@@ -115,3 +118,41 @@ def test_version_not_found_404(_, client, mock_db, auth_headers):
     r = client.get(f"/assets/{asset.id}/comments/export?format=edl&version_id={uuid.uuid4()}",
                    headers=auth_headers)
     assert r.status_code == 404
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_cjk_asset_name_export_does_not_crash(_, client, mock_db, auth_headers):
+    """Non-ASCII asset names must not 500 (Content-Disposition is latin-1 only);
+    the ASCII fallback filename is underscored, and the RFC 5987 filename*
+    part carries the real UTF-8 name for browsers that support it."""
+    asset, version = _asset(), _version()
+    asset.name = "デモ動画 v2"
+    mock_db.first.side_effect = [asset, version, _media()]
+    mock_db.order_by.return_value = mock_db
+    mock_db.all.side_effect = [[_comment()]]
+
+    r = client.get(f"/assets/{asset.id}/comments/export?format=edl&version_id={version.id}",
+                   headers=auth_headers)
+
+    assert r.status_code == 200
+    disposition = r.headers["content-disposition"]
+    assert 'filename="____ v2_v2_comments.edl"' in disposition
+    assert "filename*=UTF-8''" in disposition
+    assert disposition.isascii()
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_start_tc_out_of_range_422(_, client, mock_db, auth_headers):
+    """start_tc=99:99:99:99 satisfies the HH:MM:SS:FF regex but every field
+    is out of range for any supported frame rate."""
+    asset, version = _asset(), _version()
+    mock_db.first.side_effect = [asset, version, _media()]
+
+    r = client.get(
+        f"/assets/{asset.id}/comments/export?format=edl&version_id={version.id}"
+        "&start_tc=99:99:99:99",
+        headers=auth_headers,
+    )
+
+    assert r.status_code == 422
+    assert "out of range" in r.json()["detail"]

--- a/apps/api/tests/test_comments_export_endpoint.py
+++ b/apps/api/tests/test_comments_export_endpoint.py
@@ -99,7 +99,7 @@ def test_nle_rejected_for_audio_but_csv_allowed(_, client, mock_db, auth_headers
     r = client.get(f"/assets/{asset.id}/comments/export?format=csv&version_id={version.id}",
                    headers=auth_headers)
     assert r.status_code == 200
-    assert r.text.lstrip("﻿").startswith("comment_id,")
+    assert r.text.lstrip("\ufeff").startswith("comment_id,")
 
 
 @patch("apps.api.routers.comments.require_asset_access")


### PR DESCRIPTION
## Summary

Adds `GET /assets/{asset_id}/comments/export?format=edl|fcpxml|premiere_xml|csv` — turns a version's timecoded review comments into timeline markers editors can import directly into their NLE (part of #84; the issue closes with the frontend PR that follows).

## Formats

- **DaVinci Resolve** — marker EDL (`Timelines → Import → Timeline Markers from EDL`; match the timeline start TC, default `01:00:00:00`, overridable via `start_tc`). Blue markers for open comments, green for resolved; ranges carry their real duration in `|D:`.
- **Final Cut Pro** — FCPXML 1.9 with markers on a media-less gap; resolved comments become completed to-dos.
- **Premiere Pro** — FCP7 XML sequence markers (Premiere cannot import FCPXML — this is its only file-based marker path).
- **CSV** — universal fallback, works for all asset types and never needs a frame rate.

Replies fold into the marker note in thread order; same-frame comments merge (Resolve drops overlapping point markers). Frame rate comes from stored `MediaFile.fps` (#124) with a `?fps=` override; proper drop-frame timecode for 29.97/59.94. CORS now exposes `Content-Disposition` so the web app can read the download filename (found during real-browser verification).

## Product notes (conscious acceptances)

- Exports include internal-visibility comments — same behavior as the authenticated comments list. A `?visibility=` filter is a candidate follow-up.
- The CSV includes an `author_email` column (useful for round-tripping feedback; slightly more exposure than the in-app API, which hides member emails). Flagging for awareness.
- VFR sources (phone footage): markers can land ±1 frame — documented in CHANGELOG.

## Verification

- Full API suite passing with zero failures.
- Serializer golden tests hand-verified in review: EDL byte-exact vector, drop-frame math against industry hour constants (107,892 @ 29.97; 215,784 @ 59.94), FCPXML rationals, xmeml range math.
- Live HTTP smoke against the dev stack: all four formats' real output verified, `fps_required` 422 + `?fps=` override, two-part `Content-Disposition` (ASCII fallback + RFC 5987 UTF-8 filename — non-Latin asset names crash-tested with CJK).

Part of #84 · Depends on #124's metadata fix
