### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-07-23
+
 ### Fixed
 - **Sign-in codes are no longer issued to uninvited emails** — `POST /auth/send-magic-code` used to create and, on verification, fully activate an account for any email address, whether or not an admin had invited it. Only an existing user (already active, or already invited via `POST /users/invite`) can now receive a working code; an unrecognized email gets the same generic response, so the endpoint still doesn't reveal which emails are registered.
 


### PR DESCRIPTION
## Summary

Cut v1.7.1 — patch release containing the invite-gate fix from #206.

## Changes

- Move the `[Unreleased]` CHANGELOG entry under a new `## [1.7.1] - 2026-07-23` heading.

## Testing

- [x] N/A — docs-only change (CHANGELOG heading move)

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]` (n/a, this PR moves it out)