### PR TITLE
fix(web): persist tokens after magic-code verify so first-time sign-in works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **First-time sign-in no longer breaks at the set-password step** — after verifying a magic code, a brand-new user (one who hasn't set a password yet) was advanced to the "set password" screen but the tokens issued by `verify-magic-code` were discarded, so the follow-up `POST /auth/set-password` (which requires an authenticated user) returned 401 and bounced the user back to the login screen — never able to finish onboarding. The tokens are now persisted before the set-password step. The password-login form also validates the email format client-side, so a malformed address shows a friendly "Enter a valid email address" instead of surfacing the raw backend validation message.
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -121,6 +121,10 @@ export function LoginForm() {
       })
 
       if (res.needs_password) {
+        // Persist the tokens issued by verify-magic-code before moving on:
+        // /auth/set-password requires an authenticated user (get_current_user),
+        // so without these the set-password call 401s and bounces the user out.
+        setTokens(res.access_token, res.refresh_token)
         setStep('password')
       } else {
         setTokens(res.access_token, res.refresh_token)
@@ -201,6 +205,10 @@ export function LoginForm() {
 
     if (!classicEmail || !classicPassword) {
       setClassicError('Email and password are required')
+      return
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(classicEmail)) {
+      setClassicError('Enter a valid email address')
       return
     }
 


### PR DESCRIPTION
## Summary

A brand-new user (no password set yet) was advanced to the set-password screen after verifying their magic code, but the tokens returned by `POST /auth/verify-magic-code` were discarded. Because `POST /auth/set-password` requires an authenticated user, it returned **401**, the client cleared state and bounced back to the login screen, and the user could never finish first-time sign-in.

## Changes

- Persist the access/refresh tokens from `verify-magic-code` before advancing to the set-password step (`apps/web/components/auth/login-form.tsx`).
- Validate the email format client-side on the password-login form, so a malformed address shows a friendly message instead of surfacing the raw backend validation error.

## Testing

- [ ] Backend tests pass (`docker compose -f docker-compose.dev.yml exec -w /workspace api python -m pytest apps/api/tests/ -q`)
- [ ] Frontend tests + build pass (`pnpm --filter web test && pnpm --filter web build`)
- [ ] Tested manually in browser

**Verified manually:** confirmed the backend contract with curl — `POST /auth/set-password` returns **401 without** the token and **200 with** the token issued by `verify-magic-code` (the `needs_password` path). Full test suite/build not run in this change.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`

## Screenshots

_n/a (no visual change; error path only)_
