### PR TITLE
chore(deps): group Dependabot updates to stop the rebase cascade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,140 @@
 version: 2
+
+# Routine version updates are batched into ONE PR per manifest.
+#
+# Why grouping (and not a lower open-pull-requests-limit): every pip PR edits
+# apps/api/requirements.txt and every npm PR edits apps/web/pnpm-lock.yaml, so
+# N open PRs means N-1 rebases after any merge. The conflict-optimal number of
+# open PRs per manifest is exactly 1. Lowering the limit caps the symptom;
+# grouping removes the cascade.
+#
+# Security updates are NOT throttled by anything in this file:
+#   - groups default to `applies-to: version-updates` (none here opt in to
+#     security-updates)
+#   - `cooldown` is documented as version-updates only
+#   - `ignore` + `update-types` is documented as version-updates only
+#   - security PRs are exempt from `open-pull-requests-limit`
+# NOTE: this only holds if Dependabot security updates are ENABLED on the repo.
+# That is a repo setting, not a config option:
+#   gh api -X PUT repos/:owner/:repo/automated-security-fixes
+#
+# Vocabulary trap: `groups.update-types` takes bare minor/patch/major, while
+# `ignore.update-types` takes version-update:semver-major. They are not the
+# same vocabulary.
+
 updates:
+  # ---------------------------------------------------------------------
+  # Python API — apps/api/requirements.txt
+  # ---------------------------------------------------------------------
   - package-ecosystem: pip
     directory: /apps/api
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
+      time: "06:00"
+      timezone: Etc/UTC
     open-pull-requests-limit: 5
     labels: ["dependencies", "backend"]
+    cooldown:
+      # boto3 ships almost daily; without a cooldown the grouped PR is
+      # superseded and rebased constantly.
+      default-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      api-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     ignore:
-      # Avoid major version bumps — review manually
+      # Majors reviewed by hand. Does NOT suppress security updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  # ---------------------------------------------------------------------
+  # Web frontend — apps/web/package.json + pnpm-lock.yaml
+  # ---------------------------------------------------------------------
   - package-ecosystem: npm
     directory: /apps/web
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
+      time: "06:00"
+      timezone: Etc/UTC
     open-pull-requests-limit: 5
     labels: ["dependencies", "frontend"]
+    cooldown:
+      default-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      web-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  # ---------------------------------------------------------------------
+  # GitHub Actions — .github/workflows/*
+  # Majors are deliberately NOT ignored. For actions the major tag is the
+  # ordinary release channel (setup-node v6 -> v7 is a runner/Node bump, not
+  # a breaking API change), and pinning to an old major is how you end up
+  # stranded on a retired runner. The workflows ARE the test surface, so a
+  # bad bump fails CI immediately. Batch them instead of muting them.
+  # ---------------------------------------------------------------------
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
     open-pull-requests-limit: 3
     labels: ["dependencies", "ci"]
+    cooldown:
+      # github-actions supports default-days only (no semver-*-days).
+      default-days: 7
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
+          - minor
+          - patch
 
+  # ---------------------------------------------------------------------
+  # Docker base images
+  # `directories` (plural, supports globbing) covers both app images in one
+  # entry. Note: apps/web/Dockerfile* pin node:20-alpine, and Node 20 is EOL
+  # (2026-04-30). Moving to node:22 is a MAJOR bump and is therefore ignored
+  # below — it still needs a hand-written PR. Do not assume this entry
+  # handles it.
+  # ---------------------------------------------------------------------
   - package-ecosystem: docker
-    directory: /apps/api
+    directories:
+      - /apps/api
+      - /apps/web
     schedule:
       interval: monthly
     open-pull-requests-limit: 2
     labels: ["dependencies", "docker"]
+    cooldown:
+      default-days: 7
+    groups:
+      docker-images:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Why

Dependabot was opening one PR per package, and all three ecosystems were sitting at their `open-pull-requests-limit` (12 open at once). The real cost was not the count. Every pip PR edits `apps/api/requirements.txt` and every npm PR edits `apps/web/pnpm-lock.yaml`, so merging one made its siblings stale and forced a rebase. Draining the queue took roughly one rebase round-trip per PR.

Grouping brings this to exactly one open PR per manifest, which is the conflict-optimal number.

## What changed

- Routine minor and patch updates are grouped into one PR per ecosystem
- pip and npm move to a monthly cadence
- `cooldown` added so fast-moving packages do not constantly supersede the grouped PR (boto3 ships almost daily)
- Docker coverage extended to `apps/web`, which previously had no update path
- github-actions majors deliberately keep flowing, batched monthly

Expected volume: 2 PRs on a normal month, 3 to 4 when actions or a base image moves. Down from 12.

## Security updates are not throttled

Every mechanism used here is documented as version-updates only: groups default to `applies-to: version-updates`, `cooldown` and `ignore`/`update-types` do not apply to security updates, and security PRs are exempt from `open-pull-requests-limit`. A CVE fixed only in a major release still gets a PR despite the semver-major ignore.

## Not fixed by this change

- `apps/web/Dockerfile*` pin `node:20-alpine` and `ci.yml` uses `node-version: "20"`. Node 20 reached EOL on 2026-04-30. That bump is a major, so it stays ignored and needs a hand-written PR.
- The root `pnpm-lock.yaml` has no Dependabot coverage (the npm entry targets `/apps/web` only), and `turbo` is pinned to `"latest"`, so it cannot be bumped.
