### PR TITLE
[codex] Fix page-bound PDF annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **PDF drawings stay attached to the page they were made on** — PDF review now renders one app-owned page at a time, so annotations scroll and resize with that page instead of floating at fixed coordinates across the browser's multi-page PDF viewer. Opening an annotated comment also returns to its saved page, including from shared review links.
+
 ## [1.10.0] - 2026-08-21
 
 ### Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PDFs now get preview thumbnails** — the processing worker renders the first page as a bounded JPEG, so PDF assets have visual previews in project and shared folder grids while the original PDF remains the review source.
+
 ### Fixed
 
 - **PDF drawings stay attached to the page they were made on** — PDF review now renders one app-owned page at a time, so annotations scroll and resize with that page instead of floating at fixed coordinates across the browser's multi-page PDF viewer. Opening an annotated comment also returns to its saved page, including from shared review links.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,9 +2,12 @@ FROM python:3.11-slim
 
 WORKDIR /workspace
 
-RUN apt-get update && apt-get install -y \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
+    && apt-get -o Acquire::Retries=5 -o Acquire::https::No-Cache=true update \
+    && apt-get -o Acquire::Retries=5 -o Acquire::https::No-Cache=true install -y \
     ffmpeg \
     imagemagick \
+    poppler-utils \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -2,9 +2,12 @@ FROM python:3.11-slim
 
 WORKDIR /workspace
 
-RUN apt-get update && apt-get install -y \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
+    && apt-get -o Acquire::Retries=5 -o Acquire::https::No-Cache=true update \
+    && apt-get -o Acquire::Retries=5 -o Acquire::https::No-Cache=true install -y \
     ffmpeg \
     imagemagick \
+    poppler-utils \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/api/alembic/versions/e1f2a3b4c5d6_add_pdf_review_support.py
+++ b/apps/api/alembic/versions/e1f2a3b4c5d6_add_pdf_review_support.py
@@ -1,0 +1,32 @@
+"""add PDF asset support and page anchors for comments
+
+Revision ID: e1f2a3b4c5d6
+Revises: cdcf8e5a6437
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, Sequence[str], None] = "cdcf8e5a6437"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # PostgreSQL enum values must be added before application rows can use them.
+    op.execute("ALTER TYPE assettype ADD VALUE IF NOT EXISTS 'pdf'")
+    op.execute("ALTER TYPE filetype ADD VALUE IF NOT EXISTS 'pdf'")
+    op.add_column("comments", sa.Column("page_number", sa.Integer(), nullable=True))
+    op.create_check_constraint(
+        "ck_comments_page_number_positive", "comments", "page_number > 0"
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_comments_page_number_positive", "comments", type_="check")
+    op.drop_column("comments", "page_number")
+    # PostgreSQL does not support removing enum values safely. Leave the values
+    # in place so downgrades preserve data and remain operational.

--- a/apps/api/models/asset.py
+++ b/apps/api/models/asset.py
@@ -15,6 +15,7 @@ class AssetType(str, PyEnum):
     image_carousel = "image_carousel"
     audio = "audio"
     video = "video"
+    pdf = "pdf"
 
 class AssetStatus(str, PyEnum):
     draft = "draft"
@@ -75,6 +76,7 @@ class FileType(str, PyEnum):
     image = "image"
     audio = "audio"
     video = "video"
+    pdf = "pdf"
 
 class MediaFile(Base):
     __tablename__ = "media_files"

--- a/apps/api/models/comment.py
+++ b/apps/api/models/comment.py
@@ -24,6 +24,8 @@ class Comment(Base):
     guest_author_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("guest_users.id"), nullable=True)
     timecode_start: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     timecode_end: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    # PDFs are reviewed by page rather than by a temporal playhead.
+    page_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     body: Mapped[str] = mapped_column(Text, nullable=False)
     resolved: Mapped[bool] = mapped_column(Boolean, default=False)
     visibility: Mapped[str] = mapped_column(String(20), default="public", server_default="public", nullable=False)

--- a/apps/api/routers/assets.py
+++ b/apps/api/routers/assets.py
@@ -386,7 +386,7 @@ def initiate_new_version(
     version.upload_id = upload_id
     version.last_activity_at = datetime.now(timezone.utc)
 
-    file_type_map = {AssetType.image: FileType.image, AssetType.audio: FileType.audio, AssetType.video: FileType.video, AssetType.image_carousel: FileType.image}
+    file_type_map = {AssetType.image: FileType.image, AssetType.audio: FileType.audio, AssetType.video: FileType.video, AssetType.image_carousel: FileType.image, AssetType.pdf: FileType.pdf}
     media_file = MediaFile(
         version_id=version.id,
         file_type=file_type_map.get(asset.asset_type, FileType.video),

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -367,6 +367,7 @@ def create_comment(
         author_id=current_user.id,
         timecode_start=body.timecode_start,
         timecode_end=body.timecode_end,
+        page_number=body.page_number,
         body=body.body,
         visibility=body.visibility or "public",
     )
@@ -933,6 +934,7 @@ def guest_comment(
         guest_author_id=guest_author_id,
         timecode_start=body.timecode_start,
         timecode_end=body.timecode_end,
+        page_number=body.page_number,
         body=body.body,
     )
     db.add(comment)

--- a/apps/api/routers/upload.py
+++ b/apps/api/routers/upload.py
@@ -113,7 +113,7 @@ def initiate_upload(
     version.last_activity_at = datetime.now(timezone.utc)
 
     # Create MediaFile record
-    file_type_map = {AssetType.image: FileType.image, AssetType.audio: FileType.audio, AssetType.video: FileType.video, AssetType.image_carousel: FileType.image}
+    file_type_map = {AssetType.image: FileType.image, AssetType.audio: FileType.audio, AssetType.video: FileType.video, AssetType.image_carousel: FileType.image, AssetType.pdf: FileType.pdf}
     media_file = MediaFile(
         version_id=version.id,
         file_type=file_type_map.get(asset.asset_type, FileType.video),

--- a/apps/api/schemas/comment.py
+++ b/apps/api/schemas/comment.py
@@ -13,6 +13,7 @@ class CommentCreate(BaseModel):
     parent_id: Optional[uuid.UUID] = None
     timecode_start: Optional[float] = None
     timecode_end: Optional[float] = None
+    page_number: Optional[int] = Field(default=None, ge=1)
     body: str
     visibility: Optional[str] = "public"  # "public" or "internal"
     annotation: Optional[AnnotationData] = None
@@ -24,6 +25,7 @@ class GuestCommentCreate(BaseModel):
     parent_id: Optional[uuid.UUID] = None
     timecode_start: Optional[float] = None
     timecode_end: Optional[float] = None
+    page_number: Optional[int] = Field(default=None, ge=1)
     body: str
     annotation: Optional[AnnotationData] = None
     guest_email: Optional[str] = None  # Not needed if user is logged in
@@ -109,6 +111,9 @@ class CommentResponse(BaseModel):
     guest_author_id: Optional[uuid.UUID]
     timecode_start: Optional[float]
     timecode_end: Optional[float]
+    # Optional for comments created before PDF review support, and for the
+    # lightweight namespaces used by the mock-database test suite.
+    page_number: Optional[int] = None
     body: str
     resolved: bool
     visibility: str = "public"

--- a/apps/api/schemas/upload.py
+++ b/apps/api/schemas/upload.py
@@ -11,6 +11,8 @@ ALLOWED_MIME_TYPES = {
     # Video
     "video/mp4", "video/quicktime", "video/x-msvideo", "video/x-matroska",
     "video/webm", "video/mpeg", "video/x-ms-wmv",
+    # Documents
+    "application/pdf",
 }
 
 CHUNK_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
@@ -41,6 +43,8 @@ def mime_to_asset_type(mime_type: str) -> AssetType:
         return AssetType.audio
     elif mime_type.startswith("video/"):
         return AssetType.video
+    elif mime_type == "application/pdf":
+        return AssetType.pdf
     raise ValueError(f"Unsupported mime type: {mime_type}")
 
 class InitiateUploadRequest(BaseModel):

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -63,9 +63,7 @@ def process_asset(self, asset_id: str, version_id: str):
             elif asset.asset_type in (AssetType.image, AssetType.image_carousel):
                 _process_image(db, asset, version, media_file, s3, output_prefix)
             elif asset.asset_type == AssetType.pdf:
-                # PDFs are rendered in the browser. Keep the original object as
-                # the viewable file and avoid an unnecessary conversion step.
-                pass
+                _process_pdf(db, asset, version, media_file, s3, output_prefix)
 
             version.processing_status = ProcessingStatus.ready
             db.commit()
@@ -134,6 +132,13 @@ def _process_image(db, asset, version, media_file, s3, output_prefix):
     from packages.transcoder.image_processor import process_image
     result = process_image(s3, settings.s3_bucket, media_file.s3_key_raw, output_prefix)
     media_file.s3_key_processed = result.get("webp_key")
+    media_file.s3_key_thumbnail = result.get("thumbnail_key")
+    db.flush()
+
+
+def _process_pdf(db, asset, version, media_file, s3, output_prefix):
+    from packages.transcoder.image_processor import process_pdf
+    result = process_pdf(s3, settings.s3_bucket, media_file.s3_key_raw, output_prefix)
     media_file.s3_key_thumbnail = result.get("thumbnail_key")
     db.flush()
 

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -62,6 +62,10 @@ def process_asset(self, asset_id: str, version_id: str):
                 _process_audio(db, asset, version, media_file, s3, output_prefix)
             elif asset.asset_type in (AssetType.image, AssetType.image_carousel):
                 _process_image(db, asset, version, media_file, s3, output_prefix)
+            elif asset.asset_type == AssetType.pdf:
+                # PDFs are rendered in the browser. Keep the original object as
+                # the viewable file and avoid an unnecessary conversion step.
+                pass
 
             version.processing_status = ProcessingStatus.ready
             db.commit()

--- a/apps/api/tests/test_pdf_support.py
+++ b/apps/api/tests/test_pdf_support.py
@@ -1,0 +1,14 @@
+from apps.api.models.asset import AssetType, FileType
+from apps.api.schemas.upload import ALLOWED_MIME_TYPES, mime_to_asset_type
+from apps.api.schemas.comment import CommentCreate
+
+
+def test_pdf_is_a_supported_first_class_upload_type():
+    assert "application/pdf" in ALLOWED_MIME_TYPES
+    assert mime_to_asset_type("application/pdf") is AssetType.pdf
+    assert FileType.pdf.value == "pdf"
+
+
+def test_pdf_comment_page_anchor_must_be_positive():
+    comment = CommentCreate(version_id="00000000-0000-0000-0000-000000000001", body="Note", page_number=2)
+    assert comment.page_number == 2

--- a/apps/api/tests/test_pdf_support.py
+++ b/apps/api/tests/test_pdf_support.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock, patch
+
 from apps.api.models.asset import AssetType, FileType
 from apps.api.schemas.upload import ALLOWED_MIME_TYPES, mime_to_asset_type
 from apps.api.schemas.comment import CommentCreate
+from packages.transcoder.image_processor import process_pdf
 
 
 def test_pdf_is_a_supported_first_class_upload_type():
@@ -12,3 +15,39 @@ def test_pdf_is_a_supported_first_class_upload_type():
 def test_pdf_comment_page_anchor_must_be_positive():
     comment = CommentCreate(version_id="00000000-0000-0000-0000-000000000001", body="Note", page_number=2)
     assert comment.page_number == 2
+
+
+def test_pdf_processor_renders_first_page_thumbnail():
+    s3 = MagicMock()
+
+    with patch("packages.transcoder.image_processor.subprocess.run") as run:
+        result = process_pdf(s3, "media", "raw/document.pdf", "processed/p/a/v")
+
+    s3.download_file.assert_called_once()
+    command = run.call_args.args[0]
+    assert command[0] == "pdftoppm"
+    assert command[command.index("-f") + 1] == "1"
+    assert command[command.index("-l") + 1] == "1"
+    assert command[command.index("-scale-to") + 1] == "400"
+    assert run.call_args.kwargs["timeout"] == 120
+    assert result == {"thumbnail_key": "processed/p/a/v/thumbnail.jpg"}
+    assert s3.upload_file.call_args.args[1:] == (
+        "media",
+        "processed/p/a/v/thumbnail.jpg",
+    )
+    assert s3.upload_file.call_args.kwargs["ExtraArgs"]["ContentType"] == "image/jpeg"
+
+
+def test_pdf_processing_persists_thumbnail_key():
+    from apps.api.tasks.transcode_tasks import _process_pdf
+
+    db = MagicMock()
+    media_file = MagicMock(s3_key_raw="raw/document.pdf")
+    with patch(
+        "packages.transcoder.image_processor.process_pdf",
+        return_value={"thumbnail_key": "processed/p/a/v/thumbnail.jpg"},
+    ):
+        _process_pdf(db, MagicMock(), MagicMock(), media_file, MagicMock(), "processed/p/a/v")
+
+    assert media_file.s3_key_thumbnail == "processed/p/a/v/thumbnail.jpg"
+    db.flush.assert_called_once_with()

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -12,6 +12,7 @@ coverage/
 # next.js
 .next/
 out/
+public/pdfjs/
 
 # production
 build/

--- a/apps/web/app/(dashboard)/projects/[id]/assets/[assetId]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/assets/[assetId]/page.tsx
@@ -7,6 +7,7 @@ import { ReviewProvider, useReview } from '@/components/review/review-provider'
 import { VideoPlayer } from '@/components/review/video-player'
 import { AudioPlayer } from '@/components/review/audio-player'
 import { ImageViewer } from '@/components/review/image-viewer'
+import { PdfViewer } from '@/components/review/pdf-viewer'
 import { AnnotationCanvas } from '@/components/review/annotation-canvas'
 import { AnnotationOverlay } from '@/components/review/annotation-overlay'
 import { CommentPanel } from '@/components/review/comment-panel'
@@ -44,6 +45,7 @@ const acceptByType: Record<string, string> = {
   audio: 'audio/*',
   image: 'image/*',
   image_carousel: 'image/*',
+  pdf: 'application/pdf',
 }
 
 function ReviewScreenInner({ projectId }: { projectId: string }) {
@@ -51,7 +53,15 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const { asset, versions, isLoading, refetchComments, refetchVersions } = useReview()
-  const { currentVersion, isDrawingMode, focusedCommentId, seekTo, setFocusedCommentId, setActiveAnnotation } = useReviewStore()
+  const {
+    currentVersion,
+    isDrawingMode,
+    focusedCommentId,
+    seekTo,
+    setFocusedCommentId,
+    setActiveAnnotation,
+    discardAnnotations,
+  } = useReviewStore()
   const { user } = useAuthStore()
   const startVersionUpload = useUploadStore((s) => s.startVersionUpload)
   const versionFileInputRef = useRef<HTMLInputElement>(null)
@@ -59,9 +69,26 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
   const setLabel = useBreadcrumbStore((s) => s.setLabel)
   usePageTitle(asset?.name ?? null)
   const [annotationData, setAnnotationData] = useState<Record<string, unknown> | null>(null)
+  const [pdfPage, setPdfPage] = useState(1)
   const [activeTab, setActiveTab] = useState<'comments' | 'fields'>('comments')
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const deepLinkApplied = useRef(false)
+
+  const discardPdfAnnotation = useCallback(() => {
+    setAnnotationData(null)
+    discardAnnotations()
+  }, [discardAnnotations])
+
+  const changePdfPage = useCallback((page: number) => {
+    discardPdfAnnotation()
+    setPdfPage(page)
+  }, [discardPdfAnnotation])
+
+  useEffect(() => {
+    if (asset?.asset_type !== 'pdf') return
+    discardPdfAnnotation()
+    setPdfPage(1)
+  }, [asset?.id, asset?.asset_type, currentVersion?.id, discardPdfAnnotation])
 
   // Fetch folder tree to build the folder path for the breadcrumb
   const { data: folderTree } = useSWR<FolderTreeNode[]>(
@@ -153,13 +180,16 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
     deepLinkApplied.current = true
     setFocusedCommentId(commentId)
     setActiveTab('comments')
+    if ((target as any).page_number !== null && (target as any).page_number !== undefined) {
+      changePdfPage((target as any).page_number)
+    }
     if ((target as any).timecode_start !== null && (target as any).timecode_start !== undefined) {
       seekTo((target as any).timecode_start, true)
     }
     if ((target as any).annotation?.drawing_data) {
       setActiveAnnotation((target as any).annotation.drawing_data)
     }
-  }, [comments, searchParams, seekTo, setFocusedCommentId, setActiveAnnotation])
+  }, [comments, searchParams, seekTo, setFocusedCommentId, setActiveAnnotation, changePdfPage])
 
   // Version-compare overlay: driven entirely by the ?compare= URL param so it
   // survives refresh/deep-link. closeCompare strips all four compare params.
@@ -217,6 +247,7 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
     parentId?: string,
     visibility?: string,
     mentionUserIds?: string[],
+    pageNumber?: number,
   ) => {
     await createComment(
       body,
@@ -226,6 +257,7 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
       parentId,
       visibility,
       mentionUserIds,
+      pageNumber,
     )
     setAnnotationData(null)
     refetchComments()
@@ -335,6 +367,21 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
               }
             />
           </div>
+        )
+      case 'pdf':
+        return (
+          <PdfViewer
+            asset={asset}
+            version={currentVersion as any}
+            pageNumber={pdfPage}
+            onPageChange={changePdfPage}
+            annotationCanvas={
+              <>
+                <AnnotationOverlay key={focusedCommentId ?? 'none'} />
+                {isDrawingMode && <AnnotationCanvas onSave={(data) => setAnnotationData(data)} />}
+              </>
+            }
+          />
         )
       default:
         return null
@@ -509,6 +556,7 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
                     onRemoveReaction={removeReaction}
                     onReply={() => {}}
                     onSubmitReply={handleSubmitReply}
+                    onSelectPage={asset.asset_type === 'pdf' ? changePdfPage : undefined}
                   />
                   {canComment && (
                     <CommentInput
@@ -517,6 +565,7 @@ function ReviewScreenInner({ projectId }: { projectId: string }) {
                       assetType={asset.asset_type}
                       onSubmit={handleSubmitComment}
                       annotationData={annotationData}
+                      pageNumber={asset.asset_type === 'pdf' ? pdfPage : undefined}
                     />
                   )}
                 </>

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -585,6 +585,7 @@ function ShareMediaViewer({ asset, token, streamUrl, streamLoading }: ShareMedia
 
   React.useEffect(() => {
     if (!streamUrl || streamLoading) return
+    if (asset.asset_type !== 'video' && asset.asset_type !== 'audio') return
 
     setFatalError(null)
     const mediaEl = asset.asset_type === 'video' ? videoRef.current : audioRef.current
@@ -745,6 +746,16 @@ function ShareMediaViewer({ asset, token, streamUrl, streamLoading }: ShareMedia
             }}
           />
         </div>
+      )}
+
+      {asset.asset_type === 'pdf' && (
+        streamLoading ? (
+          <Loader2 className="h-8 w-8 animate-spin text-text-tertiary" />
+        ) : streamUrl ? (
+          <iframe title={asset.name} src={`${streamUrl}#zoom=page-width`} className="h-full w-full border-0" />
+        ) : (
+          <div className="flex flex-col items-center gap-2"><FileText className="h-10 w-10 text-text-tertiary" /><p className="text-sm text-text-tertiary">PDF unavailable</p></div>
+        )
       )}
     </div>
   )

--- a/apps/web/components/projects/asset-card.tsx
+++ b/apps/web/components/projects/asset-card.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Film, Music, Image as ImageIcon, Images, MessageSquare, MoreHorizontal, Check, Share2, Download, Link as LinkIcon, Pencil, Trash2 } from 'lucide-react'
+import { Film, Music, Image as ImageIcon, Images, FileText, MessageSquare, MoreHorizontal, Check, Share2, Download, Link as LinkIcon, Pencil, Trash2 } from 'lucide-react'
 import { cn, formatRelativeTime, formatBytes } from '@/lib/utils'
 import type { Asset, AssetType, User } from '@/types'
 import type { AspectRatio, ThumbnailScale, TitleLines } from '@/stores/view-store'
@@ -12,6 +12,7 @@ const assetTypeIcons: Record<AssetType, React.ElementType> = {
   audio: Music,
   image: ImageIcon,
   image_carousel: Images,
+  pdf: FileText,
 }
 
 const aspectMap = {

--- a/apps/web/components/projects/asset-grid.tsx
+++ b/apps/web/components/projects/asset-grid.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { X, Download, MoreHorizontal, Layers, Share2, Trash2, FolderInput, FolderIcon, Check, Film, Music, Image as ImageIcon, Images, Link as LinkIcon, Pencil } from 'lucide-react'
+import { X, Download, MoreHorizontal, Layers, Share2, Trash2, FolderInput, FolderIcon, Check, Film, Music, Image as ImageIcon, Images, FileText, Link as LinkIcon, Pencil } from 'lucide-react'
 import { cn, formatRelativeTime, formatBytes } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Avatar } from '@/components/shared/avatar'
@@ -20,6 +20,7 @@ const assetTypeIcons: Record<string, React.ElementType> = {
   audio: Music,
   image: ImageIcon,
   image_carousel: Images,
+  pdf: FileText,
 }
 
 const statusOrder: Record<AssetStatus, number> = {

--- a/apps/web/components/projects/folder-card.tsx
+++ b/apps/web/components/projects/folder-card.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useState } from 'react'
 import useSWR from 'swr'
-import { Folder, Film, Music, Image as ImageIcon, Images, MoreHorizontal, Pencil, Trash, Share2 } from 'lucide-react'
+import { Folder, Film, Music, Image as ImageIcon, Images, FileText, MoreHorizontal, Pencil, Trash, Share2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { api } from '@/lib/api'
 import { NameDialog } from './name-dialog'
@@ -14,6 +14,7 @@ const assetTypeIcons = {
   audio: Music,
   image: ImageIcon,
   image_carousel: Images,
+  pdf: FileText,
 } as const
 
 function ThumbCell({ asset, className }: { asset: AssetResponse; className?: string }) {

--- a/apps/web/components/review/__tests__/comment-overrides.test.tsx
+++ b/apps/web/components/review/__tests__/comment-overrides.test.tsx
@@ -33,6 +33,14 @@ function annotatedComment() {
   } as never
 }
 
+function pdfComment() {
+  return {
+    ...(annotatedComment() as Record<string, unknown>),
+    timecode_start: null,
+    page_number: 2,
+  } as never
+}
+
 describe('CommentPanel onSeekToTimecode', () => {
   it('routes timecode clicks through the override instead of the store', () => {
     const onSeek = vi.fn()
@@ -133,5 +141,55 @@ describe('CommentPanel onShowAnnotation', () => {
     )
     fireEvent.click(screen.getByTitle('Show annotation'))
     expect(useReviewStore.getState().activeAnnotation).toEqual(DRAWING)
+  })
+})
+
+describe('CommentPanel onSelectPage', () => {
+  it('selects the stored page from a whole-row click', () => {
+    const onSelectPage = vi.fn()
+    render(
+      <CommentPanel
+        comments={[pdfComment()]}
+        onResolve={noop} onDelete={noop}
+        onAddReaction={noop} onRemoveReaction={noop}
+        onReply={() => {}}
+        onSelectPage={onSelectPage}
+      />,
+    )
+    fireEvent.click(screen.getByText('Fix the logo'))
+    expect(onSelectPage).toHaveBeenCalledOnce()
+    expect(onSelectPage).toHaveBeenCalledWith(2)
+  })
+
+  it('selects the stored page from the page badge', () => {
+    const onSelectPage = vi.fn()
+    render(
+      <CommentPanel
+        comments={[pdfComment()]}
+        onResolve={noop} onDelete={noop}
+        onAddReaction={noop} onRemoveReaction={noop}
+        onReply={() => {}}
+        onSelectPage={onSelectPage}
+      />,
+    )
+    fireEvent.click(screen.getByTitle('Go to page 2'))
+    expect(onSelectPage).toHaveBeenCalledOnce()
+    expect(onSelectPage).toHaveBeenCalledWith(2)
+  })
+
+  it('selects the stored page before showing its annotation', () => {
+    const calls: string[] = []
+    render(
+      <CommentPanel
+        comments={[pdfComment()]}
+        onResolve={noop} onDelete={noop}
+        onAddReaction={noop} onRemoveReaction={noop}
+        onReply={() => {}}
+        onSelectPage={() => calls.push('page')}
+        onShowAnnotation={() => calls.push('annotation')}
+      />,
+    )
+    fireEvent.click(screen.getByTitle('Show annotation'))
+    expect(calls).toEqual(['page', 'annotation'])
   })
 })

--- a/apps/web/components/review/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/components/review/__tests__/pdf-viewer.test.tsx
@@ -1,0 +1,125 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PdfViewer } from '../pdf-viewer'
+
+const getPage = vi.fn()
+const destroyDocument = vi.fn(async () => {})
+const destroyLoadingTask = vi.fn(async () => {})
+const getDocument = vi.fn(() => ({
+  promise: Promise.resolve({ numPages: 3, getPage, destroy: destroyDocument }),
+  destroy: destroyLoadingTask,
+}))
+
+vi.mock('@/lib/load-pdfjs', () => ({
+  loadPdfJs: vi.fn(async () => ({
+    GlobalWorkerOptions: { workerSrc: '' },
+    getDocument,
+  })),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { get: vi.fn(async () => ({ url: 'https://files.example.test/demo.pdf' })) },
+}))
+
+vi.mock('../review-provider', () => ({
+  useReview: () => ({ shareToken: undefined, shareSession: null }),
+}))
+
+const asset = { id: 'a1', name: 'Demo.pdf', asset_type: 'pdf' } as never
+const version = { id: 'v1', version_number: 1 } as never
+
+let observedWidth = 800
+let resizeCallback: ResizeObserverCallback | null = null
+
+function makePage(renderPromise: Promise<void> = Promise.resolve()) {
+  const cancel = vi.fn()
+  return {
+    cancel,
+    page: {
+      getViewport: ({ scale }: { scale: number }) => ({ width: 600 * scale, height: 800 * scale }),
+      render: vi.fn(() => ({ promise: renderPromise, cancel })),
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  observedWidth = 800
+  resizeCallback = null
+  getPage.mockImplementation(async () => makePage().page)
+
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement) {
+    return this.dataset.testid === 'pdf-scroll-viewport' ? observedWidth : 0
+  })
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({} as never)
+  vi.stubGlobal('ResizeObserver', class {
+    constructor(callback: ResizeObserverCallback) { resizeCallback = callback }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  })
+  Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2 })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('PdfViewer', () => {
+  it('renders only the selected page and mounts annotations inside its page-sized surface', async () => {
+    render(
+      <PdfViewer
+        asset={asset}
+        version={version}
+        pageNumber={2}
+        onPageChange={vi.fn()}
+        annotationCanvas={<div data-testid="annotation-slot" />}
+      />,
+    )
+
+    const annotation = await screen.findByTestId('annotation-slot')
+    await waitFor(() => expect(getPage).toHaveBeenCalledWith(2))
+    expect(annotation.parentElement).toBe(screen.getByTestId('pdf-page-surface'))
+    expect(screen.getByTestId('pdf-page-surface')).toHaveStyle({ width: '768px', height: '1024px' })
+
+    const canvas = screen.getByTestId('pdf-page-canvas') as HTMLCanvasElement
+    expect(canvas.width).toBe(1536)
+    expect(canvas.height).toBe(2048)
+    expect(screen.getByLabelText('PDF page count')).toHaveTextContent('of 3')
+  })
+
+  it('clamps the page input and disables navigation at the document bounds', async () => {
+    const onPageChange = vi.fn()
+    render(<PdfViewer asset={asset} version={version} pageNumber={3} onPageChange={onPageChange} />)
+
+    await screen.findByLabelText('PDF page count')
+    expect(screen.getByTitle('Next page')).toBeDisabled()
+    fireEvent.change(screen.getByLabelText('PDF page'), { target: { value: '99' } })
+    expect(onPageChange).toHaveBeenCalledWith(3)
+
+    fireEvent.click(screen.getByTitle('Previous page'))
+    expect(onPageChange).toHaveBeenCalledWith(2)
+  })
+
+  it('cancels a stale render and rerenders when the viewport width changes', async () => {
+    let resolveFirstRender!: () => void
+    const firstRenderPromise = new Promise<void>((resolve) => { resolveFirstRender = resolve })
+    const first = makePage(firstRenderPromise)
+    const second = makePage()
+    getPage
+      .mockResolvedValueOnce(first.page)
+      .mockResolvedValueOnce(second.page)
+
+    render(<PdfViewer asset={asset} version={version} pageNumber={1} onPageChange={vi.fn()} />)
+    await waitFor(() => expect(getPage).toHaveBeenCalledTimes(1))
+
+    observedWidth = 500
+    act(() => resizeCallback?.([], {} as ResizeObserver))
+
+    await waitFor(() => expect(first.cancel).toHaveBeenCalled())
+    await waitFor(() => expect(getPage).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('pdf-page-surface')).toHaveStyle({ width: '468px', height: '624px' })
+    resolveFirstRender()
+  })
+})

--- a/apps/web/components/review/comment-input.tsx
+++ b/apps/web/components/review/comment-input.tsx
@@ -33,6 +33,8 @@ interface CommentInputProps {
   assetId: string;
   projectId: string;
   assetType?: string;
+  /** Current PDF page; stored on comments instead of a video timecode. */
+  pageNumber?: number;
   replyToId?: string | null;
   annotationData?: Record<string, unknown> | null;
   onSubmit: (
@@ -43,6 +45,7 @@ interface CommentInputProps {
     parentId?: string,
     visibility?: string,
     mentionUserIds?: string[],
+    pageNumber?: number,
   ) => Promise<void>;
   onCancelReply?: () => void;
   onPauseVideo?: () => void;
@@ -192,6 +195,7 @@ export function CommentInput({
   assetId,
   projectId,
   assetType,
+  pageNumber,
   replyToId,
   annotationData,
   onSubmit,
@@ -410,6 +414,7 @@ export function CommentInput({
         replyToId ?? undefined,
         commentVisibility,
         mentionUserIds.length > 0 ? mentionUserIds : undefined,
+        pageNumber,
       );
 
       setBody("");

--- a/apps/web/components/review/comment-panel.tsx
+++ b/apps/web/components/review/comment-panel.tsx
@@ -54,6 +54,8 @@ interface CommentPanelProps {
   onSeekToTimecode?: (time: number, pause?: boolean) => void;
   /** Compare mode: route annotation display to a pane-scoped overlay instead of the global store. */
   onShowAnnotation?: (drawingData: Record<string, unknown> | null) => void;
+  /** PDF review: move the viewer to a comment's page before showing it. */
+  onSelectPage?: (page: number) => void;
   /** Compare mode: export this pane's version instead of the store's currentVersion. */
   exportVersionId?: string;
   className?: string;
@@ -370,6 +372,7 @@ interface CommentItemProps {
   onSubmitReply?: (parentId: string, body: string) => Promise<void>;
   onSeekToTimecode?: (time: number, pause?: boolean) => void;
   onShowAnnotation?: (drawingData: Record<string, unknown> | null) => void;
+  onSelectPage?: (page: number) => void;
 }
 
 function CommentItem({
@@ -388,6 +391,7 @@ function CommentItem({
   onSubmitReply,
   onSeekToTimecode,
   onShowAnnotation,
+  onSelectPage,
 }: CommentItemProps) {
   const storeSeekTo = useReviewStore((s) => s.seekTo);
   const seekTo = onSeekToTimecode ?? storeSeekTo;
@@ -452,6 +456,22 @@ function CommentItem({
     else await onAddReaction(comment.id, emoji);
   }
 
+  function activateComment() {
+    setFocusedCommentId(comment.id);
+    if (comment.page_number !== null && comment.page_number !== undefined) {
+      onSelectPage?.(comment.page_number);
+    }
+    if (
+      comment.timecode_start !== null &&
+      comment.timecode_start !== undefined
+    ) {
+      seekTo(comment.timecode_start, true);
+    }
+    showAnnotation(
+      comment.annotation ? comment.annotation.drawing_data : null,
+    );
+  }
+
   return (
     <div
       ref={itemRef}
@@ -466,18 +486,7 @@ function CommentItem({
                 : "border-white/[0.06] hover:border-white/15 hover:bg-white/[0.02]",
             ),
       )}
-      onClick={() => {
-        setFocusedCommentId(comment.id);
-        if (
-          comment.timecode_start !== null &&
-          comment.timecode_start !== undefined
-        ) {
-          seekTo(comment.timecode_start, true);
-        }
-        showAnnotation(
-          comment.annotation ? comment.annotation.drawing_data : null,
-        );
-      }}
+      onClick={activateComment}
     >
       <div className="flex gap-2.5 py-3">
         {/* Colored avatar */}
@@ -519,12 +528,9 @@ function CommentItem({
               comment.timecode_start !== undefined && (
                 <button
                   className="inline-flex items-center gap-1 rounded-md bg-accent/15 px-1.5 py-0.5 text-[11px] font-mono text-accent hover:bg-accent/25 transition-colors"
-                  onClick={() => {
-                    seekTo(comment.timecode_start!, true);
-                    setFocusedCommentId(comment.id);
-                    if (comment.annotation) {
-                      showAnnotation(comment.annotation.drawing_data);
-                    }
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    activateComment();
                   }}
                   title="Jump to timecode"
                 >
@@ -536,18 +542,24 @@ function CommentItem({
                     )}
                 </button>
               )}
+            {comment.page_number !== null && comment.page_number !== undefined && (
+              <button
+                className="ml-2 rounded bg-bg-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary hover:text-text-primary"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  activateComment();
+                }}
+                title={`Go to page ${comment.page_number}`}
+              >
+                Page {comment.page_number}
+              </button>
+            )}
             {comment.annotation && (
               <button
                 className="inline-flex items-center justify-center h-5 w-5 rounded text-purple-400/70 hover:text-purple-400 hover:bg-purple-500/15 transition-colors"
-                onClick={() => {
-                  showAnnotation(comment.annotation!.drawing_data);
-                  setFocusedCommentId(comment.id);
-                  if (
-                    comment.timecode_start !== null &&
-                    comment.timecode_start !== undefined
-                  ) {
-                    seekTo(comment.timecode_start, true);
-                  }
+                onClick={(event) => {
+                  event.stopPropagation();
+                  activateComment();
                 }}
                 title="Show annotation"
               >
@@ -732,6 +744,7 @@ function CommentItem({
                   onSubmitReply={onSubmitReply}
                   onSeekToTimecode={onSeekToTimecode}
                   onShowAnnotation={onShowAnnotation}
+                  onSelectPage={onSelectPage}
                 />
               ))}
             </div>
@@ -779,6 +792,7 @@ export function CommentPanel({
   onSubmitReply,
   onSeekToTimecode,
   onShowAnnotation,
+  onSelectPage,
   exportVersionId,
   className,
 }: CommentPanelProps) {
@@ -1305,6 +1319,7 @@ export function CommentPanel({
                 onSubmitReply={onSubmitReply}
                 onSeekToTimecode={onSeekToTimecode}
                 onShowAnnotation={onShowAnnotation}
+                onSelectPage={onSelectPage}
               />
             </div>
           ))}

--- a/apps/web/components/review/pdf-viewer.tsx
+++ b/apps/web/components/review/pdf-viewer.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import * as React from 'react'
+import { ChevronLeft, ChevronRight, FileText, Loader2 } from 'lucide-react'
+import { api } from '@/lib/api'
+import { withBasePath } from '@/lib/base-path'
+import { loadPdfJs } from '@/lib/load-pdfjs'
+import { useReview } from './review-provider'
+import type { Asset, AssetVersion } from '@/types'
+import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist/types/src/display/api'
+
+interface PdfViewerProps {
+  asset: Asset
+  version: AssetVersion | null
+  pageNumber: number
+  onPageChange: (page: number) => void
+  annotationCanvas?: React.ReactNode
+}
+
+interface PageSize {
+  width: number
+  height: number
+}
+
+/**
+ * Renders one PDF page into an app-owned canvas. Keeping the PDF bitmap and
+ * annotation layers in the same page-sized wrapper makes annotations scroll
+ * and resize with the page instead of floating over a browser PDF iframe.
+ */
+export function PdfViewer({ asset, version, pageNumber, onPageChange, annotationCanvas }: PdfViewerProps) {
+  const [url, setUrl] = React.useState<string | null>(null)
+  const [document, setDocument] = React.useState<PDFDocumentProxy | null>(null)
+  const [totalPages, setTotalPages] = React.useState(0)
+  const [pageSize, setPageSize] = React.useState<PageSize | null>(null)
+  const [availableWidth, setAvailableWidth] = React.useState(0)
+  const [error, setError] = React.useState<string | null>(null)
+  const [loadingDocument, setLoadingDocument] = React.useState(true)
+  const [renderingPage, setRenderingPage] = React.useState(false)
+  const viewportRef = React.useRef<HTMLDivElement>(null)
+  const canvasRef = React.useRef<HTMLCanvasElement>(null)
+  const onPageChangeRef = React.useRef(onPageChange)
+  const pageNumberRef = React.useRef(pageNumber)
+  const { shareToken, shareSession } = useReview()
+  const versionId = version?.id
+
+  onPageChangeRef.current = onPageChange
+  pageNumberRef.current = pageNumber
+
+  React.useEffect(() => {
+    if (!versionId) return
+    let cancelled = false
+    setLoadingDocument(true)
+    setError(null)
+    setUrl(null)
+    setDocument(null)
+    setTotalPages(0)
+    setPageSize(null)
+
+    const loadUrl = async () => {
+      try {
+        if (shareToken) {
+          const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+          const session = shareSession ? `&share_session=${encodeURIComponent(shareSession)}` : ''
+          const response = await fetch(`${apiUrl}/share/${shareToken}/stream/${asset.id}?version_id=${versionId}${session}`)
+          if (!response.ok) throw new Error('Failed to load PDF')
+          const data = await response.json()
+          if (!cancelled) setUrl(data.url)
+        } else {
+          const data = await api.get<{ url: string }>(`/assets/${asset.id}/stream?version_id=${versionId}`)
+          if (!cancelled) setUrl(data.url)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load PDF')
+          setLoadingDocument(false)
+        }
+      }
+    }
+
+    void loadUrl()
+    return () => { cancelled = true }
+  }, [asset.id, versionId, shareToken, shareSession])
+
+  React.useEffect(() => {
+    if (!url) return
+
+    let cancelled = false
+    let loadingTask: ReturnType<typeof import('pdfjs-dist')['getDocument']> | null = null
+    let loadedDocument: PDFDocumentProxy | null = null
+
+    const loadDocument = async () => {
+      try {
+        const assetsBase = withBasePath('/pdfjs')
+        const pdfjs = await loadPdfJs(assetsBase)
+        if (cancelled) return
+        pdfjs.GlobalWorkerOptions.workerSrc = `${assetsBase}/pdf.worker.min.mjs`
+        const task = pdfjs.getDocument({
+          url,
+          cMapUrl: `${assetsBase}/cmaps/`,
+          cMapPacked: true,
+          standardFontDataUrl: `${assetsBase}/standard_fonts/`,
+          wasmUrl: `${assetsBase}/wasm/`,
+        })
+        loadingTask = task
+        loadedDocument = await task.promise
+        if (cancelled) return
+
+        setDocument(loadedDocument)
+        setTotalPages(loadedDocument.numPages)
+        setLoadingDocument(false)
+
+        const requestedPage = pageNumberRef.current
+        const clampedPage = Math.min(Math.max(1, requestedPage), loadedDocument.numPages)
+        if (clampedPage !== requestedPage) onPageChangeRef.current(clampedPage)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load PDF')
+          setLoadingDocument(false)
+        }
+      }
+    }
+
+    void loadDocument()
+    return () => {
+      cancelled = true
+      if (loadedDocument) void loadedDocument.destroy()
+      else void loadingTask?.destroy()
+    }
+  }, [url]) // page changes must not reload the whole document
+
+  React.useEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport) return
+
+    const syncWidth = () => setAvailableWidth(viewport.clientWidth)
+    syncWidth()
+
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(syncWidth)
+    observer.observe(viewport)
+    return () => observer.disconnect()
+  }, [loadingDocument, error])
+
+  React.useEffect(() => {
+    if (!document || !availableWidth || !canvasRef.current) return
+
+    let cancelled = false
+    let renderTask: RenderTask | null = null
+    setRenderingPage(true)
+    setError(null)
+
+    const renderPage = async () => {
+      try {
+        const page = await document.getPage(pageNumber)
+        if (cancelled || !canvasRef.current) return
+
+        const baseViewport = page.getViewport({ scale: 1 })
+        const cssWidth = Math.max(1, availableWidth - 32)
+        const viewport = page.getViewport({ scale: cssWidth / baseViewport.width })
+        const outputScale = window.devicePixelRatio || 1
+        const canvas = canvasRef.current
+        const context = canvas.getContext('2d')
+        if (!context) throw new Error('Unable to render PDF page')
+
+        const nextSize = {
+          width: Math.floor(viewport.width),
+          height: Math.floor(viewport.height),
+        }
+        setPageSize(nextSize)
+        canvas.width = Math.floor(viewport.width * outputScale)
+        canvas.height = Math.floor(viewport.height * outputScale)
+        canvas.style.width = `${nextSize.width}px`
+        canvas.style.height = `${nextSize.height}px`
+
+        renderTask = page.render({
+          canvas,
+          canvasContext: context,
+          viewport,
+          transform: outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : undefined,
+        })
+        await renderTask.promise
+        if (!cancelled) setRenderingPage(false)
+      } catch (err) {
+        if (cancelled || (err as { name?: string })?.name === 'RenderingCancelledException') return
+        setError(err instanceof Error ? err.message : 'Failed to render PDF page')
+        setRenderingPage(false)
+      }
+    }
+
+    void renderPage()
+    return () => {
+      cancelled = true
+      renderTask?.cancel()
+    }
+  }, [document, pageNumber, availableWidth])
+
+  const setPage = (next: number) => {
+    const maximum = totalPages || Number.MAX_SAFE_INTEGER
+    onPageChange(Math.min(Math.max(1, next), maximum))
+  }
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col bg-bg-primary">
+      <div className="absolute left-1/2 top-3 z-20 flex -translate-x-1/2 items-center gap-1 rounded-md border border-border bg-bg-secondary/95 p-1 shadow-lg">
+        <button title="Previous page" className="rounded p-1 hover:bg-bg-hover disabled:opacity-40" disabled={pageNumber <= 1 || loadingDocument} onClick={() => setPage(pageNumber - 1)}><ChevronLeft className="h-4 w-4" /></button>
+        <label className="flex items-center gap-1 px-1 text-xs text-text-secondary">
+          Page
+          <input
+            aria-label="PDF page"
+            className="w-10 rounded border border-border bg-bg-tertiary px-1 py-0.5 text-center text-text-primary"
+            min="1"
+            max={totalPages || undefined}
+            type="number"
+            value={pageNumber}
+            onChange={(event) => setPage(Number(event.target.value) || 1)}
+          />
+          {totalPages > 0 && <span aria-label="PDF page count">of {totalPages}</span>}
+        </label>
+        <button title="Next page" className="rounded p-1 hover:bg-bg-hover disabled:opacity-40" disabled={loadingDocument || (totalPages > 0 && pageNumber >= totalPages)} onClick={() => setPage(pageNumber + 1)}><ChevronRight className="h-4 w-4" /></button>
+      </div>
+
+      <div ref={viewportRef} data-testid="pdf-scroll-viewport" className="min-h-0 flex-1 overflow-auto px-4 pb-4 pt-14">
+        {error ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-text-tertiary"><FileText className="h-8 w-8" /><span className="text-sm">{error}</span></div>
+        ) : (
+          <div
+            key={`${version?.id ?? 'none'}-${pageNumber}`}
+            data-testid="pdf-page-surface"
+            className="relative mx-auto bg-white shadow-lg"
+            style={pageSize ? { width: pageSize.width, height: pageSize.height } : { width: '100%', minHeight: 1 }}
+          >
+            <canvas ref={canvasRef} data-testid="pdf-page-canvas" className="block" />
+            {pageSize && annotationCanvas}
+            {(loadingDocument || renderingPage) && (
+              <div className="absolute inset-0 z-20 flex items-center justify-center bg-bg-primary/60"><Loader2 className="h-7 w-7 animate-spin text-text-tertiary" /></div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/review/review-provider.tsx
+++ b/apps/web/components/review/review-provider.tsx
@@ -21,6 +21,7 @@ export interface CreateCommentPayload {
   parent_id?: string;
   timecode_start?: number;
   timecode_end?: number;
+  page_number?: number;
   annotation?: { drawing_data: Record<string, unknown> };
 }
 

--- a/apps/web/components/share/__tests__/share-review-mount.test.tsx
+++ b/apps/web/components/share/__tests__/share-review-mount.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { FolderShareViewer } from '../folder-share-viewer'
+import { FolderShareViewer, submitPendingShareComment } from '../folder-share-viewer'
 
 // Regression for #192: ShareReviewInner used to resolve its hooks with bare
 // CommonJS require('@/...') calls. Node's loader does not understand the '@'
@@ -44,5 +44,23 @@ describe('folder share — opening an asset mounts the review UI (#192)', () => 
     // subtree mounted — i.e. if its hook imports resolved.
     await waitFor(() => expect(screen.getByText('Fields')).toBeInTheDocument(), { timeout: 3000 })
     expect(screen.getByText('Comments')).toBeInTheDocument()
+  })
+})
+
+describe('folder share — pending guest PDF comment', () => {
+  it('retains the page number when identity collection delays submission', async () => {
+    const submit = vi.fn(async () => {})
+    await submitPendingShareComment(
+      { body: 'Mark this', annotationData: { objects: [] }, pageNumber: 4 },
+      submit,
+    )
+
+    expect(submit).toHaveBeenCalledWith(
+      'Mark this',
+      undefined,
+      undefined,
+      { objects: [] },
+      4,
+    )
   })
 })

--- a/apps/web/components/share/folder-share-viewer.tsx
+++ b/apps/web/components/share/folder-share-viewer.tsx
@@ -59,6 +59,33 @@ interface FolderShareViewerProps {
   onAssetClick?: (assetId: string) => void
 }
 
+export interface PendingShareComment {
+  body: string
+  timecodeStart?: number
+  timecodeEnd?: number
+  annotationData?: Record<string, unknown>
+  pageNumber?: number
+}
+
+export function submitPendingShareComment(
+  pending: PendingShareComment,
+  submit: (
+    body: string,
+    timecodeStart?: number,
+    timecodeEnd?: number,
+    annotationData?: Record<string, unknown>,
+    pageNumber?: number,
+  ) => Promise<void>,
+) {
+  return submit(
+    pending.body,
+    pending.timecodeStart,
+    pending.timecodeEnd,
+    pending.annotationData,
+    pending.pageNumber,
+  )
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatFileSize(bytes: number | null): string {
@@ -740,6 +767,7 @@ function ShareReviewScreen({
   const [VideoPlayer, setVideoPlayer] = React.useState<any>(null)
   const [ImageViewer, setImageViewer] = React.useState<any>(null)
   const [AudioPlayer, setAudioPlayer] = React.useState<any>(null)
+  const [PdfViewer, setPdfViewer] = React.useState<any>(null)
   const [CommentPanel, setCommentPanel] = React.useState<any>(null)
   const [CommentInput, setCommentInput] = React.useState<any>(null)
   const [VersionSwitcher, setVersionSwitcher] = React.useState<any>(null)
@@ -752,14 +780,16 @@ function ShareReviewScreen({
       import('@/components/review/video-player'),
       import('@/components/review/image-viewer'),
       import('@/components/review/audio-player'),
+      import('@/components/review/pdf-viewer'),
       import('@/components/review/comment-panel'),
       import('@/components/review/comment-input'),
       import('@/components/review/version-switcher'),
-    ]).then(([provider, video, image, audio, comments, input, versionSwitcher]) => {
+    ]).then(([provider, video, image, audio, pdf, comments, input, versionSwitcher]) => {
       setProvider(() => provider.ReviewProvider)
       setVideoPlayer(() => video.VideoPlayer)
       setImageViewer(() => image.ImageViewer)
       setAudioPlayer(() => audio.AudioPlayer)
+      setPdfViewer(() => pdf.PdfViewer)
       setCommentPanel(() => comments.CommentPanel)
       setCommentInput(() => input.CommentInput)
       setVersionSwitcher(() => versionSwitcher.VersionSwitcher)
@@ -784,6 +814,7 @@ function ShareReviewScreen({
         VideoPlayer={VideoPlayer}
         ImageViewer={ImageViewer}
         AudioPlayer={AudioPlayer}
+        PdfViewer={PdfViewer}
         CommentPanel={CommentPanel}
         CommentInput={CommentInput}
         VersionSwitcher={VersionSwitcher}
@@ -794,14 +825,31 @@ function ShareReviewScreen({
 
 function ShareReviewInner({
   token, shareSession, assetName, permission, allowDownload, showVersions, onBack,
-  VideoPlayer, ImageViewer, AudioPlayer, CommentPanel, CommentInput, VersionSwitcher,
+  VideoPlayer, ImageViewer, AudioPlayer, PdfViewer, CommentPanel, CommentInput, VersionSwitcher,
 }: any) {
   const { asset, versions, isLoading, comments, refetchComments, addComment } = useReview()
-  const { currentVersion, isDrawingMode, focusedCommentId } = useReviewStore()
+  const {
+    currentVersion,
+    isDrawingMode,
+    focusedCommentId,
+    discardAnnotations,
+  } = useReviewStore()
   const [sidebarOpen, setSidebarOpen] = React.useState(() => typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches)
   const [activeTab, setActiveTab] = React.useState<'comments' | 'fields'>('comments')
+  const [pdfPage, setPdfPage] = React.useState(1)
   const [AnnotationOverlay, setAnnotationOverlay] = React.useState<any>(null)
   const [AnnotationCanvas, setAnnotationCanvas] = React.useState<any>(null)
+
+  const changePdfPage = React.useCallback((page: number) => {
+    discardAnnotations()
+    setPdfPage(page)
+  }, [discardAnnotations])
+
+  React.useEffect(() => {
+    if (asset?.asset_type !== 'pdf') return
+    discardAnnotations()
+    setPdfPage(1)
+  }, [asset?.id, asset?.asset_type, currentVersion?.id, discardAnnotations])
 
   React.useEffect(() => {
     Promise.all([
@@ -819,7 +867,7 @@ function ShareReviewInner({
   // Guest identity flow for non-authenticated users
   const [guestIdentity, setGuestIdentity] = React.useState<{ name: string; email: string } | null>(null)
   const [showGuestPrompt, setShowGuestPrompt] = React.useState(false)
-  const pendingCommentRef = React.useRef<{ body: string; timecodeStart?: number; timecodeEnd?: number; annotationData?: Record<string, unknown> } | null>(null)
+  const pendingCommentRef = React.useRef<PendingShareComment | null>(null)
   React.useEffect(() => {
     try {
       const stored = localStorage.getItem('ff_guest_identity')
@@ -828,11 +876,12 @@ function ShareReviewInner({
   }, [])
   const isLoggedIn = typeof window !== 'undefined' && !!localStorage.getItem('ff_access_token')
 
-  const submitComment = React.useCallback(async (body: string, timecodeStart?: number, timecodeEnd?: number, annotationData?: Record<string, unknown>) => {
+  const submitComment = React.useCallback(async (body: string, timecodeStart?: number, timecodeEnd?: number, annotationData?: Record<string, unknown>, pageNumber?: number) => {
     const payload: CreateCommentPayload = { body }
     if (currentVersion?.id) payload.version_id = currentVersion.id
     if (timecodeStart != null) payload.timecode_start = timecodeStart
     if (timecodeEnd != null) payload.timecode_end = timecodeEnd
+    if (pageNumber != null) payload.page_number = pageNumber
     if (annotationData) payload.annotation = { drawing_data: annotationData }
     await addComment(payload)
     refetchComments().catch(() => {})
@@ -846,9 +895,9 @@ function ShareReviewInner({
 
     // Auto-submit the pending comment
     if (pendingCommentRef.current) {
-      const { body, timecodeStart, timecodeEnd, annotationData } = pendingCommentRef.current
+      const pending = pendingCommentRef.current
       pendingCommentRef.current = null
-      setTimeout(() => submitComment(body, timecodeStart, timecodeEnd, annotationData), 50)
+      setTimeout(() => { void submitPendingShareComment(pending, submitComment) }, 50)
     }
   }, [submitComment])
 
@@ -913,6 +962,19 @@ function ShareReviewInner({
                 }
               />
             </div>
+          ) : asset.asset_type === 'pdf' && versionReady && PdfViewer ? (
+            <PdfViewer
+              asset={asset}
+              version={currentVersion}
+              pageNumber={pdfPage}
+              onPageChange={changePdfPage}
+              annotationCanvas={
+                <>
+                  {AnnotationOverlay && <AnnotationOverlay key={focusedCommentId ?? 'none'} />}
+                  {isDrawingMode && AnnotationCanvas && <AnnotationCanvas />}
+                </>
+              }
+            />
           ) : (
             <div className="flex-1 flex items-center justify-center">
               <Loader2 className="h-8 w-8 animate-spin text-text-tertiary" />
@@ -944,21 +1006,23 @@ function ShareReviewInner({
                   onRemoveReaction={() => {}}
                   onReply={() => {}}
                   onSubmitReply={async () => {}}
+                  onSelectPage={asset.asset_type === 'pdf' ? changePdfPage : undefined}
                 />
                 {canComment && CommentInput && (
                   <CommentInput
                     assetId={asset.id}
                     projectId=""
                     assetType={asset.asset_type}
-                    onSubmit={async (body: string, timecodeStart?: number, timecodeEnd?: number, annotationData?: Record<string, unknown>) => {
+                    pageNumber={asset.asset_type === 'pdf' ? pdfPage : undefined}
+                    onSubmit={async (body: string, timecodeStart?: number, timecodeEnd?: number, annotationData?: Record<string, unknown>, _parentId?: string, _visibility?: string, _mentionUserIds?: string[], pageNumber?: number) => {
                       const hasAuth = !!localStorage.getItem('ff_access_token')
                       const hasGuest = !!localStorage.getItem('ff_guest_identity')
                       if (!hasAuth && !hasGuest) {
-                        pendingCommentRef.current = { body, timecodeStart, timecodeEnd, annotationData }
+                        pendingCommentRef.current = { body, timecodeStart, timecodeEnd, annotationData, pageNumber }
                         setShowGuestPrompt(true)
                         return
                       }
-                      await submitComment(body, timecodeStart, timecodeEnd, annotationData)
+                      await submitComment(body, timecodeStart, timecodeEnd, annotationData, pageNumber)
                     }}
                   />
                 )}

--- a/apps/web/components/shared/branding-head.tsx
+++ b/apps/web/components/shared/branding-head.tsx
@@ -26,7 +26,12 @@ const DEFAULT_ICON = '/logo-icon.png'
  */
 function setIcon(rel: string, href: string) {
   document
-    .querySelectorAll<HTMLLinkElement>(`link[rel="${rel}"]:not([${DATA_ATTR}])`)
+    // Never remove links owned by Next.js. React tracks those nodes and will
+    // later attempt to unmount them; removing them here causes a null
+    // parentNode and the `removeChild` crash in React's head reconciler.
+    .querySelectorAll<HTMLLinkElement>(
+      `link[rel="${rel}"]:not([${DATA_ATTR}]):not([data-next-head])`,
+    )
     .forEach((el) => el.remove())
 
   let link = document.querySelector<HTMLLinkElement>(`link[rel="${rel}"][${DATA_ATTR}]`)

--- a/apps/web/components/upload/upload-zone.tsx
+++ b/apps/web/components/upload/upload-zone.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { CloudUpload, Film, Music, Image as ImageIcon } from 'lucide-react'
+import { CloudUpload } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface UploadZoneProps {
@@ -70,7 +70,7 @@ export function UploadZone({ onFilesSelected, className }: UploadZoneProps) {
         ref={inputRef}
         type="file"
         multiple
-        accept="video/*,audio/*,image/*"
+        accept="video/*,audio/*,image/*,application/pdf"
         className="hidden"
         onChange={(e) => handleFiles(e.target.files)}
       />

--- a/apps/web/hooks/use-comments.ts
+++ b/apps/web/hooks/use-comments.ts
@@ -27,6 +27,7 @@ interface CreateCommentPayload {
   version_id?: string
   timecode_start?: number
   timecode_end?: number
+  page_number?: number
   annotation?: {
     drawing_data: Record<string, unknown>
     frame_number?: number
@@ -85,6 +86,7 @@ export function useComments(assetId: string | null, versionId: string | null) {
     parentId?: string,
     visibility?: string,
     mentionUserIds?: string[],
+    pageNumber?: number,
   ): Promise<CommentWithReplies> {
     if (!assetId) throw new Error('No asset selected')
     if (!versionId) throw new Error('No version selected')
@@ -92,6 +94,7 @@ export function useComments(assetId: string | null, versionId: string | null) {
     const payload: CreateCommentPayload = { body, version_id: versionId }
     if (timecodeStart !== undefined) payload.timecode_start = timecodeStart
     if (timecodeEnd !== undefined) payload.timecode_end = timecodeEnd
+    if (pageNumber !== undefined) payload.page_number = pageNumber
     if (annotationData) payload.annotation = { drawing_data: annotationData }
     if (parentId) payload.parent_id = parentId
     if (visibility) payload.visibility = visibility

--- a/apps/web/lib/load-pdfjs.ts
+++ b/apps/web/lib/load-pdfjs.ts
@@ -1,0 +1,14 @@
+import type * as PdfJs from 'pdfjs-dist'
+
+type PdfJsModule = typeof PdfJs
+
+/**
+ * PDF.js ships as native ESM. Loading its self-hosted display module directly
+ * avoids Next 14 rewriting it as a Webpack module, which breaks in development.
+ */
+export async function loadPdfJs(assetsBase: string): Promise<PdfJsModule> {
+  return import(
+    /* webpackIgnore: true */
+    `${assetsBase}/pdf.min.mjs`
+  ) as Promise<PdfJsModule>
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {
+    "pdfjs:assets": "node scripts/copy-pdfjs-assets.mjs",
+    "predev": "node scripts/copy-pdfjs-assets.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/copy-pdfjs-assets.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -28,6 +31,7 @@
     "hls.js": "^1.6.16",
     "lucide-react": "^0.577.0",
     "next": "14.2.35",
+    "pdfjs-dist": "5.4.624",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-zoom-pan-pinch": "^3.7.0",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       next:
         specifier: 14.2.35
         version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pdfjs-dist:
+        specifier: 5.4.624
+        version: 5.4.624
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -324,6 +327,76 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.2.2':
     resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
@@ -2431,6 +2504,9 @@ packages:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
 
+  node-readable-to-web-readable-stream@0.4.2:
+    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
+
   node-releases@2.0.52:
     resolution: {integrity: sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==}
     engines: {node: '>=18'}
@@ -2531,6 +2607,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdfjs-dist@5.4.624:
+    resolution: {integrity: sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3528,6 +3608,54 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -5776,6 +5904,9 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-readable-to-web-readable-stream@0.4.2:
+    optional: true
+
   node-releases@2.0.52: {}
 
   normalize-path@3.0.0: {}
@@ -5884,6 +6015,11 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@5.4.624:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+      node-readable-to-web-readable-stream: 0.4.2
 
   picocolors@1.1.1: {}
 

--- a/apps/web/scripts/copy-pdfjs-assets.mjs
+++ b/apps/web/scripts/copy-pdfjs-assets.mjs
@@ -1,0 +1,16 @@
+import { cpSync, mkdirSync, rmSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const pdfjsRoot = resolve(webRoot, 'node_modules/pdfjs-dist')
+const outputRoot = resolve(webRoot, 'public/pdfjs')
+
+rmSync(outputRoot, { recursive: true, force: true })
+mkdirSync(outputRoot, { recursive: true })
+
+cpSync(resolve(pdfjsRoot, 'build/pdf.worker.min.mjs'), resolve(outputRoot, 'pdf.worker.min.mjs'))
+cpSync(resolve(pdfjsRoot, 'build/pdf.min.mjs'), resolve(outputRoot, 'pdf.min.mjs'))
+cpSync(resolve(pdfjsRoot, 'cmaps'), resolve(outputRoot, 'cmaps'), { recursive: true })
+cpSync(resolve(pdfjsRoot, 'standard_fonts'), resolve(outputRoot, 'standard_fonts'), { recursive: true })
+cpSync(resolve(pdfjsRoot, 'wasm'), resolve(outputRoot, 'wasm'), { recursive: true })

--- a/apps/web/stores/__tests__/review-store.test.ts
+++ b/apps/web/stores/__tests__/review-store.test.ts
@@ -47,6 +47,19 @@ describe('Review store', () => {
     expect(useReviewStore.getState().brushSize).toBe(10)
   })
 
+  it('discardAnnotations exits drawing and clears active and pending drawings', () => {
+    useReviewStore.getState().setIsDrawingMode(true)
+    useReviewStore.getState().setPendingAnnotation({ objects: [{ id: 'draft' }] })
+    useReviewStore.getState().setActiveAnnotation({ objects: [{ id: 'saved' }] })
+
+    useReviewStore.getState().discardAnnotations()
+
+    const state = useReviewStore.getState()
+    expect(state.isDrawingMode).toBe(false)
+    expect(state.pendingAnnotation).toBeNull()
+    expect(state.activeAnnotation).toBeNull()
+  })
+
   it('reset returns all state to initial values', () => {
     useReviewStore.getState().setPlayheadTime(100)
     useReviewStore.getState().toggleDrawingMode()

--- a/apps/web/stores/review-store.ts
+++ b/apps/web/stores/review-store.ts
@@ -30,6 +30,7 @@ interface ReviewState {
   setDrawingTool: (tool: DrawingTool) => void
   setDrawingColor: (color: string) => void
   setBrushSize: (size: number) => void
+  discardAnnotations: () => void
   reset: () => void
 }
 
@@ -105,6 +106,10 @@ export const useReviewStore = create<ReviewState>()((set) => ({
 
   setBrushSize: (size: number) => {
     set({ brushSize: size })
+  },
+
+  discardAnnotations: () => {
+    set({ activeAnnotation: null, pendingAnnotation: null, isDrawingMode: false })
   },
 
   reset: () => {

--- a/apps/web/stores/upload-store.ts
+++ b/apps/web/stores/upload-store.ts
@@ -418,6 +418,7 @@ function mimeFromAssetType(assetType: string): string {
     case 'audio': return 'audio/mpeg'
     case 'image':
     case 'image_carousel': return 'image/jpeg'
+    case 'pdf': return 'application/pdf'
     default: return 'application/octet-stream'
   }
 }

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,6 +1,6 @@
 // ─── Enums ───────────────────────────────────────────────────────────────────
 
-export type AssetType = "image" | "image_carousel" | "audio" | "video";
+export type AssetType = "image" | "image_carousel" | "audio" | "video" | "pdf";
 
 export type AssetStatus = "draft" | "in_review" | "approved" | "rejected" | "archived";
 
@@ -29,7 +29,7 @@ export type ActivityAction =
   | "approved"
   | "rejected";
 
-export type FileType = "image" | "audio" | "video" | "document";
+export type FileType = "image" | "audio" | "video" | "pdf" | "document";
 
 export type MetadataFieldType = "text" | "number" | "date" | "select" | "multi_select";
 
@@ -200,6 +200,7 @@ export interface Comment {
   guest_author_id: string | null;
   timecode_start: number | null;
   timecode_end: number | null;
+  page_number: number | null;
   body: string;
   resolved: boolean;
   visibility: string;

--- a/packages/transcoder/image_processor.py
+++ b/packages/transcoder/image_processor.py
@@ -44,6 +44,47 @@ def process_image(s3_client, bucket: str, input_s3_key: str, output_prefix: str)
     return result
 
 
+def process_pdf(s3_client, bucket: str, input_s3_key: str, output_prefix: str) -> dict:
+    """Render the first PDF page as a JPEG thumbnail."""
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+        tmp_input = f.name
+    work_dir = tempfile.mkdtemp()
+    try:
+        s3_client.download_file(bucket, input_s3_key, tmp_input)
+
+        # pdftoppm appends the selected image extension to the output prefix.
+        # Render only page one and bound both dimensions to 400 pixels.
+        thumb_prefix = os.path.join(work_dir, "thumbnail")
+        subprocess.run(
+            [
+                "pdftoppm",
+                "-f", "1",
+                "-l", "1",
+                "-singlefile",
+                "-scale-to", "400",
+                "-jpeg",
+                tmp_input,
+                thumb_prefix,
+            ],
+            check=True,
+            capture_output=True,
+            timeout=120,
+        )
+
+        thumb_path = f"{thumb_prefix}.jpg"
+        thumb_key = f"{output_prefix}/thumbnail.jpg"
+        s3_client.upload_file(
+            thumb_path,
+            bucket,
+            thumb_key,
+            ExtraArgs={"ContentType": "image/jpeg", "CacheControl": "max-age=86400"},
+        )
+        return {"thumbnail_key": thumb_key}
+    finally:
+        os.unlink(tmp_input)
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
 def process_audio(s3_client, bucket: str, input_s3_key: str, output_prefix: str) -> dict:
     """Normalize audio to MP3 + generate waveform JSON.
 


### PR DESCRIPTION
## Summary

- replace the browser PDF iframe with a page-at-a-time PDF.js canvas renderer
- scope drawing and annotation overlays to the rendered page surface
- navigate to a comment’s stored PDF page in authenticated and shared viewers
- discard stale unsent drawings when changing pages or versions
- preserve PDF page numbers through guest identity submission

## Root cause

The annotation canvases were positioned against a viewer-level surface while the browser-owned PDF iframe controlled its own multi-page layout and scrolling. As a result, annotation coordinates were static relative to the app and could overlap multiple PDF pages.

## Validation

- `python -m pytest apps/api/tests/ -v` — 346 passed, 2 skipped
- `pnpm --filter web test` — 346 passed
- `pnpm --filter web exec tsc --noEmit` — passed
- `pnpm --filter web lint` — passed (pre-existing warnings only)
- `pnpm --filter web build` — passed
- manually verified page count, navigation, drawing-layer nesting, and stale-layer cleanup on a two-page PDF