### PR TITLE
fix(web): hold a wake lock so a sleeping machine can't kill an upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **A machine going to sleep no longer silently kills an upload** — the browser is now asked for a Screen Wake Lock while an upload is in progress, and releases it when the last one finishes. An upload lives entirely in the tab, so a suspend mid-transfer kills the loop pushing chunks; worse, nothing runs afterwards, so the `/upload/abort` call never happens and the version is left at `processing_status = 'uploading'`, which in the UI is indistinguishable from a stalled transcode. Best-effort by design: without HTTPS, in low-power mode, or in a browser without the API there is simply no lock, which never blocks the upload. The lock is re-acquired on `visibilitychange`, since browsers drop it whenever the tab is hidden.
-
 ### Changed
 - **Pinned `starlette` and `botocore` so self-hosted Docker builds are reproducible** — both were floating transitives, so rebuilding the same commit on a different day could silently install different versions with no diff and no PR. FastAPI declares `starlette>=0.46.0` with no upper bound, meaning builds were free to cross a Starlette major (the ASGI layer under the SSE endpoint and the middleware stack); `botocore` is where S3 request signing lives, and unreviewed moves there have broken S3 compatibility before. Both are pinned to the versions already resolving, so no installed version changes.
 
 ### Fixed
 - **A single transient storage error no longer discards an entire multipart upload** — each part is now retried up to 8 times with exponential backoff and jitter (≈254s of tolerance per part) instead of failing the whole upload on the first non-OK response. A multi-gigabyte file is several hundred sequential requests, so one 500/503 from the object store or a brief network drop was enough to throw away everything already transferred; on a slow uplink that can be an hour of work. The presigned URL is re-fetched on every attempt, since `presign_upload_part` expires after an hour and a large upload can outlive that. User-initiated cancels are never retried, and a 4xx is thrown straight through instead of being repeated eight times over four minutes — it would fail identically every time, so retrying it only delays the error. The part loop, previously duplicated between new-asset and new-version uploads, is now shared.
+- **A machine going to sleep no longer silently kills an upload** — the browser is now asked for a Screen Wake Lock while an upload is in progress, and releases it when the last one finishes. An upload lives entirely in the tab, so a suspend mid-transfer kills the loop pushing chunks; worse, nothing runs afterwards, so the `/upload/abort` call never happens and the version is left at `processing_status = 'uploading'`, which in the UI is indistinguishable from a stalled transcode. Best-effort by design: without HTTPS, in low-power mode, or in a browser without the API there is simply no lock, which never blocks the upload. The lock is re-acquired on `visibilitychange`, since browsers drop it whenever the tab is hidden.
 
 ## [1.7.5] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A machine going to sleep no longer silently kills an upload** — the browser is now asked for a Screen Wake Lock while an upload is in progress, and releases it when the last one finishes. An upload lives entirely in the tab, so a suspend mid-transfer kills the loop pushing chunks; worse, nothing runs afterwards, so the `/upload/abort` call never happens and the version is left at `processing_status = 'uploading'`, which in the UI is indistinguishable from a stalled transcode. Best-effort by design: without HTTPS, in low-power mode, or in a browser without the API there is simply no lock, which never blocks the upload. The lock is re-acquired on `visibilitychange`, since browsers drop it whenever the tab is hidden.
+
 ### Changed
 - **Pinned `starlette` and `botocore` so self-hosted Docker builds are reproducible** — both were floating transitives, so rebuilding the same commit on a different day could silently install different versions with no diff and no PR. FastAPI declares `starlette>=0.46.0` with no upper bound, meaning builds were free to cross a Starlette major (the ASGI layer under the SSE endpoint and the middleware stack); `botocore` is where S3 request signing lives, and unreviewed moves there have broken S3 compatibility before. Both are pinned to the versions already resolving, so no installed version changes.
 

--- a/apps/web/stores/__tests__/upload-wake-lock.test.ts
+++ b/apps/web/stores/__tests__/upload-wake-lock.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}))
+
+import { retainWakeLock, releaseWakeLock } from '../upload-store'
+
+/** Minimal stand-in for a WakeLockSentinel. */
+function makeSentinel() {
+  return {
+    release: vi.fn().mockResolvedValue(undefined),
+    addEventListener: vi.fn(),
+  }
+}
+
+describe('upload wake lock', () => {
+  let request: ReturnType<typeof vi.fn>
+  let sentinel: ReturnType<typeof makeSentinel>
+
+  beforeEach(() => {
+    sentinel = makeSentinel()
+    request = vi.fn().mockResolvedValue(sentinel)
+    Object.defineProperty(navigator, 'wakeLock', {
+      value: { request },
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    // Leave no holder behind for the next test.
+    releaseWakeLock()
+    releaseWakeLock()
+    Reflect.deleteProperty(navigator as object, 'wakeLock')
+  })
+
+  it('requests a screen wake lock while an upload runs', async () => {
+    retainWakeLock()
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('screen'))
+  })
+
+  it('releases the lock when the last upload finishes', async () => {
+    retainWakeLock()
+    await vi.waitFor(() => expect(request).toHaveBeenCalled())
+
+    releaseWakeLock()
+    expect(sentinel.release).toHaveBeenCalled()
+  })
+
+  it('holds the lock until every concurrent upload is done', async () => {
+    retainWakeLock()
+    retainWakeLock()
+    await vi.waitFor(() => expect(request).toHaveBeenCalled())
+
+    releaseWakeLock()
+    expect(sentinel.release).not.toHaveBeenCalled() // one upload still running
+
+    releaseWakeLock()
+    expect(sentinel.release).toHaveBeenCalled()
+  })
+
+  it('requests the lock only once for concurrent uploads', async () => {
+    retainWakeLock()
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+    retainWakeLock()
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+  })
+
+  it('is a no-op when the browser has no Wake Lock API', () => {
+    Reflect.deleteProperty(navigator as object, 'wakeLock')
+    expect(() => {
+      retainWakeLock()
+      releaseWakeLock()
+    }).not.toThrow()
+  })
+
+  it('does not fail the upload when the lock is refused', async () => {
+    request.mockRejectedValue(new DOMException('denied', 'NotAllowedError'))
+    expect(() => retainWakeLock()).not.toThrow()
+    await vi.waitFor(() => expect(request).toHaveBeenCalled())
+    expect(() => releaseWakeLock()).not.toThrow()
+  })
+})

--- a/apps/web/stores/__tests__/upload-wake-lock.test.ts
+++ b/apps/web/stores/__tests__/upload-wake-lock.test.ts
@@ -84,4 +84,40 @@ describe('upload wake lock', () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalled())
     expect(() => releaseWakeLock()).not.toThrow()
   })
+
+  // Dropping several files calls startUpload once per file, and each runs
+  // synchronously as far as retainWakeLock() before its first await. Selecting
+  // N files therefore means N retains before the first request has resolved.
+  it('requests a single sentinel when several uploads start in the same tick', async () => {
+    const acquired: ReturnType<typeof makeSentinel>[] = []
+    request.mockImplementation(async () => {
+      const next = makeSentinel()
+      acquired.push(next)
+      return next
+    })
+
+    retainWakeLock()
+    retainWakeLock()
+    retainWakeLock()
+    await vi.waitFor(() => expect(request).toHaveBeenCalled())
+
+    expect(request).toHaveBeenCalledTimes(1)
+
+    releaseWakeLock()
+    releaseWakeLock()
+    releaseWakeLock()
+    const stillHeld = acquired.filter((s) => s.release.mock.calls.length === 0)
+    expect(stillHeld).toHaveLength(0)
+  })
+
+  it('releases a lock that arrives after the last upload already finished', async () => {
+    let handOver: (s: unknown) => void = () => {}
+    request.mockImplementation(() => new Promise((resolve) => { handOver = resolve }))
+
+    retainWakeLock() // the request is in flight
+    releaseWakeLock() // a short upload finishes before it resolves
+    handOver(sentinel) // only now does the browser hand the sentinel over
+
+    await vi.waitFor(() => expect(sentinel.release).toHaveBeenCalled())
+  })
 })

--- a/apps/web/stores/upload-store.ts
+++ b/apps/web/stores/upload-store.ts
@@ -144,41 +144,58 @@ export async function uploadAllParts(
  * released when the last one finishes.
  */
 let wakeLock: WakeLockSentinel | null = null
+let wakeLockPending: Promise<void> | null = null
 let wakeLockHolders = 0
 
-async function acquireWakeLock(): Promise<void> {
-  if (wakeLock) return
+function acquireWakeLock(): void {
+  // Dropping several files starts several uploads in the same tick, so this
+  // runs again long before the first request has resolved. Without the pending
+  // guard each one would request its own sentinel and only the last would be
+  // tracked, leaving the rest held for the life of the page.
+  if (wakeLock || wakeLockPending) return
   if (typeof navigator === 'undefined' || !('wakeLock' in navigator)) return
-  try {
-    wakeLock = await navigator.wakeLock.request('screen')
-    // The browser drops the lock by itself when the tab is hidden.
-    wakeLock.addEventListener('release', () => {
-      wakeLock = null
-    })
-  } catch {
-    // Not having a wake lock is not an upload error.
-  }
+
+  wakeLockPending = (async () => {
+    try {
+      const sentinel = await navigator.wakeLock.request('screen')
+      if (wakeLockHolders === 0) {
+        // Every upload finished while the request was still in flight.
+        void sentinel.release().catch(() => {})
+        return
+      }
+      wakeLock = sentinel
+      // The browser drops the lock by itself when the tab is hidden.
+      sentinel.addEventListener('release', () => {
+        if (wakeLock === sentinel) wakeLock = null
+      })
+    } catch {
+      // Not having a wake lock is not an upload error.
+    } finally {
+      wakeLockPending = null
+    }
+  })()
 }
 
 /** Exported for tests. */
 export function retainWakeLock(): void {
   wakeLockHolders += 1
-  void acquireWakeLock()
+  acquireWakeLock()
 }
 
 /** Exported for tests. */
 export function releaseWakeLock(): void {
   wakeLockHolders = Math.max(0, wakeLockHolders - 1)
   if (wakeLockHolders > 0) return
-  void wakeLock?.release().catch(() => {})
+  const held = wakeLock
   wakeLock = null
+  void held?.release().catch(() => {})
 }
 
 // Coming back to the foreground needs a fresh lock: the one dropped on hide is
 // dead and cannot be reused.
 if (typeof document !== 'undefined') {
   document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible' && wakeLockHolders > 0) void acquireWakeLock()
+    if (document.visibilityState === 'visible' && wakeLockHolders > 0) acquireWakeLock()
   })
 }
 
@@ -334,9 +351,9 @@ const storeCreator: StateCreator<UploadStore, [['zustand/persist', unknown]]> = 
       let s3_key: string | undefined
       let version_id: string | undefined
 
+      retainWakeLock()
       try {
         updateFile(id, { status: 'uploading' })
-        retainWakeLock()
 
         const initRes = await api.post<InitiateResponse>(
           '/upload/initiate',
@@ -424,9 +441,9 @@ const storeCreator: StateCreator<UploadStore, [['zustand/persist', unknown]]> = 
       let upload_id: string | undefined
       let s3_key: string | undefined
       let version_id: string | undefined
+      retainWakeLock()
       try {
         updateFile(id, { status: 'uploading' })
-        retainWakeLock()
         const initRes = await api.post<VersionInitiateResponse>(
           `/assets/${assetId}/versions`,
           {

--- a/apps/web/stores/upload-store.ts
+++ b/apps/web/stores/upload-store.ts
@@ -127,6 +127,61 @@ export async function uploadAllParts(
   return parts
 }
 
+/**
+ * Keeps the machine awake while an upload is running.
+ *
+ * An upload lives entirely in the browser tab. If the machine suspends
+ * mid-transfer the loop pushing chunks dies with it — and unlike a failed part,
+ * nothing runs afterwards: the `catch` that calls `/upload/abort` never
+ * executes, so the version is left at `processing_status = 'uploading'` and
+ * looks in the UI like a stalled transcode rather than a dead upload.
+ *
+ * Best-effort by design: without HTTPS, in low-power mode, or in a browser
+ * without the API there is no lock — none of which is a reason to refuse the
+ * upload.
+ *
+ * Reference-counted because several uploads can run at once; the lock is only
+ * released when the last one finishes.
+ */
+let wakeLock: WakeLockSentinel | null = null
+let wakeLockHolders = 0
+
+async function acquireWakeLock(): Promise<void> {
+  if (wakeLock) return
+  if (typeof navigator === 'undefined' || !('wakeLock' in navigator)) return
+  try {
+    wakeLock = await navigator.wakeLock.request('screen')
+    // The browser drops the lock by itself when the tab is hidden.
+    wakeLock.addEventListener('release', () => {
+      wakeLock = null
+    })
+  } catch {
+    // Not having a wake lock is not an upload error.
+  }
+}
+
+/** Exported for tests. */
+export function retainWakeLock(): void {
+  wakeLockHolders += 1
+  void acquireWakeLock()
+}
+
+/** Exported for tests. */
+export function releaseWakeLock(): void {
+  wakeLockHolders = Math.max(0, wakeLockHolders - 1)
+  if (wakeLockHolders > 0) return
+  void wakeLock?.release().catch(() => {})
+  wakeLock = null
+}
+
+// Coming back to the foreground needs a fresh lock: the one dropped on hide is
+// dead and cannot be reused.
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && wakeLockHolders > 0) void acquireWakeLock()
+  })
+}
+
 export type UploadStatus = 'pending' | 'uploading' | 'processing' | 'complete' | 'failed' | 'cancelled'
 
 export interface UploadFile {
@@ -281,6 +336,7 @@ const storeCreator: StateCreator<UploadStore, [['zustand/persist', unknown]]> = 
 
       try {
         updateFile(id, { status: 'uploading' })
+        retainWakeLock()
 
         const initRes = await api.post<InitiateResponse>(
           '/upload/initiate',
@@ -333,6 +389,7 @@ const storeCreator: StateCreator<UploadStore, [['zustand/persist', unknown]]> = 
           api.post('/upload/abort', { s3_key, upload_id, version_id }).catch(() => {})
         }
       } finally {
+        releaseWakeLock()
         delete abortControllers[id]
       }
     })()
@@ -369,6 +426,7 @@ const storeCreator: StateCreator<UploadStore, [['zustand/persist', unknown]]> = 
       let version_id: string | undefined
       try {
         updateFile(id, { status: 'uploading' })
+        retainWakeLock()
         const initRes = await api.post<VersionInitiateResponse>(
           `/assets/${assetId}/versions`,
           {
@@ -401,6 +459,7 @@ const storeCreator: StateCreator<UploadStore, [['zustand/persist', unknown]]> = 
           api.post('/upload/abort', { s3_key, upload_id, version_id }).catch(() => {})
         }
       } finally {
+        releaseWakeLock()
         delete abortControllers[id]
       }
     })()


### PR DESCRIPTION
### Summary

An upload lives entirely in the browser tab, so a machine suspending mid-transfer
kills the loop pushing chunks. Unlike a failed part, nothing runs afterwards —
the `catch` calling `/upload/abort` never executes — so the version is left at
`processing_status = 'uploading'`, indistinguishable in the UI from a stalled
transcode, and the multipart upload stays open until `reap_stale_uploads` gets to
it.

The browser is now asked for a Screen Wake Lock while an upload runs.

Closes #244

### Changes

- `retainWakeLock()` / `releaseWakeLock()`, reference-counted so the lock is only
  dropped when the last concurrent upload finishes
- Released in the `finally` that already cleans up the abort controller, so it
  also covers the cancel and error paths
- Re-acquired on `visibilitychange`, because browsers drop the lock when the tab
  is hidden and the dropped sentinel cannot be reused
- Every failure path swallowed: no secure context, low-power mode or a browser
  without the API simply means no lock, never a failed upload
- 6 tests covering acquire, release, the concurrent-upload refcount, the
  request-only-once case, the missing-API case and a refused lock

### Testing

- [ ] Backend tests pass — **not run: no backend files touched by this PR**
- [x] Frontend tests + build pass (`pnpm test` → 269 tests passing,
      `pnpm exec tsc --noEmit` clean, `pnpm build` succeeds)
- [ ] Tested manually in browser — the automated tests drive the API through a
      stub; the real-world effect (a laptop lid closing) is by nature awkward to
      assert in CI. Happy to run a manual pass if you'd like one before merging.

### Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]` → `### Fixed`

### Screenshots

n/a — no UI changes.