### PR TITLE
chore(deps): pin starlette and botocore to stop silent rebuild drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Pinned `starlette` and `botocore` so self-hosted Docker builds are reproducible** — both were floating transitives, so rebuilding the same commit on a different day could silently install different versions with no diff and no PR. FastAPI declares `starlette>=0.46.0` with no upper bound, meaning builds were free to cross a Starlette major (the ASGI layer under the SSE endpoint and the middleware stack); `botocore` is where S3 request signing lives, and unreviewed moves there have broken S3 compatibility before. Both are pinned to the versions already resolving, so no installed version changes.
+
 ## [1.7.5] - 2026-07-23
 
 ### Fixed

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,4 +1,10 @@
 fastapi==0.141.1
+# Pinned transitive: fastapi declares `starlette>=0.46.0` with no upper bound,
+# so an unpinned build drifts across starlette MAJOR versions on rebuild alone.
+# Starlette is the ASGI layer under the SSE endpoint and the BaseHTTPMiddleware
+# stack, so that drift is invisible until it is not. Pinned to the version
+# already resolving today; bump it deliberately alongside fastapi.
+starlette==1.3.1
 uvicorn[standard]==0.51.0
 sqlalchemy==2.0.51
 alembic==1.18.5
@@ -9,6 +15,11 @@ python-jose[cryptography]==3.5.0
 bcrypt==4.3.0
 python-multipart==0.0.32
 boto3==1.43.56
+# Pinned transitive: boto3 allows any botocore in >=1.43.56,<1.44.0, and botocore
+# is where S3 request signing lives. Silent botocore moves have broken S3
+# compatibility here before (SigV4 presigning against non-AWS backends), so this
+# is pinned to make those changes arrive as a reviewable PR.
+botocore==1.43.63
 celery[redis]==5.4.0
 redis==5.3.1
 httpx==0.28.1


### PR DESCRIPTION
## Why

`apps/api/requirements.txt` pins every direct dependency with `==`, but two load-bearing transitives were left floating. Since the Dockerfiles run a plain `pip install --no-cache-dir -r requirements.txt`, they resolve at build time. That means rebuilding the same commit on a different day can install a different version, with no diff, no PR, and nothing for Dependabot to watch, because neither package is in the manifest.

**`starlette`** — FastAPI declares `starlette>=0.46.0` with no upper bound. Latest starlette is `1.3.1`, so builds were free to cross a major version. Starlette is the ASGI layer underneath the SSE endpoint at `/events/{project_id}` and the `BaseHTTPMiddleware` stack, which is not a layer that should move without review.

**`botocore`** — boto3 accepts any botocore in `>=1.43.56,<1.44.0`, and botocore is where S3 request signing lives. Silent changes there have broken S3 compatibility in this repo before, specifically SigV4 presigning against non-AWS backends.

## What changed

Both are pinned to the versions that already resolve today, so nothing about the installed stack changes.

```
starlette==1.3.1
botocore==1.43.63
```

## Verification

Resolved `requirements.txt` against `python:3.11-slim` (the image the Dockerfiles use) before and after this change:

```
packages before: 66   after: 66
version differences: NONE (identical resolved set)
```

So this is provably a no-op for the current build. It only changes what happens on a future rebuild, where a version move now arrives as a reviewable PR instead of appearing silently in an image.

## Note

This is pre-existing and unrelated to the recent dependency bumps. `fastapi==0.139.0` had the same unbounded starlette spec, so the drift window was already open.
