### PR TITLE
fix(auth): send-magic-code no longer creates or activates uninvited accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Sign-in codes are no longer issued to uninvited emails** — `POST /auth/send-magic-code` used to create and, on verification, fully activate an account for any email address, whether or not an admin had invited it. Only an existing user (already active, or already invited via `POST /users/invite`) can now receive a working code; an unrecognized email gets the same generic response, so the endpoint still doesn't reveal which emails are registered.
+
 ## [1.7.0] - 2026-07-21
 
 ### Upgrade notes

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -40,28 +40,21 @@ def _generate_invite_token() -> str:
 @router.post("/send-magic-code", response_model=SendMagicCodeResponse, dependencies=[Depends(rate_limit("send_magic_code", 5, 600))])
 def send_magic_code(body: SendMagicCodeRequest, db: Session = Depends(get_db)):
     """
-    Send magic code to email.
-    - If user exists: send code for login
-    - If user doesn't exist: create pending user and send code
+    Send magic code to an existing user's email, for login.
+
+    Does not create accounts: only an admin invite (/users/invite) or
+    /setup/create-superadmin may provision a new user. An unrecognized email
+    gets the same response as a known one, so this endpoint can't be used to
+    enumerate registered emails.
     """
     user = get_user_by_email(db, body.email)
-    
+
     if not user:
-        # Check if this is the first user (becomes super admin)
-        user_count = db.query(User).filter(User.deleted_at.is_(None)).count()
-        is_first_user = user_count == 0
-        
-        # Create new user in pending_verification status
-        user = User(
+        return SendMagicCodeResponse(
+            message="Magic code sent to your email",
             email=body.email,
-            name=body.email.split("@")[0],  # Temporary name from email
-            status=UserStatus.pending_verification,
-            email_verified=False,
-            is_superadmin=is_first_user,  # First user becomes super admin
         )
-        db.add(user)
-        db.commit()
-    
+
     # Generate and store magic code in Redis
     code = generate_magic_code()
     store_magic_code(body.email, code)

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -122,6 +122,38 @@ def test_login_nonexistent_user(client, mock_db):
     assert resp.status_code == 401
 
 
+def test_send_magic_code_unknown_email_does_not_create_user(client, mock_db):
+    """POST /auth/send-magic-code — unknown email gets a generic response; no account is created.
+
+    Regression test: this endpoint used to auto-create and later auto-activate an account for
+    any email, bypassing the /users/invite gate entirely (GHSA-9m78-fww2-p89h).
+    """
+    mock_db.first.return_value = None  # no existing (i.e. no invited) user for this email
+
+    with patch("apps.api.middleware.rate_limit.check_rate_limit", return_value=(True, 0)):
+        resp = client.post("/auth/send-magic-code", json={"email": "uninvited@example.com"})
+
+    assert resp.status_code == 200
+    assert resp.json()["email"] == "uninvited@example.com"
+    mock_db.add.assert_not_called()
+    mock_db.commit.assert_not_called()
+
+
+def test_send_magic_code_existing_user_sends_code(client, mock_db):
+    """POST /auth/send-magic-code — an existing (e.g. already-invited) user gets a real code issued."""
+    user = _mock_user("invited@example.com")
+    mock_db.first.return_value = user
+
+    with patch("apps.api.middleware.rate_limit.check_rate_limit", return_value=(True, 0)), \
+         patch("apps.api.routers.auth.store_magic_code") as mock_store, \
+         patch("apps.api.routers.auth.send_task_safe") as mock_send:
+        resp = client.post("/auth/send-magic-code", json={"email": "invited@example.com"})
+
+    assert resp.status_code == 200
+    mock_store.assert_called_once()
+    mock_send.assert_called_once()
+
+
 def test_get_me(client, auth_headers, test_user):
     """GET /auth/me — returns current user profile."""
     resp = client.get("/auth/me", headers=auth_headers)


### PR DESCRIPTION
## Summary

`POST /auth/send-magic-code` auto-created a new account for any email address and `verify-magic-code` would fully activate it on a correct code — the invite gate was never consulted, so uninvited emails could self-provision full accounts.

## Changes

- `send_magic_code` now only issues a working code to an email that already has a `User` row (already active, or already invited via `POST /users/invite`, which sets `pending_invite`). An unrecognized email gets the identical generic response, so the endpoint still doesn't leak which emails are registered.
- Added regression tests: unknown email → no account created, no code issued; existing user → code issued as before.

## Testing

- [x] Backend tests pass (`docker exec -w /workspace freeframe-api-1 python -m pytest apps/api/tests/` — 210 passed, incl. 2 new regression tests for this change)
- [ ] Frontend tests + build pass (no frontend changes in this PR; not run)
- [x] Tested manually against the live dev stack (real Postgres + Redis, not mocks):
  - Unknown email → `send-magic-code` returns the generic response, but `verify-magic-code` immediately after returns `404 User not found` — confirms no account was created.
  - Existing active user → `send-magic-code` → code pulled from Redis → `verify-magic-code` → `200` with valid tokens, unchanged from before.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`