### PR TITLE
fix(transcoder): treat an audio-only video container as audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **An audio-only file in a video container now uploads instead of failing to process** — browsers type a `.mpg` or `.mp4` that carries only an audio track as `video/*`, so it was routed to the video pipeline. Every rung of the quality ladder was filtered out against a source height of zero, the "never emit an empty ladder" fallback put one back, and ffmpeg then died on `[v:0] matches no streams`, leaving the upload in `failed` with an error that said nothing about the cause. The transcoder now reports a missing video stream as its own outcome and the asset is re-typed and run through the audio pipeline. (#82)
+
 ## [1.11.0] - 2026-08-29
 
 ### Added

--- a/apps/api/tasks/transcode_tasks.py
+++ b/apps/api/tasks/transcode_tasks.py
@@ -121,6 +121,22 @@ def _process_video(db, asset, version, media_file, s3, output_prefix):
         progress_cb=_on_progress,
     )
     result = _run_async(transcoder.transcode(job))
+
+    if result.no_video_stream:
+        # The browser types a .mpg or .mp4 carrying only audio as video/*, so
+        # mime_to_asset_type routed it here. The file is perfectly good, it just
+        # is not video. Correct the asset and run it through the audio pipeline
+        # rather than failing an upload the user had no reason to think was
+        # wrong (#82).
+        log.info(
+            "asset %s has no video stream; re-routing to the audio pipeline",
+            asset.id,
+        )
+        asset.asset_type = AssetType.audio
+        db.flush()
+        _process_audio(db, asset, version, media_file, s3, output_prefix)
+        return
+
     if not result.success:
         raise RuntimeError(f"Transcode failed: {result.error}")
 

--- a/apps/api/tests/test_audio_only_reroute.py
+++ b/apps/api/tests/test_audio_only_reroute.py
@@ -1,0 +1,71 @@
+"""An audio-only file in a video container must upload successfully (#82).
+
+The browser types a .mpg or .mp4 carrying only an audio track as video/*, so
+`mime_to_asset_type` routes it to the video pipeline. The file is fine; it just
+is not video. It should end up as an audio asset rather than a failed upload.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from apps.api.models.asset import AssetType
+from apps.api.tasks import transcode_tasks
+from packages.transcoder.base import TranscodeResult
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def _stub_transcoder(result: TranscodeResult):
+    """Stub the transcoder and the async bridge together.
+
+    Patching only _run_async leaves the real transcode() coroutine constructed
+    and never awaited, which surfaces as a RuntimeWarning.
+    """
+    with patch("packages.transcoder.ffmpeg_transcoder.FFmpegTranscoder") as cls, \
+         patch.object(transcode_tasks, "_run_async", MagicMock(return_value=result)):
+        cls.return_value.transcode.return_value = None
+        yield
+
+
+def _fixtures():
+    asset = SimpleNamespace(id="asset-1", project_id="proj-1", asset_type=AssetType.video)
+    version = SimpleNamespace(id="ver-1")
+    media_file = SimpleNamespace(
+        s3_key_raw="raw/clip.mpg", s3_key_processed=None,
+        s3_key_thumbnail=None, duration_seconds=None,
+    )
+    return asset, version, media_file, MagicMock()
+
+
+def test_a_video_container_with_no_video_track_becomes_an_audio_asset():
+    asset, version, media_file, db = _fixtures()
+
+    with _stub_transcoder(TranscodeResult(success=False, no_video_stream=True,
+                                          error="No video stream in raw/clip.mpg")), \
+         patch.object(transcode_tasks, "_process_audio") as audio:
+        transcode_tasks._process_video(db, asset, version, media_file, MagicMock(), "processed/x")
+
+    # re-typed, so the viewer renders it with the audio player and the waveform
+    assert asset.asset_type == AssetType.audio
+    # and actually processed, rather than left half-done
+    audio.assert_called_once()
+    assert audio.call_args[0][0] is db
+    assert audio.call_args[0][3] is media_file
+
+
+def test_a_genuine_transcode_failure_still_raises():
+    """no_video_stream must not become a catch-all that swallows real errors."""
+    asset, version, media_file, db = _fixtures()
+
+    with _stub_transcoder(TranscodeResult(success=False, error="ffmpeg exited 1")), \
+         patch.object(transcode_tasks, "_process_audio") as audio:
+        try:
+            transcode_tasks._process_video(db, asset, version, media_file, MagicMock(), "processed/x")
+        except RuntimeError as exc:
+            assert "ffmpeg exited 1" in str(exc)
+        else:
+            raise AssertionError("a failed transcode must raise")
+
+    assert asset.asset_type == AssetType.video   # untouched
+    audio.assert_not_called()

--- a/apps/api/tests/test_ffmpeg_transcoder.py
+++ b/apps/api/tests/test_ffmpeg_transcoder.py
@@ -427,3 +427,46 @@ def test_non_hardware_error_does_not_retry():
 
     assert result.success is False
     assert len(calls) == 1, "content errors must not trigger a software retry"
+
+
+# ── audio-only file in a video container (#82) ────────────────────────────────
+
+def _audio_only_probe(cmd, **_kwargs):
+    """ffprobe -select_streams v:0 on an audio-only container returns no streams.
+
+    That is the whole of the bug: the container's mime is video/*, so the file
+    is routed to the video pipeline, but there is no video track to encode.
+    """
+    mock = MagicMock()
+    mock.returncode = 0
+    mock.stderr = ""
+    mock.stdout = json.dumps({"streams": [], "format": {"duration": "3.0"}})
+    return mock
+
+
+def test_transcode_reports_a_missing_video_stream_instead_of_an_ffmpeg_error():
+    """The browser types .mpg / .mp4 as video/* even with no video track.
+
+    Before this, every ladder rung was filtered out by the source-height check,
+    the "never emit an empty ladder" fallback put one back, and ffmpeg died on
+    `[v:0] matches no streams` -- an error that says nothing about the cause.
+    """
+    t = FFmpegTranscoder.__new__(FFmpegTranscoder)
+    t.s3 = MagicMock()
+    t.bucket = "bucket"
+    t._get_presigned_url = lambda key, expires_in=7200: "http://example.test/in.mpg"
+
+    with patch("subprocess.run", side_effect=_audio_only_probe):
+        result = asyncio.run(t.transcode(_make_job()))
+
+    assert result.success is False
+    assert result.no_video_stream is True
+    assert "No video stream" in (result.error or "")
+
+
+def test_no_video_stream_defaults_false_so_other_backends_need_not_set_it():
+    """The field is additive; a real failure must not look like an audio file."""
+    from packages.transcoder.base import TranscodeResult
+
+    assert TranscodeResult(success=True).no_video_stream is False
+    assert TranscodeResult(success=False, error="boom").no_video_stream is False

--- a/packages/transcoder/base.py
+++ b/packages/transcoder/base.py
@@ -18,6 +18,10 @@ class TranscodeJob:
 @dataclass
 class TranscodeResult:
     success: bool
+    # True when the input carries no video stream at all. Distinct from a plain
+    # failure: the file is fine, it just is not video, so a caller can re-route
+    # it to the audio pipeline instead of surfacing an error.
+    no_video_stream: bool = False
     hls_prefix: Optional[str] = None
     thumbnail_keys: list[str] = field(default_factory=list)
     waveform_key: Optional[str] = None

--- a/packages/transcoder/ffmpeg_transcoder.py
+++ b/packages/transcoder/ffmpeg_transcoder.py
@@ -494,6 +494,19 @@ class FFmpegTranscoder(BaseTranscoder):
             vid_info = self._run(cmd, timeout=120, label="ffprobe")
             vid_data = json.loads(vid_info)
             meta = parse_probe_metadata(vid_data)
+            if meta is None:
+                # No video stream. Every rung of the ladder would be filtered
+                # out, the "never emit an empty ladder" fallback would re-add
+                # one anyway, and ffmpeg would die on `[v:0] matches no
+                # streams` -- an error that says nothing about the real cause.
+                # Report it as its own outcome so the caller can decide; an
+                # audio-only file in a video container is a normal upload, not
+                # a broken one.
+                return TranscodeResult(
+                    success=False,
+                    no_video_stream=True,
+                    error=f"No video stream in {job.input_s3_key}",
+                )
             _vid_stream = (vid_data.get("streams") or [{}])[0]
             # HDR detection: PQ (smpte2084), HLG (arib-std-b67) transfer.
             # DV (profile 5) is handled separately below. (transfer-only per


### PR DESCRIPTION
## Summary

Closes #82, reported by @casinojeffrey in June.

A browser types a `.mpg` or `.mp4` that carries only an audio track as `video/*`. That mime is in `ALLOWED_MIME_TYPES`, so `mime_to_asset_type` routes the file to the video pipeline. `transcode()` probes with `-select_streams v:0`, gets no streams back, and `parse_probe_metadata` returns `None` — but nothing guarded on that. `source_height` became 0, every ladder rung was filtered out against it, the "never emit an empty ladder" fallback put 360p back, and the filtergraph was built and mapped anyway.

ffmpeg then exited 234 on `[v:0] matches no streams`, the version went to `failed` after three retries, and the reporter saw an upload that succeeded and then errored with a message about frame rates.

## Reproduced, before and after

Against a real audio-only mpeg (`ffmpeg -f lavfi -i sine -c:a mp2 -f mpeg`), driving the actual `FFmpegTranscoder.transcode()`:

```
before   success=False   error="ffmpeg exited 234: ... [v:0] matches no streams"
after    success=False   no_video_stream=True   error="No video stream in raw/audio_only.mpg"
```

## Changes

**The transcoder reports it as its own outcome.** `TranscodeResult` gains `no_video_stream`, additive and defaulting to `False`, so other backends need not set it. `transcode()` returns early instead of building a filtergraph it knows has no input.

**The task re-routes.** `_process_video` re-types the asset to `audio` and runs it through the audio pipeline. The file is not broken; it simply is not video, and the person uploading it had no reason to think otherwise. Making it succeed is the fix the issue actually asks for.

A genuine transcode failure still raises, so the new flag cannot become a catch-all that swallows real errors.

## Not mpeg-specific

Despite the report's title, an audio-only `.mp4` takes the same path and was equally broken. The fix keys off the absence of a video stream rather than the container.

## Testing

- [x] Backend tests pass — 340 passing, up from 336, same 40 pre-existing `real_db` errors (no local Postgres)
- [x] Frontend tests + build pass (frontend untouched)
- [x] Tested manually — drove the real transcoder against a real audio-only mpeg, output above

Four new tests: the transcoder reports the missing stream rather than an ffmpeg error, the flag defaults false, the task re-types and re-routes, and a real failure still raises. Mutation-checked — removing the re-route branch fails the re-route test.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`