### PR TITLE
feat(api): configurable CORS origins via CORS_ALLOW_ORIGINS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Configurable CORS origins** — a new `CORS_ALLOW_ORIGINS` setting (comma-separated) lets the API allow browser origins beyond the built-in frontend/localhost defaults; set it to `*` to allow any origin (handy when testing over a LAN IP — not recommended in production). The wildcard is served by echoing the request origin, so credentialed requests keep working.
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -50,6 +50,10 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = 15
     refresh_token_expire_days: int = 7
     frontend_url: str = "http://localhost:3000"
+    # Extra browser origins allowed by CORS, comma-separated (in addition to the
+    # frontend + localhost defaults). Set to "*" to allow any origin — handy for
+    # testing on a LAN via a machine's IP; do not use "*" in production.
+    cors_allow_origins: str = ""
     transcoder_engine: str = "ffmpeg"
 
     # Maximum size (bytes) for a single uploaded file. 0 = unlimited (no per-file cap).

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -38,13 +38,24 @@ app = FastAPI(
     openapi_url=None if _disable_docs else "/openapi.json",
 )
 
+_cors_extra = [o.strip() for o in settings.cors_allow_origins.split(",") if o.strip()]
+if "*" in _cors_extra:
+    # Allow any origin. A literal "*" can't be combined with allow_credentials,
+    # so echo the request origin via regex instead (keeps credentialed requests working).
+    _cors_origin_kwargs = {"allow_origin_regex": ".*"}
+else:
+    _cors_origin_kwargs = {
+        "allow_origins": [
+            settings.frontend_url,
+            "http://localhost:3000",
+            "http://localhost:3001",
+            *_cors_extra,
+        ]
+    }
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        settings.frontend_url,
-        "http://localhost:3000",
-        "http://localhost:3001",
-    ],
+    **_cors_origin_kwargs,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

Adds a `CORS_ALLOW_ORIGINS` setting so the API can allow browser origins beyond the built-in frontend + localhost defaults — needed when accessing the app from a machine's LAN IP (or any additional origin) without editing code.

## Changes

- New `CORS_ALLOW_ORIGINS` setting (comma-separated) in `apps/api/config.py`.
- `apps/api/main.py` merges it with the existing defaults. A literal `*` allows any origin, served via `allow_origin_regex` so the request origin is echoed and credentialed requests keep working (a bare `*` can't be combined with `allow_credentials=True`).

## Testing

- [ ] Backend tests pass (`docker compose -f docker-compose.dev.yml exec -w /workspace api python -m pytest apps/api/tests/ -q`)
- [ ] Frontend tests + build pass (`pnpm --filter web test && pnpm --filter web build`)
- [ ] Tested manually in browser

**Verified manually:** with `CORS_ALLOW_ORIGINS=*`, `OPTIONS` and `POST /auth/login` from a LAN origin return **200** with `access-control-allow-origin` echoed and `access-control-allow-credentials: true`. Full test suite not run in this change.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`

## Screenshots

_n/a (backend config)_
