### PR TITLE
fix(auth): stop leaking invite tokens and remove open registration endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`GET /users` and `GET /users/search` no longer expose pending invite tokens** — both endpoints reused the same response shape as the admin user list, which includes a pending invitee's live `invite_token`. Since either endpoint only required being logged in (not an admin), any authenticated user could look up a pending invitee and read their token, then complete the invite themselves via `/auth/accept-invite` before the real invitee did. The token is now only ever returned by the admin-gated `GET /admin/users` and `POST /users/invite` responses.
+- **Removed the legacy `POST /auth/register` endpoint** — it created an immediately-active, loginable account for any email with no auth and no invite check, bypassing the invite-only model this platform is built around. It had no frontend caller; account creation now only happens via an admin invite (`/users/invite` → `/auth/accept-invite`), first-time setup (`/setup/create-superadmin`), or a sign-in code sent to an already-known email (`/auth/send-magic-code`).
+
 ## [1.7.1] - 2026-07-23
 
 ### Fixed

--- a/apps/api/routers/admin.py
+++ b/apps/api/routers/admin.py
@@ -7,7 +7,7 @@ import uuid
 from ..database import get_db
 from ..middleware.auth import get_current_user
 from ..models.user import User, UserStatus
-from ..schemas.auth import UserResponse, UpdateUserRoleRequest
+from ..schemas.auth import UserResponse, AdminUserResponse, UpdateUserRoleRequest
 from .users import require_admin
 from ..tasks.celery_app import send_task_safe
 from ..tasks.cleanup_tasks import cleanup_soft_deleted
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 
 # ── Endpoints ──────────────────────────────────────────────────────────────────
 
-@router.get("/users", response_model=list[UserResponse])
+@router.get("/users", response_model=list[AdminUserResponse])
 def list_all_users(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -5,7 +5,7 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from ..database import get_db
 from ..schemas.auth import (
-    RegisterRequest, LoginRequest, TokenResponse,
+    LoginRequest, TokenResponse,
     RefreshRequest, UserResponse, InviteRequest,
     SendMagicCodeRequest, SendMagicCodeResponse,
     VerifyMagicCodeRequest, SetPasswordRequest,
@@ -169,24 +169,6 @@ def accept_invite(body: AcceptInviteRequest, db: Session = Depends(get_db)):
         refresh_token=create_refresh_token(str(user.id)),
         needs_password=False,
     )
-
-
-@router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
-def register(body: RegisterRequest, db: Session = Depends(get_db)):
-    """Register with email + password (legacy, prefer magic code flow)."""
-    if get_user_by_email(db, body.email):
-        raise HTTPException(status_code=400, detail="Email already registered")
-    user = User(
-        email=body.email,
-        name=body.name,
-        password_hash=hash_password(body.password),
-        status=UserStatus.active,
-        email_verified=False,  # Not verified until magic code
-    )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
 
 
 @router.post("/login", response_model=TokenResponse)

--- a/apps/api/routers/users.py
+++ b/apps/api/routers/users.py
@@ -4,7 +4,7 @@ import uuid
 import secrets
 from datetime import datetime, timezone, timedelta
 from ..database import get_db
-from ..schemas.auth import UserResponse, InviteRequest, UpdateProfileRequest
+from ..schemas.auth import UserResponse, AdminUserResponse, InviteRequest, UpdateProfileRequest
 from ..models.user import User, UserStatus
 from ..middleware.auth import get_current_user
 from ..services.auth_service import hash_password, get_user_by_email
@@ -52,7 +52,7 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
         raise HTTPException(status_code=403, detail="Admin access required")
     return current_user
 
-@router.post("/invite", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/invite", response_model=AdminUserResponse, status_code=status.HTTP_201_CREATED)
 def invite_user(body: InviteRequest, db: Session = Depends(get_db), current_user: User = Depends(require_admin)):
     if get_user_by_email(db, body.email):
         raise HTTPException(status_code=400, detail="Email already registered")

--- a/apps/api/schemas/auth.py
+++ b/apps/api/schemas/auth.py
@@ -2,11 +2,6 @@ from pydantic import BaseModel, EmailStr, field_validator
 import uuid
 from ..models.user import UserStatus
 
-class RegisterRequest(BaseModel):
-    email: EmailStr
-    name: str
-    password: str
-
 class LoginRequest(BaseModel):
     email: EmailStr
     password: str
@@ -28,7 +23,6 @@ class UserResponse(BaseModel):
     status: UserStatus
     email_verified: bool = False
     is_superadmin: bool = False
-    invite_token: str | None = None
     preferences: dict = {}
 
     model_config = {"from_attributes": True}
@@ -40,6 +34,14 @@ class UserResponse(BaseModel):
             from ..services import s3_service
             return s3_service.generate_presigned_get_url(v)
         return v
+
+class AdminUserResponse(UserResponse):
+    """UserResponse plus the pending invite token.
+
+    Only for admin-gated endpoints: exposing invite_token to any authenticated
+    caller lets them hijack a pending invite before the invitee accepts it.
+    """
+    invite_token: str | None = None
 
 class InviteRequest(BaseModel):
     email: EmailStr

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -34,50 +34,8 @@ def _mock_user(
     return u
 
 
-# Patch bcrypt hashing so tests don't depend on the local bcrypt installation.
-_HASH_PATCH = "apps.api.routers.auth.hash_password"
+# Patch bcrypt verification so tests don't depend on the local bcrypt installation.
 _VERIFY_PATCH = "apps.api.routers.auth.verify_password"
-
-
-def test_register_success(client, mock_db):
-    """POST /auth/register — happy path creates a user and returns 201."""
-    mock_db.first.return_value = None  # no duplicate email
-
-    def _refresh_side_effect(obj):
-        obj.id = uuid.uuid4()
-        obj.created_at = datetime.now(timezone.utc)
-        obj.deleted_at = None
-        obj.avatar_url = None
-        obj.status = UserStatus.active
-        obj.is_superadmin = False
-        obj.email_verified = False
-        obj.preferences = {}
-        obj.invite_token = None
-
-    mock_db.refresh.side_effect = _refresh_side_effect
-
-    with patch(_HASH_PATCH, return_value=_FAKE_HASH):
-        resp = client.post(
-            "/auth/register",
-            json={"email": "newuser@example.com", "name": "New User", "password": "securepassword"},
-        )
-
-    assert resp.status_code == 201
-    assert resp.json()["email"] == "newuser@example.com"
-
-
-def test_register_duplicate_email(client, mock_db):
-    """POST /auth/register — returns 400 when email already exists."""
-    existing = _mock_user("dup@example.com")
-    mock_db.first.return_value = existing
-
-    with patch(_HASH_PATCH, return_value=_FAKE_HASH):
-        resp = client.post(
-            "/auth/register",
-            json={"email": "dup@example.com", "name": "A", "password": "pw123456"},
-        )
-
-    assert resp.status_code == 400
 
 
 def test_login_success(client, mock_db):
@@ -152,6 +110,60 @@ def test_send_magic_code_existing_user_sends_code(client, mock_db):
     assert resp.status_code == 200
     mock_store.assert_called_once()
     mock_send.assert_called_once()
+
+
+def test_register_endpoint_removed(client):
+    """POST /auth/register — endpoint has been removed (was an unauthenticated, un-invite-gated
+    account creation path; GHSA-9m78-fww2-p89h). 404, not 405: the route no longer exists."""
+    resp = client.post(
+        "/auth/register",
+        json={"email": "newuser@example.com", "name": "New User", "password": "securepassword"},
+    )
+    assert resp.status_code == 404
+
+
+def test_users_batch_does_not_leak_invite_token(client, auth_headers, mock_db, test_user):
+    """GET /users — never includes invite_token, even for a caller with no admin rights.
+
+    Regression test: GET /users and GET /users/search reused UserResponse (which included
+    invite_token) behind only get_current_user, so any authenticated user could read a
+    pending invitee's live token and hijack the invite via /auth/accept-invite before the
+    real invitee acted (GHSA-9m78-fww2-p89h).
+    """
+    test_user.is_superadmin = False
+    target = _mock_user("invitee@example.com")
+    target.status = UserStatus.pending_invite
+    target.is_superadmin = False
+    target.email_verified = False
+    target.preferences = {}
+    target.invite_token = "super-secret-invite-token"
+    mock_db.all.return_value = [target]
+
+    resp = client.get(f"/users?ids={target.id}", headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert "invite_token" not in body[0]
+
+
+def test_admin_list_users_still_includes_invite_token(client, auth_headers, mock_db, test_user):
+    """GET /admin/users — admin-gated, so it may still expose invite_token (needed for the
+    admin "copy invite link" UI); this endpoint's own is_superadmin check is the gate."""
+    test_user.is_superadmin = True
+    target = _mock_user("invitee@example.com")
+    target.status = UserStatus.pending_invite
+    target.is_superadmin = False
+    target.email_verified = False
+    target.preferences = {}
+    target.invite_token = "super-secret-invite-token"
+    mock_db.all.return_value = [target]
+
+    resp = client.get("/admin/users", headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["invite_token"] == "super-secret-invite-token"
 
 
 def test_get_me(client, auth_headers, test_user):


### PR DESCRIPTION
## Summary

Two more access-control gaps in the invite-only account model, same family as #206:

- `GET /users` and `GET /users/search` returned the same `UserResponse` shape as the admin user list, which includes a pending invitee's live `invite_token`. Neither endpoint requires admin rights, so any authenticated user could look up a pending invitee and hijack their invite via `/auth/accept-invite` before they acted on it.
- `POST /auth/register` created an immediately-active, loginable account for any email with no auth and no invite check — a second, more direct bypass of the invite-only model.

## Changes

- New `AdminUserResponse` schema (extends `UserResponse` with `invite_token`), used only by `GET /admin/users` (already `is_superadmin`-gated) and `POST /users/invite` (already `require_admin`-gated). Base `UserResponse` no longer has the field at all, so `GET /users` / `GET /users/search` can't leak it regardless of caller.
- Removed `POST /auth/register` and its now-unused `RegisterRequest` schema. Confirmed no frontend caller. Not gated instead of removed — a bare email+password can't prove ownership of the invited email the way a mailed invite token or magic code does, so gating it the way `send_magic_code` was gated wouldn't actually close the hole.
- CHANGELOG entry under `[Unreleased]`.

## Testing

- [x] Backend tests pass (`docker exec -w /workspace freeframe-api-1 python -m pytest apps/api/tests/` — 211 passed, incl. 3 new regression tests: register 404s, `GET /users` doesn't leak `invite_token`, `GET /admin/users` still does)
- [ ] Frontend tests + build pass (no frontend changes; not run)
- [x] Tested manually against the live dev stack (real Postgres/Redis, not mocks): seeded a `pending_invite` user with a known token, confirmed a non-admin caller's `/users/search` response has no `invite_token` key at all while `/admin/users` (superadmin caller) still returns it correctly; confirmed `POST /auth/register` now 404s.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`