### PR TITLE
feat: export comments menu in the review panel (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Export comments as NLE timeline markers** ([#84](https://github.com/Techiebutler/freeframe/issues/84)) — `GET /assets/{id}/comments/export?format=edl|fcpxml|premiere_xml|csv` turns a version's timecoded comments into importable markers for DaVinci Resolve (marker EDL — import via Timelines → Import → Timeline Markers from EDL, matching the timeline start TC, default 01:00:00:00), Final Cut Pro (FCPXML), and Premiere Pro (FCP7 XML — Premiere cannot import FCPXML), plus CSV. Uses the stored frame rate (see #124) with a `?fps=` override. Note: variable-frame-rate sources may land markers ±1 frame.
+- **Export comments menu in the review panel** ([#84](https://github.com/Techiebutler/freeframe/issues/84)) — download markers for Resolve/Final Cut/Premiere/CSV from the comment panel toolbar; prompts for frame rate when the video predates the metadata backfill.
 
 ### Fixed
 - **Transcode pipeline now persists media metadata** ([#124](https://github.com/Techiebutler/freeframe/issues/124)) — `duration_seconds`, `width`, `height`, and `fps` are stored on every new video/audio transcode (previously always NULL, breaking duration display). Existing files: run the one-off backfill — `docker exec freeframe-api-1 python -m apps.api.scripts.backfill_media_metadata`.

--- a/apps/web/components/review/__tests__/fps-prompt-dialog.test.tsx
+++ b/apps/web/components/review/__tests__/fps-prompt-dialog.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FpsPromptDialog } from '../fps-prompt-dialog'
+
+describe('FpsPromptDialog (#84)', () => {
+  it('does not render its content when closed', () => {
+    render(
+      <FpsPromptDialog open={false} onOpenChange={vi.fn()} onConfirm={vi.fn()} />,
+    )
+
+    expect(screen.queryByText('Frame rate needed')).not.toBeInTheDocument()
+  })
+
+  it('renders all 9 fps options when open', () => {
+    render(
+      <FpsPromptDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />,
+    )
+
+    expect(screen.getByText('Frame rate needed')).toBeInTheDocument()
+    for (const option of [23.976, 24, 25, 29.97, 30, 48, 50, 59.94, 60]) {
+      expect(screen.getByText(String(option))).toBeInTheDocument()
+    }
+  })
+
+  it('selecting a preset then confirming exports that fps and closes the dialog', () => {
+    const onConfirm = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <FpsPromptDialog open onOpenChange={onOpenChange} onConfirm={onConfirm} />,
+    )
+
+    fireEvent.click(screen.getByText('29.97'))
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    expect(onConfirm).toHaveBeenCalledWith(29.97)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('cancel closes the dialog without confirming', () => {
+    const onConfirm = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <FpsPromptDialog open onOpenChange={onOpenChange} onConfirm={onConfirm} />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/components/review/comment-panel.tsx
+++ b/apps/web/components/review/comment-panel.tsx
@@ -26,10 +26,17 @@ import {
   Check,
   Send,
   Lock,
+  Download,
 } from "lucide-react";
 import { cn, formatTime, formatRelativeTime } from "@/lib/utils";
 import { useReviewStore } from "@/stores/review-store";
 import type { CommentWithReplies } from "@/hooks/use-comments";
+import {
+  exportComments,
+  FpsRequiredError,
+  type ExportFormat,
+} from "@/lib/export-comments";
+import { FpsPromptDialog } from "@/components/review/fps-prompt-dialog";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -761,6 +768,8 @@ export function CommentPanel({
   const focusedCommentId = useReviewStore((s) => s.focusedCommentId);
   const setFocusedCommentId = useReviewStore((s) => s.setFocusedCommentId);
   const setActiveAnnotation = useReviewStore((s) => s.setActiveAnnotation);
+  const currentAsset = useReviewStore((s) => s.currentAsset);
+  const currentVersion = useReviewStore((s) => s.currentVersion);
 
   // Toolbar state
   const [visibility, setVisibility] = React.useState<CommentVisibility>("all");
@@ -772,6 +781,9 @@ export function CommentPanel({
   const [sortMode, setSortMode] = React.useState<SortMode>("oldest");
   const [filters, setFilters] = React.useState<FilterState>(EMPTY_FILTERS);
   const [replyingTo, setReplyingTo] = React.useState<string | null>(null);
+  const [exportOpen, setExportOpen] = React.useState(false);
+  const [fpsPromptFormat, setFpsPromptFormat] =
+    React.useState<ExportFormat | null>(null);
 
   const searchRef = React.useRef<HTMLInputElement>(null);
 
@@ -871,7 +883,27 @@ export function CommentPanel({
     onReply(parentId);
   }
 
+  async function handleExport(format: ExportFormat, fps?: number) {
+    if (!currentAsset || !currentVersion) return;
+    setExportOpen(false);
+    try {
+      await exportComments({
+        assetId: currentAsset.id,
+        versionId: currentVersion.id,
+        format,
+        fps,
+      });
+    } catch (err) {
+      if (err instanceof FpsRequiredError) {
+        setFpsPromptFormat(format);
+      } else {
+        console.error(err);
+      }
+    }
+  }
+
   return (
+    <>
     <div className={cn("flex flex-col flex-1 min-h-0", className)}>
       {/* ─── Toolbar ──────────────────────────────────────────────── */}
       <div className="flex items-center justify-between px-4 py-2.5 shrink-0">
@@ -1114,6 +1146,64 @@ export function CommentPanel({
             <Search className="h-4 w-4" />
           </button>
 
+          {/* Export */}
+          <div className="relative">
+            <button
+              className={cn(
+                "h-7 w-7 flex items-center justify-center rounded-md transition-colors",
+                exportOpen
+                  ? "text-accent bg-accent/10"
+                  : "text-text-tertiary hover:text-text-secondary hover:bg-bg-tertiary",
+              )}
+              title="Export comments"
+              onClick={() => {
+                setExportOpen((p) => !p);
+                setVisOpen(false);
+                setFilterOpen(false);
+                setSortOpen(false);
+              }}
+            >
+              <Download className="h-4 w-4" />
+            </button>
+            <Dropdown
+              open={exportOpen}
+              onClose={() => setExportOpen(false)}
+              align="right"
+              className="w-56"
+            >
+              <div className="px-3 py-2 text-[11px] text-text-tertiary uppercase tracking-wider font-medium">
+                Export comments
+              </div>
+              {currentAsset?.asset_type === "video" && (
+                <>
+                  <button
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-text-secondary hover:bg-bg-tertiary transition-colors"
+                    onClick={() => handleExport("edl")}
+                  >
+                    DaVinci Resolve (EDL)
+                  </button>
+                  <button
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-text-secondary hover:bg-bg-tertiary transition-colors"
+                    onClick={() => handleExport("fcpxml")}
+                  >
+                    Final Cut Pro (FCPXML)
+                  </button>
+                  <button
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-text-secondary hover:bg-bg-tertiary transition-colors"
+                    onClick={() => handleExport("premiere_xml")}
+                  >
+                    Premiere Pro (XML)
+                  </button>
+                </>
+              )}
+              <button
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-text-secondary hover:bg-bg-tertiary transition-colors"
+                onClick={() => handleExport("csv")}
+              >
+                CSV
+              </button>
+            </Dropdown>
+          </div>
         </div>
       </div>
 
@@ -1194,5 +1284,13 @@ export function CommentPanel({
           ))}
       </div>
     </div>
+    <FpsPromptDialog
+      open={fpsPromptFormat !== null}
+      onOpenChange={(open) => !open && setFpsPromptFormat(null)}
+      onConfirm={(fps) =>
+        fpsPromptFormat && handleExport(fpsPromptFormat, fps)
+      }
+    />
+    </>
   );
 }

--- a/apps/web/components/review/comment-panel.tsx
+++ b/apps/web/components/review/comment-panel.tsx
@@ -884,8 +884,8 @@ export function CommentPanel({
   }
 
   async function handleExport(format: ExportFormat, fps?: number) {
-    if (!currentAsset || !currentVersion) return;
     setExportOpen(false);
+    if (!currentAsset || !currentVersion) return;
     try {
       await exportComments({
         assetId: currentAsset.id,

--- a/apps/web/components/review/fps-prompt-dialog.tsx
+++ b/apps/web/components/review/fps-prompt-dialog.tsx
@@ -29,8 +29,10 @@ export function FpsPromptDialog({
             Frame rate needed
           </Dialog.Title>
           <Dialog.Description className="mt-1 text-xs text-text-tertiary">
-            This video has no stored frame rate. Pick the source frame rate so
-            markers land on the right frames.
+            This video was uploaded before FreeFrame started capturing frame
+            rates automatically, so its fps isn&apos;t on file. Pick the
+            video&apos;s original frame rate so exported markers land on the
+            correct frames. (Newly uploaded videos won&apos;t ask this.)
           </Dialog.Description>
 
           <div className="mt-3 grid grid-cols-3 gap-1.5">

--- a/apps/web/components/review/fps-prompt-dialog.tsx
+++ b/apps/web/components/review/fps-prompt-dialog.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import * as React from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+
+const FPS_OPTIONS = [23.976, 24, 25, 29.97, 30, 48, 50, 59.94, 60]
+
+interface FpsPromptDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: (fps: number) => void
+}
+
+export function FpsPromptDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: FpsPromptDialogProps) {
+  const [fps, setFps] = React.useState<number>(25)
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-bg-secondary p-5 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          <Dialog.Title className="text-sm font-semibold text-text-primary">
+            Frame rate needed
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-xs text-text-tertiary">
+            This video has no stored frame rate. Pick the source frame rate so
+            markers land on the right frames.
+          </Dialog.Description>
+
+          <div className="mt-3 grid grid-cols-3 gap-1.5">
+            {FPS_OPTIONS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={fps === option}
+                onClick={() => setFps(option)}
+                className={cn(
+                  'rounded-md border px-2 py-1.5 text-[13px] font-medium transition-colors',
+                  fps === option
+                    ? 'border-accent bg-accent-muted text-accent'
+                    : 'border-border text-text-secondary hover:bg-bg-hover',
+                )}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-4 flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                onConfirm(fps)
+                onOpenChange(false)
+              }}
+            >
+              Export
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/web/lib/__tests__/export-comments.test.ts
+++ b/apps/web/lib/__tests__/export-comments.test.ts
@@ -1,20 +1,46 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../auth', () => ({ getAccessToken: () => 'tok-123' }))
 
 import { exportComments, FpsRequiredError } from '../export-comments'
 
 function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}) {
+  const blob = new Blob(['data'])
   const res = {
     ok: status >= 200 && status < 300,
     status,
     headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
     json: async () => body,
-    blob: async () => new Blob(['data']),
+    blob: async () => blob,
   }
   const fn = vi.fn(async () => res)
   vi.stubGlobal('fetch', fn)
-  return fn
+  return Object.assign(fn, { blob })
+}
+
+/**
+ * Spies on document.createElement, delegating to the real implementation so
+ * jsdom gives us a genuine <a> element, while recording it (and stubbing its
+ * click()) so we can assert on download attribute / click invocation without
+ * triggering a real navigation.
+ */
+function spyOnAnchorCreation() {
+  const originalCreateElement = document.createElement.bind(document)
+  let anchor: HTMLAnchorElement | undefined
+  const spy = vi
+    .spyOn(document, 'createElement')
+    .mockImplementation(((tagName: string) => {
+      const el = originalCreateElement(tagName as keyof HTMLElementTagNameMap)
+      if (tagName === 'a') {
+        anchor = el as HTMLAnchorElement
+        vi.spyOn(anchor, 'click').mockImplementation(() => {})
+      }
+      return el
+    }) as typeof document.createElement)
+  return {
+    spy,
+    getAnchor: () => anchor,
+  }
 }
 
 describe('exportComments', () => {
@@ -25,6 +51,11 @@ describe('exportComments', () => {
       createObjectURL: vi.fn(() => 'blob:x'),
       revokeObjectURL: vi.fn(),
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   it('calls the export endpoint with auth and params', async () => {
@@ -59,5 +90,56 @@ describe('exportComments', () => {
     await expect(
       exportComments({ assetId: 'a1', versionId: 'v1', format: 'csv' }),
     ).rejects.toThrow('Export failed (500)')
+  })
+
+  it('throws an Error carrying the exact string detail for a non-fps 422 (and not an FpsRequiredError)', async () => {
+    const detailMessage =
+      'EDL/FCPXML/Premiere XML export is only available for video assets; use format=csv'
+    mockFetch(422, { detail: detailMessage })
+
+    let caught: unknown
+    try {
+      await exportComments({ assetId: 'a1', versionId: 'v1', format: 'edl' })
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(Error)
+    expect(caught).not.toBeInstanceOf(FpsRequiredError)
+    expect((caught as Error).message).toBe(detailMessage)
+  })
+
+  it('creates an object URL from the response blob, downloads it under the server-supplied filename, and revokes the URL after the cleanup delay', async () => {
+    vi.useFakeTimers()
+    const fetchFn = mockFetch(200, null, {
+      'content-disposition':
+        'attachment; filename="Demo Asset_v2_comments.edl"; filename*=UTF-8\'\'Demo%20Asset_v2_comments.edl',
+    })
+    const { getAnchor } = spyOnAnchorCreation()
+
+    await exportComments({ assetId: 'a1', versionId: 'v2', format: 'edl' })
+
+    const anchor = getAnchor()
+    expect(anchor).toBeDefined()
+    expect(anchor?.download).toBe('Demo Asset_v2_comments.edl')
+    expect(anchor?.click).toHaveBeenCalledTimes(1)
+    expect(URL.createObjectURL).toHaveBeenCalledWith(fetchFn.blob)
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1000)
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:x')
+  })
+
+  it('falls back to a format-based filename when no Content-Disposition header is present', async () => {
+    vi.useFakeTimers()
+    mockFetch(200, null)
+    const { getAnchor } = spyOnAnchorCreation()
+
+    await exportComments({ assetId: 'a1', versionId: 'v1', format: 'premiere_xml' })
+
+    expect(getAnchor()?.download).toBe('comments.xml')
+
+    vi.advanceTimersByTime(1000)
   })
 })

--- a/apps/web/lib/__tests__/export-comments.test.ts
+++ b/apps/web/lib/__tests__/export-comments.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../auth', () => ({ getAccessToken: () => 'tok-123' }))
+
+import { exportComments, FpsRequiredError } from '../export-comments'
+
+function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}) {
+  const res = {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+    blob: async () => new Blob(['data']),
+  }
+  const fn = vi.fn(async () => res)
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+describe('exportComments', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:x'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('calls the export endpoint with auth and params', async () => {
+    const fetchFn = mockFetch(200, null, {
+      'content-disposition': 'attachment; filename="a_v2_comments.edl"',
+    })
+    await exportComments({ assetId: 'a1', versionId: 'v1', format: 'edl' })
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toContain('/assets/a1/comments/export?')
+    expect(url).toContain('format=edl')
+    expect(url).toContain('version_id=v1')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-123')
+  })
+
+  it('passes fps and include_resolved when provided', async () => {
+    const fetchFn = mockFetch(200, null)
+    await exportComments({ assetId: 'a1', versionId: 'v1', format: 'edl', fps: 29.97, includeResolved: false })
+    const [url] = fetchFn.mock.calls[0] as unknown as [string]
+    expect(url).toContain('fps=29.97')
+    expect(url).toContain('include_resolved=false')
+  })
+
+  it('throws FpsRequiredError on the fps_required 422', async () => {
+    mockFetch(422, { detail: { code: 'fps_required', message: 'need fps' } })
+    await expect(
+      exportComments({ assetId: 'a1', versionId: 'v1', format: 'edl' }),
+    ).rejects.toBeInstanceOf(FpsRequiredError)
+  })
+
+  it('throws a plain error on other failures', async () => {
+    mockFetch(500, null)
+    await expect(
+      exportComments({ assetId: 'a1', versionId: 'v1', format: 'csv' }),
+    ).rejects.toThrow('Export failed (500)')
+  })
+})

--- a/apps/web/lib/export-comments.ts
+++ b/apps/web/lib/export-comments.ts
@@ -1,0 +1,56 @@
+import { getAccessToken } from './auth'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
+export type ExportFormat = 'edl' | 'fcpxml' | 'premiere_xml' | 'csv'
+
+export class FpsRequiredError extends Error {
+  constructor() {
+    super('Frame rate required')
+    this.name = 'FpsRequiredError'
+  }
+}
+
+const EXT: Record<ExportFormat, string> = {
+  edl: 'edl',
+  fcpxml: 'fcpxml',
+  premiere_xml: 'xml',
+  csv: 'csv',
+}
+
+export async function exportComments(opts: {
+  assetId: string
+  versionId: string
+  format: ExportFormat
+  fps?: number
+  includeResolved?: boolean
+}): Promise<void> {
+  const params = new URLSearchParams({ format: opts.format, version_id: opts.versionId })
+  if (opts.fps) params.set('fps', String(opts.fps))
+  if (opts.includeResolved === false) params.set('include_resolved', 'false')
+
+  const res = await fetch(`${API_URL}/assets/${opts.assetId}/comments/export?${params}`, {
+    headers: { Authorization: `Bearer ${getAccessToken()}` },
+  })
+
+  if (res.status === 422) {
+    const body = await res.json().catch(() => null)
+    if (body?.detail?.code === 'fps_required') throw new FpsRequiredError()
+    throw new Error(typeof body?.detail === 'string' ? body.detail : 'Export failed')
+  }
+  if (!res.ok) throw new Error(`Export failed (${res.status})`)
+
+  const blob = await res.blob()
+  const match = /filename="([^"]+)"/.exec(res.headers.get('content-disposition') || '')
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = match?.[1] || `comments.${EXT[opts.format]}`
+  a.style.display = 'none'
+  document.body.appendChild(a)
+  a.click()
+  setTimeout(() => {
+    a.remove()
+    URL.revokeObjectURL(url)
+  }, 1000)
+}


### PR DESCRIPTION
## Summary

Adds the user-facing half of #84: an **Export comments** button in the review page's comment panel. Video assets get DaVinci Resolve (EDL), Final Cut Pro (FCPXML), Premiere Pro (XML), and CSV; other asset types get CSV. Downloads carry the server-provided filename (`{asset}_v{n}_comments.{ext}`).

If a video has no stored frame rate (uploads predating the #124 backfill), a small dialog prompts for it (23.976–60 presets) and retries — driven by the endpoint's `fps_required` error code. The dialog explains why it's asking (fps wasn't captured for older uploads) so the prompt doesn't feel arbitrary.

## Verification

- Web tests passing (download mechanics incl. filename resolution and objectURL cleanup, fps-dialog behavior, error branches), lint and `next build` green.
- Real-browser end-to-end: menu → EDL download with correct markers → fps dialog on a NULL-fps asset → retry with 25fps → correctly named file.

Closes #84
