### PR TITLE
fix(share): resolve review hooks with ESM imports, not CommonJS require

### DIFF
--- a/apps/web/components/review/review-provider.tsx
+++ b/apps/web/components/review/review-provider.tsx
@@ -15,7 +15,7 @@ import type { AssetResponse, AssetVersion, Comment } from "@/types";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface CreateCommentPayload {
+export interface CreateCommentPayload {
   body: string;
   version_id?: string;
   parent_id?: string;

--- a/apps/web/components/share/__tests__/share-review-mount.test.tsx
+++ b/apps/web/components/share/__tests__/share-review-mount.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { FolderShareViewer } from '../folder-share-viewer'
+
+// Regression for #192: ShareReviewInner used to resolve its hooks with bare
+// CommonJS require('@/...') calls. Node's loader does not understand the '@'
+// alias from vitest.config.ts, so the subtree threw "Cannot find module" the
+// moment a guest opened an asset — making the whole share-review UI untestable.
+describe('folder share — opening an asset mounts the review UI (#192)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        assets: [{ id: 'a1', name: 'Clip.mp4', asset_type: 'video', latest_version_id: 'v1', thumbnail_url: null, status: 'ready' }],
+        subfolders: [],
+        total: 1,
+      }),
+    })) as unknown as typeof fetch)
+    vi.stubGlobal('ResizeObserver', class { observe() {} unobserve() {} disconnect() {} })
+    // jsdom has no matchMedia (#188); the panel default reads it during render.
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: true, media: query, onchange: null,
+      addEventListener() {}, removeEventListener() {},
+      addListener() {}, removeListener() {}, dispatchEvent: () => false,
+    }))
+  })
+
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('renders the review panel tabs after double-clicking an asset', async () => {
+    render(
+      <FolderShareViewer
+        token="t" folderName="F" title="T" description={null}
+        permission="comment" allowDownload={false} showVersions={false}
+        appearance={{ open_in_viewer: true } as never} branding={null}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText('Clip.mp4')).toBeInTheDocument())
+    fireEvent.doubleClick(screen.getByText('Clip.mp4'))
+
+    // These tabs live inside ShareReviewInner, so they only appear if that
+    // subtree mounted — i.e. if its hook imports resolved.
+    await waitFor(() => expect(screen.getByText('Fields')).toBeInTheDocument(), { timeout: 3000 })
+    expect(screen.getByText('Comments')).toBeInTheDocument()
+  })
+})

--- a/apps/web/components/share/folder-share-viewer.tsx
+++ b/apps/web/components/share/folder-share-viewer.tsx
@@ -19,6 +19,8 @@ import {
   ArrowLeft,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useReview, type CreateCommentPayload } from '@/components/review/review-provider'
+import { useReviewStore } from '@/stores/review-store'
 import type {
   SharePermission,
   ShareLinkAppearance,
@@ -791,11 +793,6 @@ function ShareReviewInner({
   token, shareSession, assetName, permission, allowDownload, showVersions, onBack,
   VideoPlayer, ImageViewer, AudioPlayer, CommentPanel, CommentInput, VersionSwitcher,
 }: any) {
-  // Import hooks from the review system
-  const { useReview } = require('@/components/review/review-provider')
-  const { useReviewStore } = require('@/stores/review-store')
-  const { useComments } = require('@/hooks/use-comments')
-
   const { asset, versions, isLoading, comments, refetchComments, addComment } = useReview()
   const { currentVersion, isDrawingMode, focusedCommentId } = useReviewStore()
   const [sidebarOpen, setSidebarOpen] = React.useState(() => typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches)
@@ -829,7 +826,7 @@ function ShareReviewInner({
   const isLoggedIn = typeof window !== 'undefined' && !!localStorage.getItem('ff_access_token')
 
   const submitComment = React.useCallback(async (body: string, timecodeStart?: number, timecodeEnd?: number, annotationData?: Record<string, unknown>) => {
-    const payload: Record<string, unknown> = { body }
+    const payload: CreateCommentPayload = { body }
     if (currentVersion?.id) payload.version_id = currentVersion.id
     if (timecodeStart != null) payload.timecode_start = timecodeStart
     if (timecodeEnd != null) payload.timecode_end = timecodeEnd


### PR DESCRIPTION
Closes #192.

## Summary

`ShareReviewInner` resolved its hooks with bare CommonJS `require('@/...')` calls in the render body. Node's CJS loader doesn't understand the `@` alias from `vitest.config.ts`, so the component threw `Cannot find module '@/components/review/review-provider'` the moment a guest opened an asset from a folder share link. `vi.mock` couldn't work around it either — mocks apply to the ESM graph, and a runtime `require()` walks straight past them.

Net effect: the entire guest-facing share-review subtree (comments, annotations, approvals, version switching on a shared folder) had no reachable path to a test.

## Changes

- Converted `useReview` and `useReviewStore` to top-level ESM imports.
- Dropped the `useComments` require — it was destructured but never called anywhere in the file.
- Exported `CreateCommentPayload` and used it for `submitComment`'s payload. **This surfaced a real pre-existing type error**: the payload was typed `Record<string, unknown>`, which doesn't satisfy `addComment`'s parameter. The `require()` returned `any`, so TypeScript had never checked it.

## Testing

Adds `components/share/__tests__/share-review-mount.test.tsx` — the **first test under `components/share/`**. It double-clicks an asset in a folder share and asserts the review panel tabs render, which only happens if the subtree mounted.

- [x] Fails before this change (`Unable to find an element with the text: Fields`, preceded by the module-resolution error); passes after — verified by stashing the source change and re-running.
- [x] `pnpm --filter web test` — 33 files / 257 tests pass
- [x] `pnpm --filter web lint` — no new warnings
- [x] `pnpm --filter web exec tsc --noEmit` — clean
- [x] `pnpm --filter web build` — compiled successfully

### Bundle impact

Checked, because `ShareReviewScreen` deliberately `import()`s these modules and a static import could have pulled them into the initial chunk. It didn't — First Load JS for the route went **down**:

| | route | First Load JS |
|---|---|---|
| before | 21.3 kB | 125 kB |
| after | 21.7 kB | **119 kB** |

`review-provider` only imports React, `@/lib/api`, the store and types — no SSR-unsafe module scope. The "avoid SSR issues" comment on the dynamic-import block applies to the other six modules (hls.js, fabric), which are untouched.

No CHANGELOG entry — no user-facing behavior change.