### PR TITLE
fix(api): ignore S3_PUBLIC_ENDPOINT in AWS S3 mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Presigned URLs are correct in AWS S3 mode** — with `S3_STORAGE=s3`, a configured `S3_PUBLIC_ENDPOINT` (a MinIO/dev-only concept) would override the AWS host and point presigned upload/download URLs at the wrong endpoint. AWS mode now always uses native presigned URLs and ignores `S3_PUBLIC_ENDPOINT`.
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/apps/api/services/s3_service.py
+++ b/apps/api/services/s3_service.py
@@ -61,7 +61,10 @@ def _get_presign_client():
     so presigned URLs are accessible from the browser (e.g. localhost:9000
     instead of minio:9000 in Docker).
     """
-    endpoint = settings.s3_public_endpoint or (None if _is_aws_s3() else settings.s3_endpoint)
+    # AWS S3 mode always uses native presigned URLs; s3_public_endpoint is a
+    # MinIO/dev concept (rewrite the internal endpoint to a browser-reachable one)
+    # and must never apply to AWS, or presigned URLs would point at the wrong host.
+    endpoint = None if _is_aws_s3() else (settings.s3_public_endpoint or settings.s3_endpoint)
     kwargs = {
         "aws_access_key_id": settings.s3_access_key,
         "aws_secret_access_key": settings.s3_secret_key,


### PR DESCRIPTION
## Summary

`S3_PUBLIC_ENDPOINT` is a MinIO/dev concept — rewrite the internal storage endpoint to a browser-reachable one. In `S3_STORAGE=s3` (native AWS) mode, if `S3_PUBLIC_ENDPOINT` was set, presigned upload/download URLs were pointed at that host instead of AWS, sending the browser to the wrong endpoint.

## Changes

- `apps/api/services/s3_service.py`: the presign client now always uses native AWS presigned URLs in `s3` mode and ignores `S3_PUBLIC_ENDPOINT`. Behavior is unchanged in MinIO/non-AWS mode (still `S3_PUBLIC_ENDPOINT or S3_ENDPOINT`).

## Testing

- [ ] Backend tests pass (`docker compose -f docker-compose.dev.yml exec -w /workspace api python -m pytest apps/api/tests/ -q`)
- [ ] Frontend tests + build pass (`pnpm --filter web test && pnpm --filter web build`)
- [ ] Tested manually in browser

**Verified by inspection:** MinIO-mode presign path is unchanged (confirmed a generated URL still uses the configured public endpoint in MinIO mode). AWS-mode path not exercised against a live AWS bucket in this change.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`

## Screenshots

_n/a (backend)_
