### PR TITLE
fix(web): repair duplicated keys in pnpm-lock.yaml

### DIFF
--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -519,15 +519,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-context@1.2.0':
-    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
@@ -3841,12 +3832,6 @@ snapshots:
       '@types/react': 18.3.28
 
   '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  '@radix-ui/react-context@1.2.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

`main` is red: `Frontend Build`, `Lint` and `Docker Build` all fail with

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "apps/web/pnpm-lock.yaml" is broken:
duplicated mapping key (522:3)
```

## Cause

Merging #163 (`@radix-ui/react-avatar`) and #164 (`@radix-ui/react-popover`) back to back. Each independently pulled in `@radix-ui/react-context@1.2.0` as a **new** transitive dependency, adding an identical block to `pnpm-lock.yaml`.

The two additions landed at different offsets, so they never conflicted textually — GitHub reported both PRs `MERGEABLE` and merged both copies. The result is a YAML file with the same key twice in `packages:` and twice in `snapshots:`, which pnpm rejects.

Worth noting `MERGEABLE` is not a safety signal for lockfiles: two YAML insertions can merge cleanly as text while producing a structurally invalid document.

## Changes

- Removed the duplicate `@radix-ui/react-context@1.2.0` block from `packages:` and from `snapshots:`. Both pairs were verified byte-identical before removal, so this is a pure de-duplication — no version changes.

## Testing

- [x] `pnpm install --frozen-lockfile` succeeds (this is the check that was failing)
- [x] `pnpm --filter web test` — 32 files / 256 tests pass
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web build` — compiled successfully

No CHANGELOG entry — repository tooling, not user-facing.