### PR TITLE
fix(web): make Settings reachable for non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Settings is now reachable for non-admin users** — the sidebar "Settings" menu item and the `/settings` index both routed everyone to the admin-only `/settings/admin`, which bounced normal users back to the home page. Non-admins now land on Appearance (their first accessible settings page); superadmins still land on the admin dashboard.
+
 ## [1.5.0] - 2026-07-13
 
 ### Upgrade notes

--- a/apps/web/app/(dashboard)/settings/__tests__/page-redirect.test.tsx
+++ b/apps/web/app/(dashboard)/settings/__tests__/page-redirect.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Controllable auth + router state (hoisted so the vi.mock factories can close over it).
+const h = vi.hoisted(() => ({
+  replace: vi.fn(),
+  auth: { user: null as { id: string } | null, isSuperAdmin: false },
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: h.replace }),
+}))
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: () => h.auth,
+}))
+
+import SettingsPage from '../page'
+
+describe('SettingsPage index redirect', () => {
+  beforeEach(() => {
+    h.replace.mockClear()
+    h.auth = { user: null, isSuperAdmin: false }
+  })
+
+  it('does not redirect until the user has loaded (avoids bouncing an admin during pre-load)', () => {
+    h.auth = { user: null, isSuperAdmin: false }
+    render(<SettingsPage />)
+    expect(h.replace).not.toHaveBeenCalled()
+  })
+
+  it('sends a superadmin to the admin dashboard', () => {
+    h.auth = { user: { id: 'u1' }, isSuperAdmin: true }
+    render(<SettingsPage />)
+    expect(h.replace).toHaveBeenCalledWith('/settings/admin')
+  })
+
+  it('sends a normal user to appearance — they cannot open /settings/admin', () => {
+    h.auth = { user: { id: 'u2' }, isSuperAdmin: false }
+    render(<SettingsPage />)
+    expect(h.replace).toHaveBeenCalledWith('/settings/appearance')
+  })
+})

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,22 @@
-import { redirect } from 'next/navigation'
+'use client'
+
+import * as React from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/stores/auth-store'
 
 export default function SettingsPage() {
-  redirect('/settings/admin')
+  const router = useRouter()
+  const { user, isSuperAdmin } = useAuthStore()
+
+  // Wait for the auth store to hydrate before choosing a destination — the dashboard
+  // layout fetches the user asynchronously and doesn't block rendering, so `isSuperAdmin`
+  // is briefly false on a fresh load. Redirecting before `user` exists would bounce an
+  // admin to a non-admin page. Non-admins can't open /settings/admin (it redirects them
+  // to home), so send them to the first settings page they can actually access.
+  React.useEffect(() => {
+    if (!user) return
+    router.replace(isSuperAdmin ? '/settings/admin' : '/settings/appearance')
+  }, [user, isSuperAdmin, router])
+
+  return null
 }

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -43,7 +43,7 @@ interface SidebarProps {
 
 export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const pathname = usePathname()
-  const { user, logout } = useAuthStore()
+  const { user, logout, isSuperAdmin } = useAuthStore()
   const { files: uploadFiles, togglePanel, panelOpen } = useUploadStore()
   const { unreadCount, fetchNotifications } = useNotificationStore()
   const { orgName, orgLogoDark, orgLogoLight } = useBrandingStore()
@@ -259,7 +259,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
               </DropdownMenu.Item>
               <DropdownMenu.Item asChild>
                 <Link
-                  href="/settings/admin"
+                  href={isSuperAdmin ? '/settings/admin' : '/settings/appearance'}
                   className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-[13px] text-text-secondary hover:bg-bg-hover hover:text-text-primary focus:outline-none"
                 >
                   <Settings className="h-4 w-4" />


### PR DESCRIPTION
## Summary

The **Settings** entry points routed every user to the admin-only `/settings/admin`. That page renders `null` for non-superadmins and redirects them to the home page — so normal users had no way to reach their own settings (Profile, Appearance, Notifications). Both entry points are now role-aware.

## Changes

- `components/layout/sidebar.tsx` — the user-menu **Settings** link now points to `/settings/admin` for superadmins and `/settings/appearance` for everyone else.
- `app/(dashboard)/settings/page.tsx` — the `/settings` index (also reached from the ⌘K command palette's "Settings") now redirects by role instead of hard-coding `/settings/admin`, and waits for the auth store to hydrate first so an admin is never briefly misrouted to a non-admin page during load.
- Added `app/(dashboard)/settings/__tests__/page-redirect.test.tsx` — admin → admin, non-admin → appearance, and the pre-load gate (no redirect until the user loads).
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Testing

- [ ] Backend tests — n/a (frontend-only change)
- [x] Frontend tests pass — `pnpm --filter web test` → 19 files / 145 tests green (incl. the new 3-case test). Lint clean; `tsc --noEmit` reports no new errors. Production `build` not run, to avoid disturbing the running dev stack.
- [ ] Tested manually in browser — not yet

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`
