### PR TITLE
fix(security): close remaining Medium/Low findings from the auth audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A superadmin can no longer delete or deactivate their own account and get irrecoverably locked out** — `DELETE /users/{id}` gained the same self-protection `PATCH /admin/users/{id}/deactivate` already had. Removed two duplicate, unused endpoints (`/users/{id}/deactivate`, `/users/{id}/reactivate`) that had no such guard and no frontend caller — the admin dashboard already uses the correctly-guarded `/admin/users/{id}/...` versions.
+- **`/auth/login` is now rate-limited** (10 attempts / 10 minutes per IP) — previously only the generic global write limiter (300/minute) backed password login.
+- **`/auth/verify-magic-code` no longer reveals whether an email is registered or deactivated** — an unknown email, a deactivated account, and a wrong code now all return the same generic 401, matching how `/auth/login` already avoids this.
+- **Internal-visibility comments no longer reach public share links** — a comment (or reply, at any thread depth) marked "internal" is team-only by design, but the guest share endpoints didn't filter on visibility at all.
+- **`@mention`ing a user in a comment now requires that user to actually have access to the asset** — previously any mentioned user id (or parsed `@email`) got a real notification and email with the asset name and a comment preview, regardless of whether they could see the asset at all.
+- **Replying to a comment now checks the parent comment belongs to the same asset** — `POST /assets/{id}/comments/{comment_id}/replies` looked up the parent by id alone, so a comment id from an unrelated asset (including one the caller has no access to) would be accepted, letting a caller both probe whether an arbitrary comment id exists and inject a reply into a thread on an asset they can't see.
+- **`POST /assets/{id}/comments` now validates that `version_id` actually belongs to the asset** — previously accepted unchecked, which could create a comment whose `asset_id` and `version_id` referred to two different assets.
+
 ## [1.7.3] - 2026-07-23
 
 ### Fixed

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -79,12 +79,11 @@ def verify_magic_code(body: VerifyMagicCodeRequest, db: Session = Depends(get_db
     """
     user = get_user_by_email(db, body.email)
     
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    
-    if user.status == UserStatus.deactivated:
-        raise HTTPException(status_code=401, detail="Account deactivated")
-    
+    # "No such user" and "deactivated" get the same generic failure as a wrong/expired code —
+    # distinguishing them would let a caller enumerate registered or deactivated emails.
+    if not user or user.status == UserStatus.deactivated:
+        raise HTTPException(status_code=401, detail="Invalid or expired code")
+
     # Verify magic code from Redis
     success, error = redis_verify_magic_code(body.email, body.code)
     if not success:
@@ -171,7 +170,7 @@ def accept_invite(body: AcceptInviteRequest, db: Session = Depends(get_db)):
     )
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post("/login", response_model=TokenResponse, dependencies=[Depends(rate_limit("login", 10, 600))])
 def login(body: LoginRequest, db: Session = Depends(get_db)):
     """Login with email + password."""
     user = get_user_by_email(db, body.email)

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -36,7 +36,7 @@ from ..schemas.comment import (
 from ..services import s3_service
 from ..services import comment_export
 from ..services.permissions import (
-    require_asset_access, validate_share_link_with_session, validate_asset_in_share,
+    require_asset_access, can_access_asset, validate_share_link_with_session, validate_asset_in_share,
 )
 from ..tasks.email_tasks import send_mention_email, send_comment_email
 from ..tasks.celery_app import send_task_safe
@@ -163,22 +163,27 @@ def _build_comment_responses_batched(
     db: Session,
     current_user_id: uuid.UUID | None = None,
     max_depth: int = 5,
+    exclude_internal: bool = False,
 ) -> list[CommentResponse]:
     """Build the comment tree for `top_level` with a FIXED number of queries
     instead of one-per-comment. Field-for-field equivalent to calling
     _build_comment_response on each top-level comment, but ~6 queries total
     regardless of how many comments the asset has (avoids the N+1 that made the
-    list endpoint slow — and it's re-fetched after every comment save)."""
+    list endpoint slow — and it's re-fetched after every comment save).
+
+    exclude_internal drops visibility="internal" comments (and their whole subtree, since a
+    reply to a team-only comment is team-only too) — set for guest/public callers so an
+    internal note never reaches a share link, no matter how deep in the thread it is."""
     if not top_level:
         return []
 
     # One query for every non-deleted comment on the asset → parent→children map.
-    all_comments = (
-        db.query(Comment)
-        .filter(Comment.asset_id == asset_id, Comment.deleted_at.is_(None))
-        .order_by(Comment.created_at)
-        .all()
+    all_comments_query = db.query(Comment).filter(
+        Comment.asset_id == asset_id, Comment.deleted_at.is_(None),
     )
+    if exclude_internal:
+        all_comments_query = all_comments_query.filter(Comment.visibility != "internal")
+    all_comments = all_comments_query.order_by(Comment.created_at).all()
     children_map: dict[uuid.UUID, list[Comment]] = defaultdict(list)
     for c in all_comments:
         if c.parent_id is not None:
@@ -277,6 +282,11 @@ def _create_mentions(db: Session, comment: Comment, asset: Asset, body: str, aut
             if user and user.id != comment.author_id:
                 mentioned_users.append(user)
 
+    # A mention must only reach someone who can actually see the asset — otherwise any user
+    # (or a guest via a share link) could @mention an arbitrary user id/email and have their
+    # name, the asset name, and a comment preview emailed to someone with no access to either.
+    mentioned_users = [u for u in mentioned_users if can_access_asset(db, asset, u)]
+
     for user in mentioned_users:
         mention = Mention(comment_id=comment.id, mentioned_user_id=user.id)
         db.add(mention)
@@ -334,6 +344,13 @@ def create_comment(
     asset = _get_asset(db, asset_id)
     require_asset_access(db, asset, current_user)
 
+    version = db.query(AssetVersion).filter(
+        AssetVersion.id == body.version_id, AssetVersion.asset_id == asset_id,
+        AssetVersion.deleted_at.is_(None),
+    ).first()
+    if not version:
+        raise HTTPException(status_code=400, detail="version_id does not belong to this asset")
+
     comment = Comment(
         asset_id=asset_id,
         version_id=body.version_id,
@@ -386,7 +403,9 @@ def reply_to_comment(
 ):
     asset = _get_asset(db, asset_id)
     require_asset_access(db, asset, current_user)
-    parent = db.query(Comment).filter(Comment.id == comment_id, Comment.deleted_at.is_(None)).first()
+    parent = db.query(Comment).filter(
+        Comment.id == comment_id, Comment.asset_id == asset_id, Comment.deleted_at.is_(None),
+    ).first()
     if not parent:
         raise HTTPException(status_code=404, detail="Parent comment not found")
 
@@ -823,18 +842,20 @@ def list_share_comments(
         ).order_by(AssetVersion.version_number.desc()).first()
         version_id = latest.id if latest else version_id
 
-    # Get top-level comments — reuse same format as authenticated endpoint
+    # Get top-level comments — reuse same format as authenticated endpoint. Internal-visibility
+    # comments are team-only and must never reach a public share link.
     query = db.query(Comment).filter(
         Comment.asset_id == asset_id,
         Comment.parent_id.is_(None),
         Comment.deleted_at.is_(None),
+        Comment.visibility != "internal",
     )
     if version_id:
         query = query.filter(Comment.version_id == version_id)
     top_level = query.order_by(Comment.created_at).all()
 
     # Batched build (fixed query count) — guests have no user, so no current_user_id.
-    return _build_comment_responses_batched(asset_id, top_level, db)
+    return _build_comment_responses_batched(asset_id, top_level, db, exclude_internal=True)
 
 
 @router.post("/share/{token}/comment", response_model=CommentResponse, status_code=status.HTTP_201_CREATED)

--- a/apps/api/routers/users.py
+++ b/apps/api/routers/users.py
@@ -142,28 +142,10 @@ def confirm_avatar_upload(
     return user
 
 
-@router.patch("/{user_id}/deactivate", response_model=UserResponse)
-def deactivate_user(user_id: uuid.UUID, db: Session = Depends(get_db), _: User = Depends(require_admin)):
-    user = db.query(User).filter(User.id == user_id, User.deleted_at.is_(None)).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    user.status = UserStatus.deactivated
-    db.commit()
-    db.refresh(user)
-    return user
-
-@router.patch("/{user_id}/reactivate", response_model=UserResponse)
-def reactivate_user(user_id: uuid.UUID, db: Session = Depends(get_db), _: User = Depends(require_admin)):
-    user = db.query(User).filter(User.id == user_id, User.deleted_at.is_(None)).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    user.status = UserStatus.active
-    db.commit()
-    db.refresh(user)
-    return user
-
 @router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_user(user_id: uuid.UUID, db: Session = Depends(get_db), _: User = Depends(require_admin)):
+def delete_user(user_id: uuid.UUID, db: Session = Depends(get_db), current_user: User = Depends(require_admin)):
+    if user_id == current_user.id:
+        raise HTTPException(status_code=400, detail="You cannot delete yourself")
     user = db.query(User).filter(User.id == user_id, User.deleted_at.is_(None)).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -166,6 +166,48 @@ def test_admin_list_users_still_includes_invite_token(client, auth_headers, mock
     assert body[0]["invite_token"] == "super-secret-invite-token"
 
 
+def test_verify_magic_code_unknown_user_generic_401(client, mock_db):
+    """POST /auth/verify-magic-code — an unregistered email gets the same generic failure as a
+    wrong code (401), not a distinguishing 404. Otherwise the endpoint lets a caller enumerate
+    which emails are registered."""
+    mock_db.first.return_value = None
+
+    with patch("apps.api.middleware.rate_limit.check_rate_limit", return_value=(True, 0)):
+        resp = client.post("/auth/verify-magic-code", json={"email": "nobody@example.com", "code": "000000"})
+
+    assert resp.status_code == 401
+
+
+def test_verify_magic_code_deactivated_user_generic_401(client, mock_db):
+    """POST /auth/verify-magic-code — a deactivated account gets the same generic 401 as an
+    unregistered email or a wrong code, not a distinguishing "Account deactivated" message."""
+    user = _mock_user("deactivated@example.com")
+    user.status = UserStatus.deactivated
+    mock_db.first.return_value = user
+
+    with patch("apps.api.middleware.rate_limit.check_rate_limit", return_value=(True, 0)):
+        resp = client.post("/auth/verify-magic-code", json={"email": "deactivated@example.com", "code": "000000"})
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid or expired code"
+
+
+def test_verify_magic_code_success(client, mock_db):
+    """POST /auth/verify-magic-code — correct code for an active user returns tokens."""
+    user = _mock_user("verify@example.com")
+    user.status = UserStatus.active
+    mock_db.first.return_value = user
+
+    with patch("apps.api.middleware.rate_limit.check_rate_limit", return_value=(True, 0)), \
+         patch("apps.api.routers.auth.redis_verify_magic_code", return_value=(True, "")):
+        resp = client.post("/auth/verify-magic-code", json={"email": "verify@example.com", "code": "123456"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+
 def test_get_me(client, auth_headers, test_user):
     """GET /auth/me — returns current user profile."""
     resp = client.get("/auth/me", headers=auth_headers)
@@ -196,3 +238,13 @@ def test_get_me_no_auth(client):
     """GET /auth/me without token should return 401 or 403 (no bearer scheme)."""
     resp = client.get("/auth/me")
     assert resp.status_code in (401, 403)
+
+
+def test_delete_user_rejects_self(client, auth_headers, test_user):
+    """DELETE /users/{id} — an admin can't delete their own account. Matches the
+    self-protection already on /admin/users/{id}/deactivate; without it, a superadmin
+    (accidentally or via a compromised session) could lock themselves out irrecoverably,
+    since /setup/create-superadmin only checks is_superadmin, not soft-deletion."""
+    test_user.is_superadmin = True
+    resp = client.delete(f"/users/{test_user.id}", headers=auth_headers)
+    assert resp.status_code == 400

--- a/apps/api/tests/test_share_comments.py
+++ b/apps/api/tests/test_share_comments.py
@@ -36,7 +36,7 @@ def test_share_comments_returns_array_for_asset_share(
     assert response.status_code == 200
     assert response.json() == [expected]
     # Batched builder, called once for the whole thread (no per-comment N+1).
-    mock_batched.assert_called_once_with(asset_id, [comment], mock_db)
+    mock_batched.assert_called_once_with(asset_id, [comment], mock_db, exclude_internal=True)
 
 
 @patch("apps.api.routers.comments.validate_asset_in_share")
@@ -70,7 +70,7 @@ def test_share_comments_returns_array_for_folder_or_project_share_asset(
 
     assert response.status_code == 200
     assert response.json() == [expected]
-    mock_batched.assert_called_once_with(asset_id, [comment], mock_db)
+    mock_batched.assert_called_once_with(asset_id, [comment], mock_db, exclude_internal=True)
     # Regression: the client-supplied asset_id must be checked against the link's scope
     # (GHSA-5x82-5pxm-x2q7), not trusted outright.
     mock_validate_asset.assert_called_once_with(mock_db, link, asset)


### PR DESCRIPTION
## Summary

Several smaller access-control gaps found in the same adversarial review as #206/#208/#210. None individually severe enough for a standalone advisory, but each is real and independently verified — not filing a formal advisory for this batch given the lower severity, but tracking here.

## Changes

- `DELETE /users/{id}`: added a self-deletion guard (matches `/admin/users/{id}/deactivate`'s existing one). Removed `/users/{id}/deactivate` and `/users/{id}/reactivate` — unused duplicates of the already-guarded `/admin/users/{id}/...` routes, missing the same self-protection.
- `/auth/login`: added an endpoint-specific rate limit (10/10min per IP), on top of the existing generic 300/min global limiter.
- `/auth/verify-magic-code`: unknown email, deactivated account, and wrong code now all return the same generic 401 — previously distinguishable (404 vs two different 401 messages), enumerable.
- `list_share_comments`: internal-visibility comments (and replies at any depth) are now excluded from the public share view.
- `_create_mentions`: mentioned users are now filtered to those who can actually access the asset before a notification/email goes out.
- `reply_to_comment`: parent comment lookup now also requires `asset_id` to match.
- `create_comment`: `version_id` is now validated against the asset before use.

## Testing

- [x] Backend tests pass (`docker exec -w /workspace freeframe-api-1 python -m pytest apps/api/tests/` — 218 passed). Added regression tests for the self-delete guard and the verify-magic-code enumeration fix.
- [ ] Frontend tests + build pass (no frontend changes; not run)
- [x] Tested manually against the live dev stack with real seeded data (not mocks) for the fixes that are hard to prove via mocked-DB tests:
  - `create_comment` with a `version_id` from a different asset → `400`; correct `version_id` → `201`.
  - `reply_to_comment` targeting a comment id from a different asset → `404` (previously would have succeeded).
  - `@mention`ing a project member → real `Mention`/`Notification` row created; `@mention`ing a user with no access to the asset → nothing created.
  - An `internal`-visibility comment on an asset → confirmed absent from that asset's public share-link comment listing, alongside its normal public comments which still appear.
  - Test data cleaned up afterward; dev DB restored to prior state.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`