### PR TITLE
feat(api): persist the upload id and last upload activity on a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A slow upload is no longer aborted while it is still running** — the stale-upload reaper aged uploads by when they *started*, so anything slower than `STALE_UPLOAD_TIMEOUT_HOURS` (default 24) was reclaimed mid-transfer. On the connections this project exists for that is not a corner case: a 90 GB master at 8 Mbit/s takes longer than a day. Versions now record when a part was last requested and are aged by that, falling back to creation time for uploads that predate the column.
+- **`/upload/presign-part` no longer signs an arbitrary upload id** — the endpoint passed whatever upload id the caller sent straight to the signer, because nothing recorded which S3 upload a version actually belonged to. The upload id is now stored at initiate and checked here. It also no longer signs parts for a version the reaper has already soft-deleted, which wrote bytes to a key nothing owned. Neither was exploitable across accounts, since the key must already belong to the caller.
+
+### Changed
+- **`media_files.s3_key_raw` is indexed.** `/upload/presign-part` looks it up once per part, which was a sequential scan per chunk of a table that grows with every version ever uploaded — 10,000 of them on a large upload, several at a time now that parts upload in parallel.
+
+
 ### Changed
 - **Large uploads send several parts at once instead of strictly one after another** — up to 5 parts are now in flight per file, so an upload no longer pays a full presign round-trip and a TCP ramp-up for every 10 MB chunk in turn. **This helps only where a single stream cannot fill the link**, which means fast connections and object stores that are far away; on a bandwidth-limited uplink one stream already saturates the line and the upload will take exactly as long as before. Tune with `NEXT_PUBLIC_UPLOAD_CONCURRENCY` (default `5`) if your storage backend throttles concurrent part uploads; it is read at build time, so changing it needs a web image rebuild. Part order is preserved regardless of the order parts finish in, and progress counts completed parts rather than the highest one started. (#242)
 

--- a/apps/api/alembic/versions/b2c4d6e8f0a1_persist_upload_id_and_activity.py
+++ b/apps/api/alembic/versions/b2c4d6e8f0a1_persist_upload_id_and_activity.py
@@ -1,0 +1,49 @@
+"""persist the S3 upload id and last upload activity on asset_versions
+
+The multipart upload id was never stored anywhere, so nothing server-side could
+answer "which S3 upload does this version belong to". That left two known holes:
+the stale-upload reaper had to sweep the whole bucket to find abandoned uploads,
+and `/upload/presign-part` signed whatever upload id the caller handed it because
+there was nothing to check it against.
+
+`last_activity_at` exists because the reaper currently ages uploads by when they
+were *started*. An upload slower than the window is aborted while it is still
+running, which on a connection this project explicitly supports is not a corner
+case.
+
+Also indexes media_files.s3_key_raw, which `/upload/presign-part` looks up once
+per part -- 10,000 sequential scans on a large upload, several concurrently since
+parts now upload in parallel.
+
+Revision ID: b2c4d6e8f0a1
+Revises: a9ee0209151a
+Create Date: 2026-08-15
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'b2c4d6e8f0a1'
+down_revision: Union[str, Sequence[str], None] = 'a9ee0209151a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable with no backfill: existing rows predate this and their uploads are
+    # long finished or long abandoned. Consumers must treat NULL as "unknown" and
+    # fall back to current behaviour rather than assuming a value is present.
+    op.add_column('asset_versions', sa.Column('upload_id', sa.String(length=255), nullable=True))
+    op.add_column(
+        'asset_versions',
+        sa.Column('last_activity_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        'ix_media_files_s3_key_raw', 'media_files', ['s3_key_raw'], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_media_files_s3_key_raw', table_name='media_files')
+    op.drop_column('asset_versions', 'last_activity_at')
+    op.drop_column('asset_versions', 'upload_id')

--- a/apps/api/models/asset.py
+++ b/apps/api/models/asset.py
@@ -58,6 +58,15 @@ class AssetVersion(Base):
     asset_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("assets.id"), nullable=False, index=True)
     version_number: Mapped[int] = mapped_column(Integer, nullable=False)
     processing_status: Mapped[ProcessingStatus] = mapped_column(Enum(ProcessingStatus), default=ProcessingStatus.uploading)
+    # The S3 multipart upload backing this version while it is being uploaded.
+    # NULL for rows created before this was recorded, and for versions whose
+    # upload has been completed or aborted -- treat NULL as "unknown", never as
+    # "no upload exists".
+    upload_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # Last time a part was signed for this upload. The reaper ages uploads by
+    # this rather than by created_at, so a transfer slower than the window is not
+    # aborted while it is still making progress.
+    last_activity_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/apps/api/routers/assets.py
+++ b/apps/api/routers/assets.py
@@ -325,6 +325,12 @@ def initiate_new_version(
     s3_key = f"raw/{asset.project_id}/{asset_id}/{version.id}/original{ext}"
     upload_id = create_multipart_upload(s3_key, body.mime_type)
 
+    # Record which S3 upload backs this version. Without it nothing server-side can
+    # map a version to its multipart upload, so the reaper has to sweep the whole
+    # bucket and presign-part has nothing to validate against.
+    version.upload_id = upload_id
+    version.last_activity_at = datetime.now(timezone.utc)
+
     file_type_map = {AssetType.image: FileType.image, AssetType.audio: FileType.audio, AssetType.video: FileType.video, AssetType.image_carousel: FileType.image}
     media_file = MediaFile(
         version_id=version.id,

--- a/apps/api/routers/upload.py
+++ b/apps/api/routers/upload.py
@@ -99,6 +99,12 @@ def initiate_upload(
     # Initiate S3 multipart upload
     upload_id = create_multipart_upload(s3_key, body.mime_type)
 
+    # Record which S3 upload backs this version. Without it nothing server-side can
+    # map a version to its multipart upload, so the reaper has to sweep the whole
+    # bucket and presign-part has nothing to validate against.
+    version.upload_id = upload_id
+    version.last_activity_at = datetime.now(timezone.utc)
+
     # Create MediaFile record
     file_type_map = {AssetType.image: FileType.image, AssetType.audio: FileType.audio, AssetType.video: FileType.video, AssetType.image_carousel: FileType.image}
     media_file = MediaFile(
@@ -133,11 +139,31 @@ def presign_part(
     media_file = db.query(MediaFile).filter(MediaFile.s3_key_raw == body.s3_key).first()
     if not media_file:
         raise HTTPException(status_code=404, detail="Upload not found")
-    version = db.query(AssetVersion).filter(AssetVersion.id == media_file.version_id).first()
+    version = db.query(AssetVersion).filter(
+        AssetVersion.id == media_file.version_id,
+        # A version the reaper has already soft-deleted must not keep accepting
+        # parts: those bytes would be written to a key nothing owns, and no later
+        # sweep would attribute them to anything.
+        AssetVersion.deleted_at.is_(None),
+    ).first()
     if not version or version.created_by != current_user.id:
         raise HTTPException(status_code=403, detail="Not authorized for this upload")
 
+    # Sign only the upload this version actually belongs to. Previously whatever
+    # upload id the caller sent was passed straight to the signer, because there
+    # was nothing recorded to compare it against. NULL means the row predates
+    # that being stored, so it is accepted rather than breaking uploads that are
+    # already in flight across the upgrade.
+    if version.upload_id is not None and version.upload_id != body.upload_id:
+        raise HTTPException(status_code=403, detail="Not authorized for this upload")
+
     url = presign_upload_part(body.s3_key, body.upload_id, body.part_number)
+
+    # Proof of life for the reaper: an upload slower than its window is still
+    # making progress and must not be aborted underneath the user.
+    version.last_activity_at = datetime.now(timezone.utc)
+    db.commit()
+
     return PresignPartResponse(presigned_url=url, part_number=body.part_number)
 
 

--- a/apps/api/tasks/cleanup_tasks.py
+++ b/apps/api/tasks/cleanup_tasks.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone, timedelta
 
-from sqlalchemy import text
+from sqlalchemy import text, func
 
 from .celery_app import celery_app
 from ..database import SessionLocal
@@ -236,10 +236,14 @@ def _reap_stale_uploads(db) -> int:
         _safe(abort_multipart_upload, key, upload_id)
 
     # 2. Reclaim stuck `uploading` / `failed` versions past the cutoff.
+    # Age by last activity, falling back to creation for rows that predate it being
+    # recorded. A large upload on a slow line can legitimately outlive the window
+    # -- 90 GB at 8 Mbit/s takes longer than a day -- and reclaiming it by start
+    # time destroys an upload that is still making progress.
     versions = db.query(AssetVersion).filter(
         AssetVersion.processing_status.in_([ProcessingStatus.uploading, ProcessingStatus.failed]),
         AssetVersion.deleted_at.is_(None),
-        AssetVersion.created_at < cutoff,
+        func.coalesce(AssetVersion.last_activity_at, AssetVersion.created_at) < cutoff,
     ).all()
     for v in versions:
         for mf in db.query(MediaFile).filter(MediaFile.version_id == v.id).all():

--- a/apps/api/tests/test_upload_id_and_activity.py
+++ b/apps/api/tests/test_upload_id_and_activity.py
@@ -1,0 +1,244 @@
+"""Tests for persisting the S3 upload id and last upload activity on a version.
+
+Both columns exist to be read: `upload_id` so `/upload/presign-part` has something
+to check the caller's value against, and `last_activity_at` so the stale-upload
+reaper ages an upload by progress rather than by when it started.
+"""
+import uuid
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+import apps.api.routers.upload as upload_module
+from apps.api.models.asset import ProcessingStatus
+
+
+@pytest.fixture
+def presign_rows(mock_db, test_user):
+    """A media file and the version that owns it, wired into the mock session."""
+    media_file = MagicMock()
+    media_file.version_id = uuid.uuid4()
+    media_file.s3_key_raw = "raw/p/a/v/original.mp4"
+
+    version = MagicMock()
+    version.id = media_file.version_id
+    version.created_by = test_user.id
+    version.upload_id = "the-real-upload-id"
+    version.last_activity_at = None
+
+    mock_db.first.side_effect = [media_file, version]
+    return media_file, version
+
+
+def _presign(client, auth_headers, media_file, upload_id, part=1):
+    return client.post(
+        "/upload/presign-part",
+        json={"s3_key": media_file.s3_key_raw, "upload_id": upload_id, "part_number": part},
+        headers=auth_headers,
+    )
+
+
+# ------------------------------------------------------------------ upload_id
+
+def test_presign_signs_the_upload_the_version_belongs_to(
+    client, auth_headers, mock_db, presign_rows, monkeypatch
+):
+    media_file, _ = presign_rows
+    signed = {}
+    monkeypatch.setattr(
+        upload_module, "presign_upload_part",
+        lambda k, u, n: signed.update(key=k, upload=u, part=n) or "https://s3/url",
+    )
+
+    resp = _presign(client, auth_headers, media_file, "the-real-upload-id")
+
+    assert resp.status_code == 200
+    assert signed["upload"] == "the-real-upload-id"
+
+
+def test_presign_refuses_an_upload_id_the_version_does_not_own(
+    client, auth_headers, mock_db, presign_rows, monkeypatch
+):
+    """Previously any value the caller sent was handed to the signer unchecked."""
+    media_file, _ = presign_rows
+    monkeypatch.setattr(
+        upload_module, "presign_upload_part",
+        lambda k, u, n: pytest.fail("must not sign a foreign upload id"),
+    )
+
+    resp = _presign(client, auth_headers, media_file, "some-other-upload")
+
+    assert resp.status_code == 403
+
+
+def test_presign_still_works_for_versions_recorded_before_this_column_existed(
+    client, auth_headers, mock_db, presign_rows, monkeypatch
+):
+    """NULL means "unknown", not "no upload". Uploads in flight across the
+    upgrade must not start failing halfway."""
+    media_file, version = presign_rows
+    version.upload_id = None
+    monkeypatch.setattr(upload_module, "presign_upload_part", lambda k, u, n: "https://s3/url")
+
+    assert _presign(client, auth_headers, media_file, "whatever-it-was").status_code == 200
+
+
+def test_presign_refuses_a_version_the_reaper_already_soft_deleted(real_db, monkeypatch):
+    """Real DB, because the filter under test is a query clause.
+
+    A mocked session hands back whatever it was primed with no matter what the
+    query said, so this passes with the filter removed unless it runs for real.
+    Parts signed for a soft-deleted version are written to a key nothing owns and
+    no later sweep attributes to anything.
+    """
+    from apps.api.models.user import User
+    from apps.api.models.project import Project, ProjectType
+    from apps.api.models.asset import Asset, AssetType, AssetVersion, MediaFile, FileType
+    from apps.api.schemas.upload import PresignPartRequest
+    from fastapi import HTTPException
+
+    owner = User(email=f"sd-{uuid.uuid4()}@t.local", name="t")
+    real_db.add(owner); real_db.flush()
+    project = Project(name="t", project_type=ProjectType.personal, created_by=owner.id)
+    real_db.add(project); real_db.flush()
+    asset = Asset(project_id=project.id, name="t", asset_type=AssetType.video, created_by=owner.id)
+    real_db.add(asset); real_db.flush()
+    version = AssetVersion(asset_id=asset.id, version_number=1,
+                           processing_status=ProcessingStatus.uploading, created_by=owner.id,
+                           upload_id="u-1", deleted_at=datetime.now(timezone.utc))
+    real_db.add(version); real_db.flush()
+    key = f"raw/{version.id}/original.mp4"
+    real_db.add(MediaFile(version_id=version.id, file_type=FileType.video,
+                          original_filename="f.mp4", mime_type="video/mp4",
+                          file_size_bytes=1, s3_key_raw=key))
+    real_db.flush()
+
+    monkeypatch.setattr(upload_module, "presign_upload_part",
+                        lambda k, u, n: pytest.fail("must not sign for a deleted version"))
+
+    with pytest.raises(HTTPException) as exc:
+        upload_module.presign_part(
+            PresignPartRequest(s3_key=key, upload_id="u-1", part_number=1),
+            db=real_db, current_user=owner,
+        )
+    assert exc.value.status_code == 403
+
+
+# ------------------------------------------------------------ last_activity_at
+
+def test_presign_records_activity_so_a_slow_upload_is_not_reaped(
+    client, auth_headers, mock_db, presign_rows, monkeypatch
+):
+    media_file, version = presign_rows
+    monkeypatch.setattr(upload_module, "presign_upload_part", lambda k, u, n: "https://s3/url")
+    before = datetime.now(timezone.utc)
+
+    _presign(client, auth_headers, media_file, "the-real-upload-id")
+
+    assert version.last_activity_at is not None
+    assert version.last_activity_at >= before
+
+
+# ------------------------------------------------------------------ initiate
+
+@pytest.mark.parametrize("path", ["new_asset", "new_version"])
+def test_both_initiate_paths_record_the_upload_id(real_db, monkeypatch, path):
+    """There are two initiate handlers and they are near-verbatim copies.
+
+    Recording the upload id in only one of them would leave every new *version*
+    unresumable and unvalidatable, which is the half nobody would notice.
+    """
+    from apps.api.models.user import User
+    from apps.api.models.project import Project, ProjectType
+    from apps.api.models.asset import Asset, AssetType, AssetVersion
+    from apps.api.schemas.upload import InitiateUploadRequest
+    import apps.api.routers.assets as assets_module
+
+    owner = User(email=f"init-{uuid.uuid4()}@t.local", name="t")
+    real_db.add(owner); real_db.flush()
+    project = Project(name="t", project_type=ProjectType.personal, created_by=owner.id)
+    real_db.add(project); real_db.flush()
+
+    for mod in (upload_module, assets_module):
+        monkeypatch.setattr(mod, "create_multipart_upload", lambda k, m: "brand-new-upload",
+                            raising=False)
+    monkeypatch.setattr(upload_module, "upload_guard_error", lambda db, n: None)
+    monkeypatch.setattr(assets_module, "upload_guard_error", lambda db, n: None, raising=False)
+    monkeypatch.setattr(upload_module, "require_project_role", lambda db, pid, u, r: None)
+
+    if path == "new_asset":
+        body = InitiateUploadRequest(
+            project_id=project.id, asset_name="clip", original_filename="clip.mp4",
+            mime_type="video/mp4", file_size_bytes=1024,
+        )
+        result = upload_module.initiate_upload(body, db=real_db, current_user=owner)
+    else:
+        asset = Asset(project_id=project.id, name="t", asset_type=AssetType.video,
+                      created_by=owner.id)
+        real_db.add(asset); real_db.flush()
+        monkeypatch.setattr(assets_module, "require_project_role", lambda *a, **k: None,
+                            raising=False)
+        result = assets_module.initiate_new_version(
+            asset.id,
+            InitiateUploadRequest(
+                project_id=project.id, asset_name="clip", original_filename="clip.mp4",
+                mime_type="video/mp4", file_size_bytes=1024,
+            ),
+            db=real_db, current_user=owner,
+        )
+
+    version = real_db.query(AssetVersion).filter(AssetVersion.id == result.version_id).first()
+    assert version.upload_id == "brand-new-upload"
+    assert version.last_activity_at is not None
+
+
+# -------------------------------------------------------------------- reaper
+
+def _seed_version(db, status, created_shift_hours, activity_shift_hours=None):
+    from apps.api.models.user import User
+    from apps.api.models.project import Project, ProjectType
+    from apps.api.models.asset import Asset, AssetType, AssetVersion, MediaFile, FileType
+
+    owner = User(email=f"act-{uuid.uuid4()}@t.local", name="t")
+    db.add(owner); db.flush()
+    project = Project(name="t", project_type=ProjectType.personal, created_by=owner.id)
+    db.add(project); db.flush()
+    asset = Asset(project_id=project.id, name="t", asset_type=AssetType.video, created_by=owner.id)
+    db.add(asset); db.flush()
+    v = AssetVersion(asset_id=asset.id, version_number=1, processing_status=status,
+                     created_by=owner.id)
+    db.add(v); db.flush()
+    v.created_at = datetime.now(timezone.utc) - timedelta(hours=created_shift_hours)
+    if activity_shift_hours is not None:
+        v.last_activity_at = datetime.now(timezone.utc) - timedelta(hours=activity_shift_hours)
+    db.add(MediaFile(version_id=v.id, file_type=FileType.video, original_filename="f.mp4",
+                     mime_type="video/mp4", file_size_bytes=1, s3_key_raw=f"raw/{v.id}"))
+    db.flush()
+    return v
+
+
+def test_reaper_spares_a_slow_upload_that_is_still_making_progress(real_db, monkeypatch):
+    """A 90 GB upload on a slow line outlives a 24h window while still progressing.
+
+    Ageing it by when it *started* destroys an upload that is working fine, which is
+    the case this column exists for.
+    """
+    from apps.api.tasks import cleanup_tasks as ct
+
+    monkeypatch.setattr(ct, "list_stale_multipart_uploads", lambda cutoff: [])
+    monkeypatch.setattr(ct, "delete_object", lambda k: None)
+    monkeypatch.setattr(ct, "delete_prefix", lambda k: None)
+
+    # Started two days ago, signed a part a minute ago: still going.
+    slow_but_alive = _seed_version(real_db, ProcessingStatus.uploading, 48, activity_shift_hours=0)
+    # Started two days ago and silent since: genuinely abandoned.
+    abandoned = _seed_version(real_db, ProcessingStatus.uploading, 48, activity_shift_hours=48)
+    # Predates the column entirely; must still be reaped via created_at.
+    legacy = _seed_version(real_db, ProcessingStatus.uploading, 48)
+
+    ct._reap_stale_uploads(real_db)
+
+    assert slow_but_alive.deleted_at is None
+    assert abandoned.deleted_at is not None
+    assert legacy.deleted_at is not None


### PR DESCRIPTION
Two nullable columns on `asset_versions` plus an index, and the three places that immediately need them.

This is groundwork for #241 as much as a fix in itself. Resumable uploads need exactly this state, and landing it once means that work builds on it rather than inventing a second shape for it — which is what we said we'd do in the #241 handoff.

## Why

**The multipart upload id was stored nowhere.** Nothing server-side could map a version to its S3 upload. That left two holes:

- `/upload/presign-part` handed whatever upload id the caller sent straight to the signer, because there was nothing to compare it against (#253)
- the stale-upload reaper had to sweep the whole bucket to find abandoned uploads instead of driving off its own rows (#251)

**`last_activity_at` fixes the more dangerous half of #251.** The reaper ages uploads by `created_at`, so an upload slower than `STALE_UPLOAD_TIMEOUT_HOURS` is aborted *while it is still transferring*. This is not a corner case for this project: `CLAUDE.md` advertises no size cap and 4K footage, and 90 GB at 8 Mbit/s takes longer than a day.

## What changed

- `asset_versions.upload_id` and `asset_versions.last_activity_at`, both nullable, no backfill
- both initiate handlers record them
- `/upload/presign-part` validates the upload id, filters soft-deleted versions, and bumps activity
- the reaper's **version sweep** ages by `coalesce(last_activity_at, created_at)`
- `media_files.s3_key_raw` is indexed — looked up once per part, so a large upload was 10,000 sequential scans of a table that grows with every version ever uploaded, and #242 made several concurrent

## What this deliberately does not do

The reaper's **bucket sweep** (step 1) still ages by the multipart's own `Initiated` time and is unchanged. Rewriting it to drive off these rows is #251, and it is now unblocked.

## On NULL

There is no backfill, and NULL means "unknown", not "absent". `presign_part` accepts a mismatch when `upload_id` is NULL so uploads already in flight across the upgrade do not start failing halfway; the reaper falls back to `created_at`. Both consumers degrade to exactly today's behaviour on an unmigrated row.

## Testing

235 passing (baseline 227). Migration applied and rolled forward against the real dev Postgres.

The two initiate handlers are parametrised against a **real** database, because they are near-verbatim copies and recording this in only one would leave every new *version* unresumable while new assets looked fine.

Five mutations of the behaviour are each caught:

| Mutation | Result |
|---|---|
| drop the `upload_id` check in `presign_part` | killed |
| stop recording in the new-version path only | killed |
| revert the reaper to `created_at` alone | killed |
| drop the soft-delete filter | killed |
| stop bumping `last_activity_at` | killed |

The soft-delete filter needed a real session to test — with a mocked one it survived, because a mock returns its primed row regardless of what the query filters on.

## Order

Independent of #255, which is also open. They touch `upload.py` in different handlers (`initiate`/`presign-part` here, `complete`/`abort` there), so either can land first; whichever is second may need a trivial import-block rebase.