### PR TITLE
fix(web): copy invite link over plain HTTP / LAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **"Copy invite link" works over plain HTTP / LAN** — the admin users page called the browser Clipboard API directly, which only exists in a secure context (HTTPS or `localhost`); on a plain-HTTP LAN address the button threw. It now uses the shared clipboard helper (with an `execCommand` fallback) and only shows "Copied" on success.
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/apps/web/app/(dashboard)/settings/admin/page.tsx
+++ b/apps/web/app/(dashboard)/settings/admin/page.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import useSWR, { mutate } from "swr";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Users, Plus, X, Shield, Link2, Check } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, copyToClipboard } from "@/lib/utils";
 import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -204,12 +204,15 @@ export default function AdminPage() {
 
   const [copiedId, setCopiedId] = React.useState<string | null>(null);
 
-  const handleCopyInviteLink = (u: User) => {
+  const handleCopyInviteLink = async (u: User) => {
     if (!u.invite_token) return;
     const link = `${window.location.origin}/invite/${u.invite_token}`;
-    navigator.clipboard.writeText(link);
-    setCopiedId(u.id);
-    setTimeout(() => setCopiedId(null), 2000);
+    // copyToClipboard falls back to execCommand in insecure contexts (e.g. plain
+    // HTTP on a LAN IP), where navigator.clipboard is undefined and would throw.
+    if (await copyToClipboard(link)) {
+      setCopiedId(u.id);
+      setTimeout(() => setCopiedId(null), 2000);
+    }
   };
 
   const handleToggleAdmin = async (


### PR DESCRIPTION
## Summary

On the admin users page, "Copy Invite Link" called `navigator.clipboard.writeText` directly. The Clipboard API only exists in a **secure context** (HTTPS or `localhost`), so on a plain-HTTP LAN address (e.g. `http://192.168.x.x:3000`) `navigator.clipboard` is `undefined` and the click threw a `TypeError`.

## Changes

- Route `handleCopyInviteLink` through the existing `copyToClipboard` helper (`apps/web/lib/utils.ts`), which falls back to `document.execCommand('copy')` in insecure contexts, and only show the "Copied" state on success (`apps/web/app/(dashboard)/settings/admin/page.tsx`).

## Testing

- [ ] Backend tests pass (`docker compose -f docker-compose.dev.yml exec -w /workspace api python -m pytest apps/api/tests/ -q`)
- [ ] Frontend tests + build pass (`pnpm --filter web test && pnpm --filter web build`)
- [ ] Tested manually in browser

**Verified by inspection:** reuses the same `copyToClipboard` helper already backing the working copy buttons in the share dialogs; no new type errors introduced. Not browser-tested in this change.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`

## Screenshots

_n/a_
