### PR TITLE
docs: add NLE comment export guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Put two cuts or revisions on screen at once and see exactly what changed. Video 
 
 Export a version's timecoded comments as timeline markers your editor can import — DaVinci Resolve (marker EDL), Final Cut Pro (FCPXML), Premiere Pro (XML), or CSV — so notes land on the exact frame back in the timeline.
 
+See [Export comments to an NLE](docs/comment-export.md) for the export workflow, format choices, and frame-rate troubleshooting.
+
 <p align="center">
   <img src="docs/images/comment-export.png" alt="Export comments menu — DaVinci Resolve (EDL), Final Cut Pro (FCPXML), Premiere Pro (XML), and CSV" width="480">
 </p>
@@ -197,6 +199,7 @@ For the full guide including **SSL setup**, **bring-your-own infrastructure** (e
 |-------|-------------|
 | [Production Deployment](docs/deployment.md) | SSL, bring-your-own infra, scaling, troubleshooting |
 | [Architecture](docs/architecture.md) | System design, data flow, media pipeline, permissions |
+| [Export comments to an NLE](docs/comment-export.md) | Export review notes for Resolve, Final Cut Pro, Premiere Pro, or CSV |
 | [Contributing](docs/contributing.md) | Dev setup, testing, code style, PR process |
 | [Environment Variables](.env.example) | Full config reference with comments |
 

--- a/docs/comment-export.md
+++ b/docs/comment-export.md
@@ -1,0 +1,42 @@
+# Export comments to an NLE
+
+FreeFrame can export a version's timecoded comments as timeline markers for DaVinci Resolve, Final Cut Pro, and Adobe Premiere Pro. It can also export comments as CSV for a spreadsheet or archive.
+
+## Export a version's comments
+
+1. Open the asset and select the version whose comments you want to export.
+2. In the comment panel toolbar, select **Export comments**.
+3. Choose the format for your destination:
+
+   | Destination | FreeFrame export |
+   |-------------|------------------|
+   | DaVinci Resolve | **DaVinci Resolve (EDL)** |
+   | Final Cut Pro | **Final Cut Pro (FCPXML)** |
+   | Adobe Premiere Pro | **Premiere Pro (XML)** |
+   | Spreadsheet or archive | **CSV** |
+
+4. If FreeFrame asks for a frame rate, choose the original frame rate of the uploaded video. Newly uploaded videos normally have this metadata stored and skip the prompt.
+5. Import the downloaded marker file into the matching editing application.
+
+EDL, FCPXML, and Premiere XML exports are available for video assets. Use CSV for image or audio assets.
+
+## Keep markers aligned
+
+- Export comments from the exact version that matches the edit in your timeline.
+- When prompted, use the source video's original frame rate. Choosing a different rate can shift markers away from the reviewed frame.
+- In DaVinci Resolve, keep the timeline start timecode aligned with the exported EDL. FreeFrame uses `01:00:00:00` as the default start timecode.
+- Variable-frame-rate source video can place a marker up to one frame away from the expected position.
+
+## Troubleshooting
+
+### The markers drift over time
+
+Export again and select the video's original frame rate. A frame-rate mismatch causes the marker offset to grow over the duration of the video.
+
+### The markers do not match the current cut
+
+Confirm that the selected FreeFrame version is the same cut loaded in the editing application. Comments are exported relative to the reviewed version.
+
+### An NLE export is not available
+
+The NLE formats are shown only for video assets. Choose CSV when reviewing an image or audio asset.


### PR DESCRIPTION
## Summary

- add a user-facing guide for exporting review comments to DaVinci Resolve, Final Cut Pro, Premiere Pro, or CSV
- document frame-rate alignment guidance and common troubleshooting steps
- link the guide from the README feature section and documentation table

## Validation

- git diff --check
- changed-file relative-link check (0 missing links)

This is a documentation-only change.