### PR TITLE
fix(share): validate asset scope and enforce password on comment endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Public share-link comments can no longer read or write outside the shared scope** — both `GET /share/{token}/comments` and `POST /share/{token}/comment` trusted a client-supplied `asset_id` for folder/project-scoped links (and, for the write endpoint, even for a single-asset link — a request body could name a different asset entirely) with no check that the asset was actually within the link's scope. A holder of any comment/approve-permission share link could read or post comments on assets never shared with them. Both endpoints now validate the resolved asset against the share link the same way every other public share endpoint already does.
+- **Password-protected share links now actually gate comments** — the two comment endpoints were the only public share routes that skipped password/session verification, so a password-protected link's comments were fully readable and writable with just the token.
+
 ## [1.7.2] - 2026-07-23
 
 ### Fixed

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -35,7 +35,9 @@ from ..schemas.comment import (
 )
 from ..services import s3_service
 from ..services import comment_export
-from ..services.permissions import require_asset_access, validate_share_link
+from ..services.permissions import (
+    require_asset_access, validate_share_link_with_session, validate_asset_in_share,
+)
 from ..tasks.email_tasks import send_mention_email, send_comment_email
 from ..tasks.celery_app import send_task_safe
 
@@ -790,20 +792,26 @@ def list_share_comments(
     asset_id: Optional[uuid.UUID] = None,
     version_id: Optional[uuid.UUID] = None,
     latest_only: bool = False,
+    share_session: Optional[str] = Query(None, alias="share_session"),
     db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_user),
 ):
-    """Public endpoint — list comments for a shared asset. No auth required.
-    For folder/project shares, pass asset_id as query param to get comments for a specific asset.
+    """Public endpoint — list comments for a shared asset. Enforces the share link's password
+    (if any) via share_session, same as the other public share endpoints.
+    For folder/project shares, pass asset_id as query param to get comments for a specific asset —
+    it's validated against the link's scope, so it can't be used to read another asset's comments.
     Pass version_id to scope comments to a single version (matches the authenticated review view).
     Pass latest_only=true to scope to the latest ready version — used by the folder/grid preview,
     which has no version picker."""
-    link = validate_share_link(db, token)
+    link = validate_share_link_with_session(db, token, share_session=share_session, current_user=current_user)
 
     # Determine the asset_id to list comments for
     target_asset_id = link.asset_id or asset_id
     if not target_asset_id:
         return []
-    asset_id = target_asset_id
+    asset = _get_asset(db, target_asset_id)
+    validate_asset_in_share(db, link, asset)
+    asset_id = asset.id
 
     # The folder/grid preview has no version switcher, so it scopes to the latest ready version.
     if latest_only and not version_id:
@@ -833,20 +841,24 @@ def list_share_comments(
 def guest_comment(
     token: str,
     body: GuestCommentCreate,
+    share_session: Optional[str] = Query(None, alias="share_session"),
     db: Session = Depends(get_db),
     current_user: Optional[User] = Depends(get_optional_user),
 ):
-    link = validate_share_link(db, token)
+    link = validate_share_link_with_session(db, token, share_session=share_session, current_user=current_user)
 
     # Check share link permission allows commenting
     if link.permission == SharePermission.view:
         raise HTTPException(status_code=403, detail="This share link does not allow commenting")
 
-    # Resolve asset_id: from body, link, or error
-    target_asset_id = body.asset_id or link.asset_id
+    # Resolve asset_id: from the link when it's scoped to one asset; otherwise from the request
+    # body (folder/project shares only), validated against the link's actual scope below — the
+    # link's own asset_id always wins so a single-asset link can't be redirected to another asset.
+    target_asset_id = link.asset_id or body.asset_id
     if not target_asset_id:
         raise HTTPException(status_code=400, detail="asset_id is required for folder/project shares")
     asset = _get_asset(db, target_asset_id)
+    validate_asset_in_share(db, link, asset)
 
     # Resolve version_id: use provided or get latest ready version
     version_id = body.version_id

--- a/apps/api/routers/share.py
+++ b/apps/api/routers/share.py
@@ -35,7 +35,10 @@ from ..schemas.share import (
     ShareLinkUpdate,
     ShareLinkValidateResponse,
 )
-from ..services.permissions import require_project_role, validate_share_link, validate_share_link_with_session
+from ..services.permissions import (
+    require_project_role, validate_share_link, validate_share_link_with_session,
+    validate_asset_in_share, _is_descendant_of,
+)
 from ..services.redis_service import create_share_session
 from ..services.s3_service import generate_presigned_get_url, build_download_filename
 from ..services.crypto_service import encrypt_password, decrypt_password
@@ -65,31 +68,6 @@ def _get_folder(db: Session, folder_id: uuid.UUID) -> Folder:
     if not folder:
         raise HTTPException(status_code=404, detail="Folder not found")
     return folder
-
-
-def _validate_asset_in_share(db: Session, link: ShareLink, asset: Asset) -> None:
-    """Validate that an asset belongs to a share link (folder, asset, project, or multi-share)."""
-    if link.folder_id:
-        if asset.folder_id != link.folder_id:
-            if not asset.folder_id or not _is_descendant_of(db, asset.folder_id, link.folder_id):
-                raise HTTPException(status_code=403, detail="Asset is not within the shared folder")
-    elif link.asset_id:
-        if asset.id != link.asset_id:
-            raise HTTPException(status_code=403, detail="Asset does not match share link")
-    elif link.project_id:
-        if asset.project_id != link.project_id:
-            raise HTTPException(status_code=403, detail="Asset is not within the shared project")
-        # For multi-share links, also check ShareLinkItem entries
-        multi_items = db.query(ShareLinkItem).filter(ShareLinkItem.share_link_id == link.id).all()
-        if multi_items:
-            multi_asset_ids = {item.asset_id for item in multi_items if item.asset_id}
-            multi_folder_ids = {item.folder_id for item in multi_items if item.folder_id}
-            if asset.id not in multi_asset_ids:
-                # Check if asset is in one of the shared folders
-                if not any(asset.folder_id == fid or (asset.folder_id and _is_descendant_of(db, asset.folder_id, fid)) for fid in multi_folder_ids):
-                    raise HTTPException(status_code=403, detail="Asset is not in the shared items")
-    else:
-        raise HTTPException(status_code=400, detail="Invalid share link")
 
 
 def _get_project_id_from_link(db: Session, link: ShareLink) -> uuid.UUID:
@@ -140,19 +118,6 @@ def _log_share_activity(
         db.commit()
     except Exception:
         db.rollback()
-
-
-def _is_descendant_of(db: Session, folder_id: uuid.UUID, ancestor_id: uuid.UUID) -> bool:
-    """Check if folder_id is a descendant of ancestor_id via parent chain traversal."""
-    current_id = folder_id
-    visited = set()
-    while current_id and current_id not in visited:
-        if current_id == ancestor_id:
-            return True
-        visited.add(current_id)
-        folder = db.query(Folder.parent_id).filter(Folder.id == current_id).first()
-        current_id = folder.parent_id if folder else None
-    return False
 
 
 def _get_latest_media_file(db: Session, asset_id: uuid.UUID) -> Optional[MediaFile]:
@@ -1402,7 +1367,7 @@ def get_share_stream_url(
     asset = _get_asset(db, asset_id)
 
     # Validate asset belongs to this share
-    _validate_asset_in_share(db, link, asset)
+    validate_asset_in_share(db, link, asset)
 
     media_file = None
     if version_id and link.show_versions:
@@ -1479,7 +1444,7 @@ def get_share_thumbnail_url(
     asset = _get_asset(db, asset_id)
 
     # Validate asset belongs to this share
-    _validate_asset_in_share(db, link, asset)
+    validate_asset_in_share(db, link, asset)
 
     media_file = _get_latest_media_file(db, asset.id)
     if not media_file or not media_file.s3_key_thumbnail:
@@ -1505,7 +1470,7 @@ def get_share_asset_versions(
     link = validate_share_link_with_session(db, token, share_session=share_session, current_user=current_user)
 
     asset = _get_asset(db, asset_id)
-    _validate_asset_in_share(db, link, asset)
+    validate_asset_in_share(db, link, asset)
 
     versions = db.query(AssetVersion).filter(
         AssetVersion.asset_id == asset.id,

--- a/apps/api/services/permissions.py
+++ b/apps/api/services/permissions.py
@@ -4,7 +4,8 @@ import uuid
 from ..models.user import User
 from ..models.project import Project, ProjectMember, ProjectRole
 from ..models.asset import Asset
-from ..models.share import AssetShare, ShareLink, SharePermission
+from ..models.folder import Folder
+from ..models.share import AssetShare, ShareLink, ShareLinkItem, SharePermission
 from ..services.redis_service import verify_share_session
 
 
@@ -146,3 +147,46 @@ def validate_share_link_with_session(
                 detail="Password required",
             )
     return link
+
+
+def _is_descendant_of(db: Session, folder_id: uuid.UUID, ancestor_id: uuid.UUID) -> bool:
+    """Check if folder_id is a descendant of ancestor_id via parent chain traversal."""
+    current_id = folder_id
+    visited = set()
+    while current_id and current_id not in visited:
+        if current_id == ancestor_id:
+            return True
+        visited.add(current_id)
+        folder = db.query(Folder.parent_id).filter(Folder.id == current_id).first()
+        current_id = folder.parent_id if folder else None
+    return False
+
+
+def validate_asset_in_share(db: Session, link: ShareLink, asset: Asset) -> None:
+    """Validate that an asset belongs to a share link (folder, asset, project, or multi-share).
+
+    Every endpoint that accepts a client-supplied asset_id alongside a share token must call
+    this — the token alone only proves the caller holds *some* valid link, not that this
+    particular asset is within its shared scope.
+    """
+    if link.folder_id:
+        if asset.folder_id != link.folder_id:
+            if not asset.folder_id or not _is_descendant_of(db, asset.folder_id, link.folder_id):
+                raise HTTPException(status_code=403, detail="Asset is not within the shared folder")
+    elif link.asset_id:
+        if asset.id != link.asset_id:
+            raise HTTPException(status_code=403, detail="Asset does not match share link")
+    elif link.project_id:
+        if asset.project_id != link.project_id:
+            raise HTTPException(status_code=403, detail="Asset is not within the shared project")
+        # For multi-share links, also check ShareLinkItem entries
+        multi_items = db.query(ShareLinkItem).filter(ShareLinkItem.share_link_id == link.id).all()
+        if multi_items:
+            multi_asset_ids = {item.asset_id for item in multi_items if item.asset_id}
+            multi_folder_ids = {item.folder_id for item in multi_items if item.folder_id}
+            if asset.id not in multi_asset_ids:
+                # Check if asset is in one of the shared folders
+                if not any(asset.folder_id == fid or (asset.folder_id and _is_descendant_of(db, asset.folder_id, fid)) for fid in multi_folder_ids):
+                    raise HTTPException(status_code=403, detail="Asset is not in the shared items")
+    else:
+        raise HTTPException(status_code=400, detail="Invalid share link")

--- a/apps/api/tests/test_share_comments.py
+++ b/apps/api/tests/test_share_comments.py
@@ -1,12 +1,16 @@
 import uuid
 from unittest.mock import MagicMock, patch
 
+from apps.api.models.share import SharePermission
 
+
+@patch("apps.api.routers.comments.validate_asset_in_share")
 @patch("apps.api.routers.comments._build_comment_responses_batched")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_returns_array_for_asset_share(
     mock_validate,
     mock_batched,
+    mock_validate_asset,
     client,
     mock_db,
 ):
@@ -20,6 +24,9 @@ def test_share_comments_returns_array_for_asset_share(
     link = MagicMock()
     link.asset_id = asset_id
     mock_validate.return_value = link
+    asset = MagicMock()
+    asset.id = asset_id
+    mock_db.first.return_value = asset  # _get_asset lookup
     mock_db.order_by.return_value = mock_db
     mock_db.all.return_value = [comment]
     mock_batched.return_value = [expected]
@@ -32,11 +39,13 @@ def test_share_comments_returns_array_for_asset_share(
     mock_batched.assert_called_once_with(asset_id, [comment], mock_db)
 
 
+@patch("apps.api.routers.comments.validate_asset_in_share")
 @patch("apps.api.routers.comments._build_comment_responses_batched")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_returns_array_for_folder_or_project_share_asset(
     mock_validate,
     mock_batched,
+    mock_validate_asset,
     client,
     mock_db,
 ):
@@ -50,6 +59,9 @@ def test_share_comments_returns_array_for_folder_or_project_share_asset(
     link = MagicMock()
     link.asset_id = None
     mock_validate.return_value = link
+    asset = MagicMock()
+    asset.id = asset_id
+    mock_db.first.return_value = asset  # _get_asset lookup
     mock_db.order_by.return_value = mock_db
     mock_db.all.return_value = [comment]
     mock_batched.return_value = [expected]
@@ -59,9 +71,12 @@ def test_share_comments_returns_array_for_folder_or_project_share_asset(
     assert response.status_code == 200
     assert response.json() == [expected]
     mock_batched.assert_called_once_with(asset_id, [comment], mock_db)
+    # Regression: the client-supplied asset_id must be checked against the link's scope
+    # (GHSA-5x82-5pxm-x2q7), not trusted outright.
+    mock_validate_asset.assert_called_once_with(mock_db, link, asset)
 
 
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_returns_empty_array_without_target_asset(
     mock_validate,
     client,
@@ -74,3 +89,101 @@ def test_share_comments_returns_empty_array_without_target_asset(
 
     assert response.status_code == 200
     assert response.json() == []
+
+
+def test_share_comments_rejects_asset_outside_shared_folder(client, mock_db):
+    """GET /share/{token}/comments — a folder-scoped link's asset_id query param is validated
+    against the link's actual scope, not trusted outright (GHSA-5x82-5pxm-x2q7). Uses the real
+    validate_asset_in_share so the rejection is exercised, not just asserted-called."""
+    shared_folder_id = uuid.uuid4()
+    other_asset_id = uuid.uuid4()
+
+    link = MagicMock()
+    link.asset_id = None
+    link.folder_id = shared_folder_id
+    link.project_id = None
+
+    other_asset = MagicMock()
+    other_asset.id = other_asset_id
+    other_asset.folder_id = None  # not in the shared folder, and no parent chain to it
+
+    with patch("apps.api.routers.comments.validate_share_link_with_session", return_value=link), \
+         patch("apps.api.routers.comments._get_asset", return_value=other_asset):
+        response = client.get(f"/share/some-token/comments?asset_id={other_asset_id}")
+
+    assert response.status_code == 403
+
+
+def test_guest_comment_single_asset_link_ignores_body_asset_id(client, mock_db):
+    """POST /share/{token}/comment — a single-asset share link always comments on its own
+    asset; a client-supplied body.asset_id for a different asset is never consulted
+    (GHSA-5x82-5pxm-x2q7)."""
+    shared_asset_id = uuid.uuid4()
+    other_asset_id = uuid.uuid4()
+
+    link = MagicMock()
+    link.asset_id = shared_asset_id
+    link.folder_id = None
+    link.project_id = None
+    link.permission = SharePermission.comment
+
+    shared_asset = MagicMock()
+    shared_asset.id = shared_asset_id
+    shared_asset.folder_id = None
+    shared_asset.project_id = uuid.uuid4()
+
+    with patch("apps.api.routers.comments.validate_share_link_with_session", return_value=link), \
+         patch("apps.api.routers.comments._get_asset") as mock_get_asset:
+        mock_get_asset.return_value = shared_asset
+        mock_db.order_by.return_value = mock_db
+        mock_db.first.return_value = None  # no ready version -> 400, short-circuits before insert
+
+        response = client.post(
+            "/share/some-token/comment",
+            json={
+                "asset_id": str(other_asset_id),
+                "body": "sneaky comment",
+                "guest_email": "attacker@example.com",
+                "guest_name": "Attacker",
+            },
+        )
+
+        # _get_asset must have been called with the link's own asset, never the attacker's.
+        mock_get_asset.assert_called_once_with(mock_db, shared_asset_id)
+
+    # No ready version for the (correctly-resolved) shared asset -> 400, not a successful post.
+    assert response.status_code == 400
+
+
+def test_guest_comment_rejects_asset_outside_shared_project(client, mock_db):
+    """POST /share/{token}/comment — a project-scoped share link can't be redirected to comment
+    on an asset from a different, unrelated project (GHSA-5x82-5pxm-x2q7)."""
+    shared_project_id = uuid.uuid4()
+    other_project_id = uuid.uuid4()
+    other_asset_id = uuid.uuid4()
+
+    link = MagicMock()
+    link.asset_id = None
+    link.folder_id = None
+    link.project_id = shared_project_id
+    link.id = uuid.uuid4()
+    link.permission = SharePermission.comment
+
+    other_asset = MagicMock()
+    other_asset.id = other_asset_id
+    other_asset.folder_id = None
+    other_asset.project_id = other_project_id  # not the shared project
+
+    with patch("apps.api.routers.comments.validate_share_link_with_session", return_value=link), \
+         patch("apps.api.routers.comments._get_asset", return_value=other_asset):
+        response = client.post(
+            "/share/some-token/comment",
+            json={
+                "asset_id": str(other_asset_id),
+                "body": "sneaky comment",
+                "guest_email": "attacker@example.com",
+                "guest_name": "Attacker",
+            },
+        )
+
+    assert response.status_code == 403

--- a/apps/api/tests/test_share_password_preview.py
+++ b/apps/api/tests/test_share_password_preview.py
@@ -61,7 +61,7 @@ def test_folder_share_assets_creator_bypasses_password(
 
 @patch("apps.api.routers.share.generate_presigned_get_url")
 @patch("apps.api.routers.share._get_latest_media_file")
-@patch("apps.api.routers.share._validate_asset_in_share")
+@patch("apps.api.routers.share.validate_asset_in_share")
 @patch("apps.api.routers.share._get_asset")
 @patch("apps.api.services.permissions.verify_share_session")
 @patch("apps.api.services.permissions.validate_share_link")

--- a/apps/api/tests/test_share_versions.py
+++ b/apps/api/tests/test_share_versions.py
@@ -20,7 +20,7 @@ def _ready_version(number: int):
     )
 
 
-@patch("apps.api.routers.share._validate_asset_in_share")
+@patch("apps.api.routers.share.validate_asset_in_share")
 @patch("apps.api.routers.share._get_asset")
 @patch("apps.api.services.permissions.validate_share_link")
 def test_guest_versions_returns_all_when_show_versions_enabled(
@@ -48,7 +48,7 @@ def test_guest_versions_returns_all_when_show_versions_enabled(
     assert all(v["processing_status"] == "ready" for v in resp.json())
 
 
-@patch("apps.api.routers.share._validate_asset_in_share")
+@patch("apps.api.routers.share.validate_asset_in_share")
 @patch("apps.api.routers.share._get_asset")
 @patch("apps.api.services.permissions.validate_share_link")
 def test_guest_versions_returns_latest_only_when_hidden(
@@ -77,19 +77,26 @@ def test_guest_versions_returns_latest_only_when_hidden(
 
 
 @patch("apps.api.routers.comments._build_comment_response")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_asset_in_share")
+@patch("apps.api.routers.comments._get_asset")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_accepts_version_id(
-    mock_validate_link, mock_build, client, mock_db
+    mock_validate_link, mock_get_asset, mock_validate_in_share, mock_build, client, mock_db
 ):
     link = MagicMock()
     link.asset_id = None
     mock_validate_link.return_value = link
 
+    asset = MagicMock()
+    asset.id = uuid.uuid4()
+    mock_get_asset.return_value = asset
+    mock_validate_in_share.return_value = None
+
     mock_db.order_by.return_value = mock_db
     mock_db.all.return_value = []
 
     resp = client.get(
-        f"/share/tok/comments?asset_id={uuid.uuid4()}&version_id={uuid.uuid4()}"
+        f"/share/tok/comments?asset_id={asset.id}&version_id={uuid.uuid4()}"
     )
 
     assert resp.status_code == 200, resp.text
@@ -98,20 +105,27 @@ def test_share_comments_accepts_version_id(
 
 
 @patch("apps.api.routers.comments._build_comment_response")
-@patch("apps.api.routers.comments.validate_share_link")
+@patch("apps.api.routers.comments.validate_asset_in_share")
+@patch("apps.api.routers.comments._get_asset")
+@patch("apps.api.routers.comments.validate_share_link_with_session")
 def test_share_comments_accepts_latest_only(
-    mock_validate_link, mock_build, client, mock_db
+    mock_validate_link, mock_get_asset, mock_validate_in_share, mock_build, client, mock_db
 ):
     """The folder/grid preview scopes to the latest ready version via latest_only=true."""
     link = MagicMock()
     link.asset_id = None
     mock_validate_link.return_value = link
 
+    asset = MagicMock()
+    asset.id = uuid.uuid4()
+    mock_get_asset.return_value = asset
+    mock_validate_in_share.return_value = None
+
     mock_db.order_by.return_value = mock_db
     mock_db.first.return_value = None  # no ready version resolved
     mock_db.all.return_value = []
 
-    resp = client.get(f"/share/tok/comments?asset_id={uuid.uuid4()}&latest_only=true")
+    resp = client.get(f"/share/tok/comments?asset_id={asset.id}&latest_only=true")
 
     assert resp.status_code == 200, resp.text
     assert resp.json() == []

--- a/apps/api/tests/test_share_video_stream.py
+++ b/apps/api/tests/test_share_video_stream.py
@@ -147,7 +147,7 @@ def test_validate_share_link_image_does_not_append_master_m3u8(
     )
 
 
-@patch("apps.api.routers.share._validate_asset_in_share")
+@patch("apps.api.routers.share.validate_asset_in_share")
 @patch("apps.api.routers.share._log_share_activity")
 @patch("apps.api.routers.share._get_latest_media_file")
 @patch("apps.api.routers.share._get_asset")


### PR DESCRIPTION
## Summary

GHSA-5x82-5pxm-x2q7: `GET /share/{token}/comments` and `POST /share/{token}/comment` trusted a client-supplied `asset_id` for folder/project-scoped links with no check that the asset was actually in scope — and the write endpoint even let a single-asset link's own `asset_id` be overridden by the request body. Holding *any* comment/approve-permission share link was enough to read or write comments on assets never shared with that link. Both endpoints also skipped password/session verification, unlike every other public share route.

## Changes

- Moved `_validate_asset_in_share` (renamed `validate_asset_in_share`, no underscore) and its `_is_descendant_of` helper from `routers/share.py` into `services/permissions.py`, so `routers/comments.py` can reuse the same scope check instead of duplicating or skipping it. `share.py`'s 3 existing call sites updated to the shared import.
- `list_share_comments`: resolves `target_asset_id` the same way as before (`link.asset_id or asset_id`), but now validates the result against the link's scope via `validate_asset_in_share` instead of trusting it outright. Switched to `validate_share_link_with_session` for password enforcement.
- `guest_comment`: resolution order flipped to `link.asset_id or body.asset_id` (link wins) so a single-asset link can't be redirected by the request body at all; for folder/project links, the body-supplied `asset_id` is now validated against scope. Switched to `validate_share_link_with_session`.
- CHANGELOG entry under `[Unreleased]`.

## Testing

- [x] Backend tests pass (`docker exec -w /workspace freeframe-api-1 python -m pytest apps/api/tests/` — 214 passed). Updated 4 existing test files whose mocks referenced the old `_validate_asset_in_share`/bare `validate_share_link` names; added 3 new regression tests (folder-scope rejection, single-asset body override ignored, project-scope rejection).
- [ ] Frontend tests + build pass (no frontend changes; not run)
- [x] Tested manually against the live dev stack with real seeded share links (not mocks):
  - Single-asset link + malicious `body.asset_id` for a different asset → comment created, but scoped to the link's own asset (attacker's `asset_id` silently ignored) — confirmed via the response's `asset_id`.
  - Project-scoped link + `asset_id` from an unrelated project → `403 Asset is not within the shared project`. Same link + an asset actually in its own project → `201`, succeeds normally.
  - Password-protected link, no `share_session` → both `GET .../comments` and `POST .../comment` now `403 Password required` (previously both succeeded with just the token).
  - Test data cleaned up afterward; dev DB restored to prior state.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`