### PR TITLE
fix(uploads): default panel to Active tab and skip history fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Dev compose honors the environment for LAN/self-host testing** — `docker-compose.dev.yml` now reads `NEXT_PUBLIC_API_URL`, the S3 storage credentials/bucket/region, `S3_PUBLIC_ENDPOINT`, and `MINIO_CORS_ALLOW_ORIGIN` from the environment (falling back to the previous defaults), so the dev stack can point at a LAN IP or external storage without editing the compose file.
+- **Uploads panel now defaults to the Active tab** — opening the panel after an upload shows only in-progress items instead of dumping the full upload history on screen. Switch to the All/Complete/Failed tabs to view history as before.
 
 ### Fixed
 - **First-time sign-in no longer breaks at the set-password step** — after verifying a magic code, a brand-new user (one who hasn't set a password yet) was advanced to the "set password" screen but the tokens issued by `verify-magic-code` were discarded, so the follow-up `POST /auth/set-password` (which requires an authenticated user) returned 401 and bounced the user back to the login screen — never able to finish onboarding. The tokens are now persisted before the set-password step. The password-login form also validates the email format client-side, so a malformed address shows a friendly "Enter a valid email address" instead of surfacing the raw backend validation message.

--- a/apps/web/components/layout/uploads-panel.tsx
+++ b/apps/web/components/layout/uploads-panel.tsx
@@ -187,18 +187,17 @@ export function UploadsPanel() {
   const scrollRef = React.useRef<HTMLDivElement>(null)
   const sentinelRef = React.useRef<HTMLDivElement>(null)
 
-  // Fetch backend history only when viewing a non-Active tab. Active tab is
-  // fed by the live upload store — skip the API call so opening the panel
-  // does not dump old failed/completed uploads on screen.
+  // Fetch backend history when panel opens
   React.useEffect(() => {
-    if (panelOpen && filter !== 'active') {
+    if (panelOpen) {
       fetchHistory()
     }
-  }, [panelOpen, filter, fetchHistory])
+  }, [panelOpen, fetchHistory])
 
-  // Infinite scroll — IntersectionObserver on sentinel
+  // Infinite scroll — IntersectionObserver on sentinel (skip on Active tab
+  // since its items come from the live upload store, not paginated history)
   React.useEffect(() => {
-    if (!panelOpen) return
+    if (!panelOpen || filter === 'active') return
     const sentinel = sentinelRef.current
     if (!sentinel) return
 
@@ -212,7 +211,7 @@ export function UploadsPanel() {
     )
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [panelOpen, historyHasMore, historyLoading, fetchMoreHistory])
+  }, [panelOpen, filter, historyHasMore, historyLoading, fetchMoreHistory])
 
   if (!panelOpen) return null
 
@@ -332,8 +331,8 @@ export function UploadsPanel() {
                 </div>
               ))}
 
-              {/* Sentinel for infinite scroll + loading indicator */}
-              <div ref={sentinelRef} className="h-1" />
+              {/* Sentinel for infinite scroll + loading indicator (skip on Active tab) */}
+              {filter !== 'active' && <div ref={sentinelRef} className="h-1" />}
               {historyLoading && (
                 <div className="flex items-center justify-center py-4">
                   <Loader2 className="h-4 w-4 animate-spin text-text-tertiary" />

--- a/apps/web/components/layout/uploads-panel.tsx
+++ b/apps/web/components/layout/uploads-panel.tsx
@@ -183,16 +183,18 @@ function UploadItem({ upload }: { upload: UploadFile }) {
 
 export function UploadsPanel() {
   const { files, panelOpen, setPanelOpen, clearCompleted, fetchHistory, fetchMoreHistory, historyHasMore, historyLoading } = useUploadStore()
-  const [filter, setFilter] = React.useState<FilterTab>('all')
+  const [filter, setFilter] = React.useState<FilterTab>('active')
   const scrollRef = React.useRef<HTMLDivElement>(null)
   const sentinelRef = React.useRef<HTMLDivElement>(null)
 
-  // Fetch backend history when panel opens
+  // Fetch backend history only when viewing a non-Active tab. Active tab is
+  // fed by the live upload store — skip the API call so opening the panel
+  // does not dump old failed/completed uploads on screen.
   React.useEffect(() => {
-    if (panelOpen) {
+    if (panelOpen && filter !== 'active') {
       fetchHistory()
     }
-  }, [panelOpen, fetchHistory])
+  }, [panelOpen, filter, fetchHistory])
 
   // Infinite scroll — IntersectionObserver on sentinel
   React.useEffect(() => {


### PR DESCRIPTION
## Problem

The uploads panel defaults to "All" and fetches `/me/assets` on every panel open, dumping every historical completed/failed upload into the sidebar. This clutters the UI and causes unnecessary DB load.

## Fix

1. **Default filter tab changed from `"all"` to `"active"`** — when opening the panel after a new upload, users see only active uploads (pending, uploading, processing).
2. **Skip history fetch on Active tab** — the `fetchHistory()` effect now only runs for non-Active tabs (`all`, `complete`, `failed`). The Active tab is fed by the live upload store, so there is no need to hit `/me/assets`.

## Changes

- `apps/web/components/layout/uploads-panel.tsx`: 2 functional changes in the `UploadsPanel` component

## Testing

- Open panel via upload button → defaults to Active tab, shows only live uploads
- Switch to All/Complete/Failed tabs → history fetch runs, pagination works
- No change to existing upload flow or SSE bridge integration

Related: upload panel introduced in #15 (4d37deb)