### PR TITLE
chore(dev): overridable dev compose config + LAN hosting docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,11 @@ S3_ENDPOINT=http://localhost:9000
 #                              # differs from S3_ENDPOINT (e.g. internal http://minio:9000
 #                              # vs public https://storage.example.com). Set this whenever
 #                              # the browser can't reach S3_ENDPOINT directly.
+#
+# MinIO server CORS: browser origins allowed to PUT/GET presigned objects directly (dev
+# compose). Dev default: http://localhost:3000. For LAN uploads from other devices set "*"
+# or your LAN origin (e.g. http://192.168.1.50:3000).
+# MINIO_CORS_ALLOW_ORIGIN=http://localhost:3000
 
 # Production — native AWS S3 (uncomment and fill in):
 # S3_STORAGE=s3
@@ -84,6 +89,15 @@ REFRESH_TOKEN_EXPIRE_DAYS=7
 # Dev: http://localhost:3000
 # Prod: your actual domain with https://
 FRONTEND_URL=http://localhost:3000
+
+# Web app → API base URL, baked into the browser bundle at build time (dev compose).
+# Dev default: http://localhost:8000. For LAN access from other devices, set this and
+# FRONTEND_URL to your machine's IP (e.g. http://192.168.1.50:8000).
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Extra browser origins the API's CORS allows, comma-separated (beyond the frontend +
+# localhost defaults). Set to "*" to allow any origin — handy for LAN testing; never in prod.
+CORS_ALLOW_ORIGINS=
 
 # ─── Email ──────────────────────────────────────────────────
 # REQUIRED for login: FreeFrame signs users in with emailed magic codes (and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Dev compose honors the environment for LAN/self-host testing** — `docker-compose.dev.yml` now reads `NEXT_PUBLIC_API_URL`, the S3 storage credentials/bucket/region, `S3_PUBLIC_ENDPOINT`, and `MINIO_CORS_ALLOW_ORIGIN` from the environment (falling back to the previous defaults), so the dev stack can point at a LAN IP or external storage without editing the compose file.
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ Open [http://localhost:3000](http://localhost:3000) to access FreeFrame. The fir
 | API Docs    | http://localhost:8000/docs    |
 | MinIO Console | http://localhost:9001       |
 
+### Access from other devices on your network (LAN)
+
+By default the dev stack is reachable only from the host machine (`localhost`). To open FreeFrame from a phone or another computer on the same network, point a few URLs at your machine's LAN IP — find it with `ipconfig getifaddr en0` (macOS) or `hostname -I` (Linux) — then recreate the containers.
+
+In `.env` (replace `192.168.1.50` with your IP):
+
+```env
+NEXT_PUBLIC_API_URL=http://192.168.1.50:8000   # web → API (baked into the browser bundle)
+FRONTEND_URL=http://192.168.1.50:3000           # links in invite/magic-code emails
+CORS_ALLOW_ORIGINS=*                            # API allows the LAN browser origin
+S3_PUBLIC_ENDPOINT=http://192.168.1.50:9000     # presigned upload/download URLs
+MINIO_CORS_ALLOW_ORIGIN=*                       # MinIO allows the LAN browser origin
+```
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --force-recreate
+```
+
+Then browse to `http://192.168.1.50:3000` from any device on the network. Server-side settings (`DATABASE_URL`, `S3_ENDPOINT`, …) stay on their docker-internal hostnames — only the browser-facing URLs above change.
+
+> The `*` wildcards are LAN-testing conveniences — don't use them in production. See [docs/deployment.md](docs/deployment.md) for a locked-down setup.
+
 ## Release channels
 
 Production self-hosters should run a **released** version, not `main`:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,7 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-      MINIO_CORS_ALLOW_ORIGIN: http://localhost:3000
+      MINIO_CORS_ALLOW_ORIGIN: ${MINIO_CORS_ALLOW_ORIGIN:-http://localhost:3000}
       MINIO_CORS_ALLOW_METHODS: GET,PUT,POST,DELETE,HEAD
       MINIO_CORS_ALLOW_HEADERS: "*"
       MINIO_CORS_EXPOSE_HEADERS: ETag,Content-Length,x-amz-request-id
@@ -73,13 +73,13 @@ services:
       DATABASE_URL: postgresql://freeframe:freeframe@postgres:5432/freeframe
       REDIS_URL: redis://redis:6379/0
       # Storage: "minio" for local MinIO (dev), "s3" for AWS S3 (prod)
-      S3_STORAGE: minio
-      S3_ACCESS_KEY: minioadmin
-      S3_SECRET_KEY: minioadmin
+      S3_STORAGE: ${S3_STORAGE:-minio}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-minioadmin}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:-minioadmin}
       S3_ENDPOINT: http://minio:9000
-      S3_BUCKET: freeframe
-      S3_REGION: us-east-1
-      S3_PUBLIC_ENDPOINT: http://localhost:9000
+      S3_BUCKET: ${S3_BUCKET:-freeframe}
+      S3_REGION: ${S3_REGION:-us-east-1}
+      S3_PUBLIC_ENDPOINT: ${S3_PUBLIC_ENDPOINT:-http://localhost:9000}
     depends_on:
       postgres:
         condition: service_healthy
@@ -102,12 +102,12 @@ services:
     environment:
       DATABASE_URL: postgresql://freeframe:freeframe@postgres:5432/freeframe
       REDIS_URL: redis://redis:6379/0
-      S3_STORAGE: minio
-      S3_ACCESS_KEY: minioadmin
-      S3_SECRET_KEY: minioadmin
+      S3_STORAGE: ${S3_STORAGE:-minio}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-minioadmin}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:-minioadmin}
       S3_ENDPOINT: http://minio:9000
-      S3_BUCKET: freeframe
-      S3_REGION: us-east-1
+      S3_BUCKET: ${S3_BUCKET:-freeframe}
+      S3_REGION: ${S3_REGION:-us-east-1}
     depends_on:
       postgres:
         condition: service_healthy
@@ -129,12 +129,12 @@ services:
     environment:
       DATABASE_URL: postgresql://freeframe:freeframe@postgres:5432/freeframe
       REDIS_URL: redis://redis:6379/0
-      S3_STORAGE: minio
-      S3_ACCESS_KEY: minioadmin
-      S3_SECRET_KEY: minioadmin
+      S3_STORAGE: ${S3_STORAGE:-minio}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-minioadmin}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:-minioadmin}
       S3_ENDPOINT: http://minio:9000
-      S3_BUCKET: freeframe
-      S3_REGION: us-east-1
+      S3_BUCKET: ${S3_BUCKET:-freeframe}
+      S3_REGION: ${S3_REGION:-us-east-1}
     depends_on:
       redis:
         condition: service_healthy
@@ -149,7 +149,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:8000
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
       - NODE_ENV=development
       - HOSTNAME=0.0.0.0
     volumes:


### PR DESCRIPTION
## Summary

Lets the dev stack (`docker-compose.dev.yml`) target a LAN IP (or external storage) without editing the compose file, and documents how to reach FreeFrame from other devices on your network. Pairs with the configurable-CORS change for the API-side origin allowance.

## Changes

- `docker-compose.dev.yml`: read `NEXT_PUBLIC_API_URL`, the S3 storage credentials/bucket/region, `S3_PUBLIC_ENDPOINT`, and `MINIO_CORS_ALLOW_ORIGIN` from the environment, with the previous values as defaults. Server-side `S3_ENDPOINT` stays pinned to the docker-internal `minio:9000` (so the API keeps using the fast internal hostname).
- `README.md`: new "Access from other devices on your network (LAN)" section with the step-by-step and env vars.
- `.env.example`: document `NEXT_PUBLIC_API_URL`, `CORS_ALLOW_ORIGINS`, and `MINIO_CORS_ALLOW_ORIGIN`.

## Testing

- [ ] Backend tests pass (`docker compose -f docker-compose.dev.yml exec -w /workspace api python -m pytest apps/api/tests/ -q`)
- [ ] Frontend tests + build pass (`pnpm --filter web test && pnpm --filter web build`)
- [ ] Tested manually in browser

**Verified manually:** `docker compose config` resolves the LAN overrides; after `--force-recreate`, generated presigned URLs use the LAN host and a MinIO CORS preflight from the LAN origin returns **204** with the origin allowed. Docs proofread; no app code paths changed.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`

## Screenshots

_n/a (config + docs)_
