### PR TITLE
chore(deps): restrict the docker group to patch updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,12 +110,31 @@ updates:
           - patch
 
   # ---------------------------------------------------------------------
-  # Docker base images
+  # Docker base images — PATCH ONLY, which today means: nothing.
+  #
   # `directories` (plural, supports globbing) covers both app images in one
-  # entry. Note: apps/web/Dockerfile* pin node:20-alpine, and Node 20 is EOL
-  # (2026-04-30). Moving to node:22 is a MAJOR bump and is therefore ignored
-  # below — it still needs a hand-written PR. Do not assume this entry
-  # handles it.
+  # entry. A base-image bump swaps the interpreter/runtime under the whole
+  # service at once, so it is not a dependency bump in the ordinary sense and
+  # is not something to accept on a green build. Restricted to patch here.
+  #
+  # READ THIS BEFORE ASSUMING THIS ENTRY KEEPS BASE IMAGES CURRENT — it does
+  # not, and cannot, for the tags we pin:
+  #   apps/api/Dockerfile*  FROM python:3.11-slim
+  #   apps/web/Dockerfile*  FROM node:20-alpine
+  # Dockerfile tag matching is precision-filtered: a two-segment tag only
+  # matches other two-segment tags, a one-segment tag only one-segment. So
+  # python:3.11-slim can only ever move to 3.x-slim (always MINOR) and
+  # node:20-alpine only to 2x-alpine (always MAJOR). Neither is ever a PATCH.
+  # Net effect: this entry opens zero PRs until a tag here gains a patch
+  # segment (e.g. python:3.11.14-slim).
+  #
+  # Keeping base images current is therefore a MANUAL, CALENDARED job, not an
+  # automated one. Node 20 is already EOL (2026-04-30) and needs a
+  # hand-written PR.
+  #
+  # The `ignore` block is load-bearing, not decoration: a dependency matching
+  # no group gets an INDIVIDUAL PR rather than being held back, so without it
+  # `update-types: [patch]` would ungroup minors instead of suppressing them.
   # ---------------------------------------------------------------------
   - package-ecosystem: docker
     directories:
@@ -133,8 +152,9 @@ updates:
         patterns:
           - "*"
         update-types:
-          - minor
           - patch
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"


### PR DESCRIPTION
Follow-up to #229. Restricts the `docker` group to **patch** updates only.

### Why

A base image bump is not a library bump. `FROM python:3.11-slim` to `python:3.14-slim` swaps the interpreter under the API service, the Celery workers and beat in a single commit, and CI cannot see it. `Backend Tests` installs on the GitHub runner's own Python (3.12), so the only job that touches the image is `Docker Build`, which proves `pip install` resolves and nothing else. A green tick on that class of change means less than it looks like it means.

### The part worth reading

This makes the entry **inert for the tags currently pinned**, and the config comment now says so rather than leaving it to be discovered later:

| File | Tag | Reachable bumps | Ever a patch? |
|---|---|---|---|
| `apps/api/Dockerfile*` | `python:3.11-slim` | `3.12-slim`, `3.13-slim`, `3.14-slim` | no, all minor |
| `apps/web/Dockerfile*` | `node:20-alpine` | `22-alpine`, `24-alpine` | no, all major |

Dockerfile tag matching is precision filtered: a two segment tag only matches other two segment tags, a one segment tag only one segment. So `3.11-slim` can never see `3.11.14-slim`, and every tag it can see is a minor. Net effect: this ecosystem opens zero PRs until one of these tags gains a patch segment.

Keeping base images current therefore becomes a manual, calendared job. Worth stating plainly: **Node 20 has been EOL since 2026-04-30** and needs a hand written PR.

### One config detail

The new `version-update:semver-minor` line in `ignore` is load bearing, not decoration. A dependency matching no group gets an **individual** PR rather than being held back, so `update-types: [patch]` on its own would have ungrouped minor bumps instead of suppressing them.

No CHANGELOG entry, since this is CI configuration with nothing user facing.
