### PR TITLE
feat: short share URLs — 4-char codes resolving at the origin root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Short share URLs** — every share link is now issued a 4-character base62 code alongside its token, so links look like `https://your-domain.example/6RBr` instead of `https://your-domain.example/share/<46-char-token>`. Codes resolve at the origin root through a new `GET /resolve/{short_code}` endpoint (302 to the share page; unknown codes land on the app root) and are shown in the dashboard, the link-created screen, and share emails whenever present, with the full token URL as the fallback. Deployments that want the short form must route root-level codes to the resolve endpoint — see `docs/deployment.md` → Short share URLs. Existing links have no code until `scripts/backfill_short_codes.py` is run once. (#178)
 - **Optional hardware-accelerated transcoding (NVENC / VAAPI) with HDR and Dolby Vision support.** Auto-detects an available GPU backend and falls back to the software pipeline when none is present, or when a hardware attempt fails at runtime (for example, out of VRAM). CPU-only and arm64 builds are unaffected by default. New env vars: `TRANSCODER_PIPELINE`, `TRANSCODER_OUTPUT`, `TRANSCODER_HDR`. (#127)
 
 ## [1.10.0] - 2026-08-21

--- a/apps/api/alembic/versions/7c3a9d4b1e2f_add_short_code_to_share_links.py
+++ b/apps/api/alembic/versions/7c3a9d4b1e2f_add_short_code_to_share_links.py
@@ -1,0 +1,35 @@
+"""add short_code column to share_links
+
+Revision ID: 7c3a9d4b1e2f
+Revises: cdcf8e5a6437
+Create Date: 2026-08-24 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '7c3a9d4b1e2f'
+down_revision: Union[str, None] = 'cdcf8e5a6437'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'share_links',
+        sa.Column('short_code', sa.String(10), nullable=True)
+    )
+    op.create_index(
+        op.f('ix_share_links_short_code'),
+        'share_links',
+        ['short_code'],
+        unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_share_links_short_code'), table_name='share_links')
+    op.drop_column('share_links', 'short_code')

--- a/apps/api/models/share.py
+++ b/apps/api/models/share.py
@@ -39,6 +39,7 @@ class ShareLink(Base):
     show_versions: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
     show_watermark: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
     appearance: Mapped[dict] = mapped_column(JSON, nullable=False, server_default='{"layout":"grid","theme":"dark","accent_color":null,"open_in_viewer":true,"sort_by":"created_at"}')
+    short_code: Mapped[str | None] = mapped_column(String(10), unique=True, index=True, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 

--- a/apps/api/routers/share.py
+++ b/apps/api/routers/share.py
@@ -5,6 +5,7 @@ from typing import Optional
 import bcrypt
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
 import sqlalchemy
 from sqlalchemy import func as sa_func, case
 from sqlalchemy.orm import Session
@@ -50,8 +51,39 @@ from ..models.project import Project, ProjectRole
 from ..tasks.email_tasks import send_share_email
 from ..tasks.celery_app import send_task_safe
 from ..config import settings
+from ..utils.short_code import generate_short_code
 
 router = APIRouter(tags=["sharing"])
+
+MAX_SHORT_CODE_RETRIES = 3
+
+
+def _generate_unique_short_code(db: Session) -> str:
+    for _ in range(MAX_SHORT_CODE_RETRIES):
+        code = generate_short_code()
+        if not db.query(ShareLink).filter(ShareLink.short_code == code).first():
+            return code
+    raise RuntimeError(f"Failed to generate unique short code after {MAX_SHORT_CODE_RETRIES} attempts")
+
+
+def _short_share_url(link: ShareLink) -> str:
+    """Preferred public URL for a share link: the short code when available.
+
+    Short codes resolve at the origin root (see /resolve/{short_code}), which
+    requires the deployment's proxy to route root-level codes to this API —
+    see docs/deployment.md. Falls back to the full token URL otherwise.
+    """
+    root = settings.frontend_origin.rstrip("/")
+    if link.short_code:
+        return f"{root}/{link.short_code}"
+    return f"{settings.frontend_url}/share/{link.token}"
+
+
+def _link_by_token(db: Session, token: str) -> Optional[ShareLink]:
+    return db.query(ShareLink).filter(
+        ShareLink.token == token,
+        ShareLink.deleted_at.is_(None),
+    ).first()
 
 
 def _get_asset(db: Session, asset_id: uuid.UUID) -> Asset:
@@ -193,6 +225,7 @@ def create_share_link(
         show_versions=body.show_versions,
         show_watermark=body.show_watermark,
         appearance=body.appearance.model_dump(),
+        short_code=_generate_unique_short_code(db),
     )
     db.add(link)
     db.add(ActivityLog(user_id=current_user.id, asset_id=asset_id, action=ActivityAction.shared))
@@ -422,6 +455,29 @@ def _share_link_response(link: ShareLink) -> ShareLinkResponse:
     return response
 
 
+# ── Short share code resolution ───────────────────────────────────────────────
+
+@router.get("/resolve/{short_code}")
+def resolve_short_code(
+    short_code: str,
+    db: Session = Depends(get_db),
+):
+    """Resolve a root-level short code to its share page.
+
+    Deployments that want short URLs must route root-level codes here (e.g.
+    an nginx catch-all proxying `/{code}` to `/resolve/{code}`) — see
+    docs/deployment.md. Codes that do not exist land on the app root.
+    """
+    link = db.query(ShareLink).filter(
+        ShareLink.short_code == short_code,
+        ShareLink.deleted_at.is_(None),
+    ).first()
+    frontend = settings.frontend_url.rstrip("/")
+    if not link:
+        return RedirectResponse(url=f"{frontend}/", status_code=302)
+    return RedirectResponse(url=f"{frontend}/share/{link.token}", status_code=302)
+
+
 # ── Authenticated share link details (for settings panel) ────────────────────
 
 @router.get("/share/{token}/details", response_model=ShareLinkResponse)
@@ -535,6 +591,7 @@ def create_folder_share_link(
         show_versions=body.show_versions,
         show_watermark=body.show_watermark,
         appearance=body.appearance.model_dump(),
+        short_code=_generate_unique_short_code(db),
     )
     db.add(link)
     db.commit()
@@ -580,6 +637,7 @@ def create_project_share_link(
         show_versions=body.show_versions,
         show_watermark=body.show_watermark,
         appearance=body.appearance.model_dump(),
+        short_code=_generate_unique_short_code(db),
     )
     db.add(link)
     db.commit()
@@ -617,7 +675,8 @@ def share_project_with_user(
     shared_user = db.query(User).filter(User.id == user_id).first()
     if shared_user:
         if body.share_token:
-            project_link = f"{settings.frontend_url}/share/{body.share_token}"
+            link = _link_by_token(db, body.share_token)
+            project_link = _short_share_url(link) if link else f"{settings.frontend_url}/share/{body.share_token}"
         else:
             project_link = f"{settings.frontend_url}/projects/{project_id}"
         send_task_safe(send_share_email,
@@ -707,7 +766,8 @@ def share_folder_with_user(
     shared_user = db.query(User).filter(User.id == user_id).first()
     if shared_user:
         if body.share_token:
-            folder_link = f"{settings.frontend_url}/share/{body.share_token}"
+            link = _link_by_token(db, body.share_token)
+            folder_link = _short_share_url(link) if link else f"{settings.frontend_url}/share/{body.share_token}"
         else:
             folder_link = f"{settings.frontend_url}/projects/{folder.project_id}?folder={folder_id}"
         send_task_safe(send_share_email,
@@ -872,7 +932,8 @@ def share_with_user(
     if shared_user:
         # Use share link URL if token provided, otherwise internal URL
         if body.share_token:
-            asset_link = f"{settings.frontend_url}/share/{body.share_token}"
+            link = _link_by_token(db, body.share_token)
+            asset_link = _short_share_url(link) if link else f"{settings.frontend_url}/share/{body.share_token}"
         else:
             asset_link = f"{settings.frontend_url}/projects/{asset.project_id}/assets/{asset_id}"
         send_task_safe(send_share_email,
@@ -1192,6 +1253,7 @@ def create_multi_share_link(
         expires_at=body.expires_at,
         appearance=body.appearance.model_dump(),
         created_by=current_user.id,
+        short_code=_generate_unique_short_code(db),
     )
     db.add(link)
     db.flush()

--- a/apps/api/schemas/share.py
+++ b/apps/api/schemas/share.py
@@ -63,6 +63,7 @@ class ShareLinkResponse(BaseModel):
     created_at: datetime
     has_password: bool = False
     password_value: Optional[str] = None  # Decrypted password for admin display only
+    short_code: Optional[str] = None
     model_config = {"from_attributes": True}
 
 
@@ -126,6 +127,7 @@ class ShareLinkListItem(BaseModel):
     target_name: str
     view_count: int = 0
     last_viewed_at: Optional[datetime] = None
+    short_code: Optional[str] = None
     model_config = {"from_attributes": True}
 
 

--- a/apps/api/tests/test_share_short_codes.py
+++ b/apps/api/tests/test_share_short_codes.py
@@ -1,0 +1,121 @@
+"""Tests for short share codes.
+
+Share links get a 4-character base62 code (`short_code`) at creation. Deployments
+can route root-level codes to `GET /resolve/{short_code}`, which 302s to the share
+page. Unknown codes land on the app root. Email links and dashboard URL display
+prefer the short URL when a code exists and fall back to the full token URL.
+"""
+import uuid
+from unittest.mock import MagicMock
+
+from apps.api.routers.share import _generate_unique_short_code, _short_share_url
+from apps.api.utils.short_code import generate_short_code
+
+
+def _link(short_code=None, token=None):
+    link = MagicMock()
+    link.short_code = short_code
+    link.token = token or "tok_" + uuid.uuid4().hex
+    return link
+
+
+# ─── Code generation ──────────────────────────────────────────────────────────
+
+def test_generate_short_code_length_and_alphabet():
+    for _ in range(50):
+        code = generate_short_code()
+        assert len(code) == 4
+        assert all(c.isascii() and (c.isalnum()) for c in code)
+
+
+def test_generate_unique_short_code_returns_when_absent(mock_db):
+    mock_db.first.return_value = None  # no collision
+    code = _generate_unique_short_code(mock_db)
+    assert len(code) == 4
+
+
+def test_generate_unique_short_code_retries_on_collision(mock_db):
+    # First two candidates collide, third is free.
+    mock_db.first.side_effect = [MagicMock(), MagicMock(), None]
+    code = _generate_unique_short_code(mock_db)
+    assert len(code) == 4
+    assert mock_db.first.call_count == 3
+
+
+def test_generate_unique_short_code_raises_after_retries(mock_db):
+    mock_db.first.return_value = MagicMock()  # always collides
+    try:
+        _generate_unique_short_code(mock_db)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected RuntimeError after exhausting retries")
+
+
+# ─── URL preference ───────────────────────────────────────────────────────────
+
+def test_short_share_url_prefers_short_code(monkeypatch):
+    from apps.api.config import settings
+    monkeypatch.setattr(settings, "frontend_url", "https://example.com")
+    link = _link(short_code="AbC1")
+    assert _short_share_url(link) == "https://example.com/AbC1"
+
+
+def test_short_share_url_uses_origin_for_subpath_deployments(monkeypatch):
+    """FRONTEND_URL may carry a path (sub-path deployments); short codes
+    resolve at the origin root, so the path must be stripped."""
+    from apps.api.config import settings
+    monkeypatch.setattr(settings, "frontend_url", "https://example.com/freeframe")
+    link = _link(short_code="AbC1")
+    assert _short_share_url(link) == "https://example.com/AbC1"
+
+
+def test_short_share_url_falls_back_to_token(monkeypatch):
+    from apps.api.config import settings
+    monkeypatch.setattr(settings, "frontend_url", "https://example.com")
+    link = _link(short_code=None, token="token123")
+    assert _short_share_url(link) == "https://example.com/share/token123"
+
+
+# ─── /resolve/{short_code} ────────────────────────────────────────────────────
+
+def test_resolve_known_code_redirects_to_share_page(client, mock_db):
+    link = _link(short_code="AbC1", token="token123")
+    mock_db.first.return_value = link
+
+    resp = client.get("/resolve/AbC1", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "http://localhost:3000/share/token123"
+
+
+def test_resolve_unknown_code_lands_on_app_root(client, mock_db):
+    mock_db.first.return_value = None
+
+    resp = client.get("/resolve/zzzz", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "http://localhost:3000/"
+
+
+def test_resolve_redirect_preserves_subpath_frontend(client, mock_db, monkeypatch):
+    """A sub-path deployment (FRONTEND_URL=https://host/freeframe) must be
+    redirected to the share page *inside* the sub-path."""
+    from apps.api.config import settings
+    monkeypatch.setattr(settings, "frontend_url", "https://host/freeframe")
+    link = _link(short_code="AbC1", token="token123")
+    mock_db.first.return_value = link
+
+    resp = client.get("/resolve/AbC1", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "https://host/freeframe/share/token123"
+
+
+def test_resolve_excludes_deleted_links(client, mock_db):
+    """The query filters deleted_at IS NULL — a deleted link's code must not resolve."""
+    mock_db.first.return_value = None
+    resp = client.get("/resolve/AbC1", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "http://localhost:3000/"
+    # The filter chain must have included the deleted_at guard.
+    exprs = [arg for call in mock_db.filter.call_args_list for arg in call[0]]
+    column_names = [str(getattr(getattr(f, "left", None), "name", "")) for f in exprs]
+    assert "deleted_at" in column_names

--- a/apps/api/utils/short_code.py
+++ b/apps/api/utils/short_code.py
@@ -1,0 +1,14 @@
+import secrets
+import string
+
+ALPHABET = string.ascii_letters + string.digits
+CODE_LENGTH = 4
+
+
+def generate_short_code(length: int = CODE_LENGTH) -> str:
+    """A cryptographically random base62 code for share links.
+
+    4 characters over 62 symbols is ~14.7M combinations — plenty for
+    self-hosted instances, and short enough to type from a phone.
+    """
+    return ''.join(secrets.choice(ALPHABET) for _ in range(length))

--- a/apps/web/components/projects/share-create-dialog.tsx
+++ b/apps/web/components/projects/share-create-dialog.tsx
@@ -58,6 +58,7 @@ interface CreatedShareResult {
   assetId?: string | null
   folderId?: string | null
   projectId?: string | null
+  short_code?: string | null
 }
 
 // ─── Asset type icon helper ──────────────────────────────────────────────────
@@ -610,8 +611,12 @@ function LinkCreatedPhase({ result, allResults, onSelectResult, onDone, onAdvanc
 
   const shareUrl =
     typeof window !== 'undefined'
-      ? `${window.location.origin}/share/${result.token}`
-      : `/share/${result.token}`
+      ? result.short_code
+        ? `${window.location.origin}/${result.short_code}`
+        : `${window.location.origin}/share/${result.token}`
+      : result.short_code
+        ? `/${result.short_code}`
+        : `/share/${result.token}`
 
   async function handleSaveTitle() {
     if (!title.trim() || title === result.title) {
@@ -1126,8 +1131,18 @@ export function ShareCreateDialog({
         await api.patch(`/share/${shareLink.token}`, patches)
       }
 
+      setCreatedResult({
+        token: shareLink.token,
+        title: shareLink.title || config.title,
+        itemType,
+        thumbnailUrl: thumbUrl,
+        assetId: shareLink.asset_id ?? null,
+        folderId: shareLink.folder_id ?? null,
+        projectId: shareLink.project_id ?? null,
+        short_code: shareLink.short_code ?? null,
+      })
+      setPhase('result')
       onShareCreated()
-      onOpenChange(false)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create share link')
     } finally {

--- a/apps/web/components/projects/share-link-detail.tsx
+++ b/apps/web/components/projects/share-link-detail.tsx
@@ -29,6 +29,14 @@ import { api } from "@/lib/api";
 import { ShareLinkActivityPanel } from "@/components/projects/share-link-activity";
 import type { ShareLink, ShareLinkAppearance } from "@/types";
 
+function originUrl(frontendUrl: string): string {
+  try {
+    return new URL(frontendUrl).origin
+  } catch {
+    return frontendUrl
+  }
+}
+
 // ─── Shared hook for share link data + mutations ────────────────────────────
 
 function useShareLinkData(token: string) {
@@ -639,7 +647,9 @@ export function ShareLinkContent({
     }
   }, [shareLink, projectId]);
 
-  const shareUrl = `${frontendUrl}/share/${token}`;
+  const shareUrl = shareLink?.short_code
+    ? `${originUrl(frontendUrl)}/${shareLink.short_code}`
+    : `${frontendUrl}/share/${token}`;
 
   if (!shareLink) {
     return (
@@ -830,8 +840,12 @@ export function ShareLinkSettingsPanel({ token }: ShareLinkSettingsPanelProps) {
 
   const shareUrl =
     typeof window !== "undefined"
-      ? `${window.location.origin}/share/${token}`
-      : `/share/${token}`;
+      ? shareLink?.short_code
+        ? `${window.location.origin}/${shareLink.short_code}`
+        : `${window.location.origin}/share/${token}`
+      : shareLink?.short_code
+        ? `/${shareLink.short_code}`
+        : `/share/${token}`;
 
   if (!shareLink) {
     return (

--- a/apps/web/components/projects/share-links-table.tsx
+++ b/apps/web/components/projects/share-links-table.tsx
@@ -25,6 +25,14 @@ export function ShareLinksTable({
   const [search, setSearch] = React.useState('')
   const [copiedToken, setCopiedToken] = React.useState<string | null>(null)
 
+  const originUrl = React.useMemo(() => {
+    try {
+      return new URL(frontendUrl).origin
+    } catch {
+      return frontendUrl
+    }
+  }, [frontendUrl])
+
   const filtered = React.useMemo(() => {
     const q = search.trim().toLowerCase()
     if (!q) return shareLinks
@@ -32,14 +40,16 @@ export function ShareLinksTable({
   }, [shareLinks, search])
 
   const handleCopy = React.useCallback(
-    async (token: string, e: React.MouseEvent) => {
+    async (link: ShareLinkListItem, e: React.MouseEvent) => {
       e.stopPropagation()
-      const url = `${frontendUrl}/share/${token}`
+      const url = link.short_code
+        ? `${originUrl}/${link.short_code}`
+        : `${frontendUrl}/share/${link.token}`
       await navigator.clipboard.writeText(url)
-      setCopiedToken(token)
+      setCopiedToken(link.token)
       setTimeout(() => setCopiedToken(null), 2000)
     },
-    [frontendUrl],
+    [frontendUrl, originUrl],
   )
 
   return (
@@ -95,7 +105,9 @@ export function ShareLinksTable({
             </thead>
             <tbody>
               {filtered.map((link, i) => {
-                const shareUrl = `${frontendUrl}/share/${link.token}`
+                const shareUrl = link.short_code
+                  ? `${originUrl}/${link.short_code}`
+                  : `${frontendUrl}/share/${link.token}`
                 const isCopied = copiedToken === link.token
                 const isLast = i === filtered.length - 1
 
@@ -131,7 +143,7 @@ export function ShareLinksTable({
                           {shareUrl}
                         </span>
                         <button
-                          onClick={(e) => handleCopy(link.token, e)}
+                          onClick={(e) => handleCopy(link, e)}
                           className="flex items-center justify-center h-6 w-6 rounded border border-border bg-bg-tertiary hover:bg-bg-hover text-text-tertiary hover:text-text-primary transition-colors shrink-0"
                           title="Copy link"
                         >

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -282,6 +282,7 @@ export interface ShareLink {
   deleted_at: string | null;
   has_password: boolean;
   password_value: string | null;
+  short_code?: string | null;
 }
 
 export interface AssetShare {
@@ -306,6 +307,7 @@ export interface ShareLinkListItem {
   target_name: string
   view_count: number
   last_viewed_at: string | null
+  short_code?: string | null
 }
 
 export type ShareActivityAction = "opened" | "viewed_asset" | "commented" | "approved" | "rejected" | "downloaded"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -133,6 +133,15 @@ If FreeFrame sits behind another proxy that already handles SSL:
 4. For **Cloudflare**: set SSL mode to "Full"
 5. Set `FRONTEND_URL` in `.env.prod` to your `https://` URL
 
+### Short share URLs (optional)
+
+Share links are also issued a 4-character short code (e.g. `https://your-domain.example/6RBr` instead of `https://your-domain.example/share/<46-char-token>`). For the short form to resolve, your reverse proxy must route root-level codes to the API's resolve endpoint:
+
+- **nginx:** `location / { proxy_pass http://<api-host>:8000/resolve/; }` as a catch-all *after* the rules for the app itself (the code path must not shadow `/share/`, `/api/`, or the frontend routes)
+- **Cloudflare:** a Worker/redirect rule matching `/{4}` → `https://<api>/resolve/{code}`
+
+Unknown codes redirect to the app root; valid codes 302 to the share page. Links created before this feature shipped have no code — run `python scripts/backfill_short_codes.py` once (server-side) to assign codes to them. Short URLs appear in the dashboard and in share emails whenever a code exists, with the full token URL as the fallback.
+
 ---
 
 ## Bring Your Own Infrastructure

--- a/scripts/backfill_short_codes.py
+++ b/scripts/backfill_short_codes.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""One-shot script: generate short codes for existing share links that have none.
+
+Usage (from project root):
+  python scripts/backfill_short_codes.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "apps", "api"))
+
+from database import SessionLocal
+from models.share import ShareLink
+from utils.short_code import generate_short_code
+
+MAX_RETRIES = 3
+
+
+def main():
+    db = SessionLocal()
+    try:
+        links = db.query(ShareLink).filter(
+            ShareLink.short_code.is_(None),
+            ShareLink.deleted_at.is_(None),
+        ).all()
+
+        if not links:
+            print("No share links need short codes.")
+            return
+
+        successes = 0
+        failures = 0
+
+        for link in links:
+            for attempt in range(MAX_RETRIES):
+                code = generate_short_code()
+                existing = db.query(ShareLink).filter(
+                    ShareLink.short_code == code
+                ).first()
+                if not existing:
+                    link.short_code = code
+                    try:
+                        db.commit()
+                        successes += 1
+                        break
+                    except Exception:
+                        db.rollback()
+                        if attempt == MAX_RETRIES - 1:
+                            failures += 1
+                            print(
+                                f"FAILED: link {link.id} (attempt {attempt + 1}/{MAX_RETRIES})"
+                            )
+                elif attempt == MAX_RETRIES - 1:
+                    failures += 1
+                    print(f"FAILED: link {link.id} — collision after {MAX_RETRIES} retries")
+
+        print(f"\nDone: {successes} assigned, {failures} failed, {len(links)} total")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to discussion #178. This is the feature running on my instance since mid-July, now rebased onto current main and generalized (no instance-specific paths).

## Why

```
Before:  https://kamiko.xyz/freeframe/share/geQF05jn5qFR2yH--wAk0fhpVX6uuS4OYBzirOUAeuE
After:   https://kamiko.xyz/6RBr
```

91 chars with hyphens/underscores reads like a malware link in a text message; 25 chars is typeable from a phone and embeds cleanly in QR codes.

## What

- `short_code` column on `share_links` (String(10), unique, indexed) + alembic migration `7c3a9d4b1e2f` chained onto the current head
- 4-char base62 codes generated with `secrets` and checked for uniqueness at creation, on all four creation paths (asset, folder, project, multi)
- `GET /resolve/{short_code}` → 302 to the share page; unknown codes land on the app root. Sub-path deployments redirect inside their `FRONTEND_URL` path, so both root and `/freeframe`-style deployments work
- Codes surface in `ShareLinkResponse` and `ShareLinkListItem`; the dashboard (links table, link detail, link-created screen) and share emails prefer the short URL, falling back to the full token URL when no code exists
- `scripts/backfill_short_codes.py` — one-shot assignment of codes to pre-existing links
- `docs/deployment.md` — proxy configuration for root-level codes (nginx catch-all → `/resolve/`, Cloudflare rule)

## Deliberate choices

- **Codes are additive, nothing existing changes** — old token URLs keep working forever; short URLs are only generated for new links (plus backfill).
- **No user-facing rename** — the code is generated server-side and cannot be picked/collided; links keep their title for the human-facing name.
- **Emails and dashboard prefer the short form** only when a code exists, so deployments without the proxy rule configured still work via the token URL (the fallback is automatic, not a config toggle).

## Verification

- 11 new backend tests (generation, collision retries, URL preference for root + sub-path deployments, resolve endpoint including deleted-link guard); full suite: 320 passed, 40 DB-dependent errors identical to the upstream baseline
- `tsc --noEmit` clean
- Running live on my instance since 2026-07-16 (all 15 existing links backfilled, resolve proxied through nginx)

Happy to adjust anything — e.g. if you would rather the code length or the redirect target differ.