### PR TITLE
docs: credit external contributors in CHANGELOG and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Version switch clears active comment annotation** — switching versions in the single-asset review view now clears the focused comment and active drawing overlay, preventing drawings from previous versions from lingering on top of the newly selected version.
-- Server-side password length validation on change-password endpoint.
+- **Version switch clears active comment annotation** — switching versions in the single-asset review view now clears the focused comment and active drawing overlay, preventing drawings from previous versions from lingering on top of the newly selected version. (#198 by @Vrindakr3300)
+- **HLS renditions no longer upscale past the source resolution** — `force_original_aspect_ratio=decrease` preserved aspect ratio but not scale, so a 640×360 source was still producing padded, blurry 1080p/720p renditions. The quality ladder is now filtered against the actual source height (ffprobe'd before transcoding), falling back to the smallest requested rendition rather than an empty ladder if the source is smaller than everything requested. (#204 by @siddharthgoyal00)
+- Server-side password length validation on change-password endpoint. (#179 by @An-Array)
 
 ### Changed
-- Password changes now revoke all other sessions by incrementing token version; current session receives fresh tokens to stay logged in.
+- Password changes now revoke all other sessions by incrementing token version; current session receives fresh tokens to stay logged in. (#179 by @An-Array)
+
+### Contributors
+Thanks to @An-Array, @Vrindakr3300, @siddharthgoyal00, and @solankimeet518 for contributing to this release! (@solankimeet518's #199 hardened the `matchMedia` test stub — no user-facing entry above, but very much appreciated.)
 
 ## [1.7.4] - 2026-07-23
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,12 +14,21 @@ self-hosters can track a known-good version instead of `main`.
 
 1. Make sure `main` is green and the `CHANGELOG.md` `[Unreleased]` section is
    complete. Move those entries under a new `## [X.Y.Z] - YYYY-MM-DD` heading.
+   - **Credit external contributors.** For every PR in this release authored by
+     someone other than the maintainer, check the entry it added has a trailing
+     `(#NNN by @handle)`, and make sure that handle appears in a `### Contributors`
+     line at the end of the version's section — *every* contributor from this
+     release goes there, even ones whose PR had no user-facing entry of its own
+     (test infra, internal refactors, etc.). Nobody who had a PR merged this
+     release should be invisible in the CHANGELOG.
 2. Tag the release commit and push the tag:
    ```bash
    git tag vX.Y.Z <commit>      # usually main's HEAD
    git push origin vX.Y.Z
    ```
-3. Publish a **GitHub Release** for `vX.Y.Z` with notes (the CHANGELOG section).
+3. Publish a **GitHub Release** for `vX.Y.Z` with notes (the CHANGELOG section,
+   `### Contributors` line included — the release notes are where a contributor's
+   name actually gets seen, so don't drop it here even if you trim anything else).
    - Publishing it triggers `release-pointers.yml`, which **auto-moves `latest`**
      to `vX.Y.Z`. (Mark it a *pre-release* to keep `latest` where it is.)
 


### PR DESCRIPTION
## Summary

Contributors currently get zero visibility in our release notes beyond the merge commit. Adds a step to the release process so that stops: every external contributor gets named in the CHANGELOG and the actual GitHub Release notes, not just buried in git history.

## Changes

- `docs/RELEASING.md`: new sub-step under "Cutting a release" — credit external contributors with a trailing `(#NNN by @handle)` on their CHANGELOG entry, and list every external contributor for the release in a `### Contributors` line, even if their PR had no user-facing entry of its own (test infra, internal refactors, etc.).
- `CHANGELOG.md`: applied to the current `[Unreleased]` section (hasn't shipped yet, so fair game) — credited #179 (@An-Array), #198 (@Vrindakr3300), #204 (@siddharthgoyal00), and added a `### Contributors` line covering all four including #199 (@solankimeet518), whose matchMedia test-stub fix has no user-facing entry of its own. Also added a missing "Fixed" entry for #204 (HLS ladder upscale), which had no CHANGELOG entry at all before this.

## Testing

- [x] N/A — docs/CHANGELOG only, no code changes

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]` (n/a, this PR edits existing entries rather than adding a new one)