### PR TITLE
fix(web): stop claiming a sign-in code was sent when it may not have been

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The sign-in code screen no longer claims a code was sent when it may not have been** — entering an address with no account still advanced to the 6-digit step and stated "We sent a 6-digit code to …", so someone who mistyped their email waited for mail that could never arrive. The API answers identically for known and unknown addresses on purpose, to stop it being used to enumerate accounts, so the screen now says only what the server guarantees: if that address has an account, a code is on its way. A typo hint sits next to the input, and "Use a different email" is a real button rather than tertiary text. No response changes, so the anti-enumeration property is untouched. (#248)
 - **An audio-only file in a video container now uploads instead of failing to process** — browsers type a `.mpg` or `.mp4` that carries only an audio track as `video/*`, so it was routed to the video pipeline. Every rung of the quality ladder was filtered out against a source height of zero, the "never emit an empty ladder" fallback put one back, and ffmpeg then died on `[v:0] matches no streams`, leaving the upload in `failed` with an error that said nothing about the cause. The transcoder now reports a missing video stream as its own outcome and the asset is re-typed and run through the audio pipeline. (#82)
 
 ## [1.11.0] - 2026-08-29

--- a/apps/web/components/auth/__tests__/login-form.test.tsx
+++ b/apps/web/components/auth/__tests__/login-form.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push, replace: vi.fn() }) }))
+
+const sendMagicCode = vi.fn()
+vi.mock('@/lib/api', () => ({
+  api: { post: (...args: unknown[]) => sendMagicCode(...args) },
+  ApiError: class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+    }
+  },
+}))
+vi.mock('@/lib/auth', () => ({ setTokens: vi.fn() }))
+
+import { LoginForm } from '../login-form'
+
+/** Walk the email step and land on the code screen for `email`. */
+async function requestCodeFor(email: string) {
+  const view = render(<LoginForm />)
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: email } })
+  fireEvent.click(screen.getByRole('button', { name: /send magic code/i }))
+  await waitFor(() => expect(screen.getByText(/check your email/i)).toBeInTheDocument())
+  return view
+}
+
+describe('LoginForm magic-code step (#248)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // The endpoint answers identically for known and unknown addresses, on
+    // purpose — that is what stops it being used to enumerate accounts.
+    sendMagicCode.mockResolvedValue({})
+  })
+
+  it('does not claim a code was sent, because the API never said one was', async () => {
+    await requestCodeFor('nobody@example.invalid')
+
+    // The old copy asserted a fact the server never promised, stranding anyone
+    // who mistyped their address on a screen waiting for mail that cannot come.
+    expect(screen.queryByText(/we sent a 6-digit code/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/has an account/i)).toBeInTheDocument()
+    expect(screen.getByText('nobody@example.invalid')).toBeInTheDocument()
+  })
+
+  it('offers the one check a person can act on without being told the account exists', async () => {
+    await requestCodeFor('typo@example.invalid')
+    expect(screen.getByText(/check the address for typos/i)).toBeInTheDocument()
+  })
+
+  it('keeps the wording identical for a registered and an unregistered address', async () => {
+    // The whole anti-enumeration property lives here: if these two screens ever
+    // differ, the login form leaks which addresses have accounts.
+    const first = await requestCodeFor('registered@example.test')
+    const registered = screen.getByText(/has an account/i).textContent
+    first.unmount()
+
+    await requestCodeFor('unknown@example.invalid')
+    const unknown = screen.getByText(/has an account/i).textContent
+
+    expect(registered?.replace('registered@example.test', 'X'))
+      .toBe(unknown?.replace('unknown@example.invalid', 'X'))
+  })
+
+  it('lets the user back out to correct the address', async () => {
+    await requestCodeFor('wrong@example.invalid')
+    fireEvent.click(screen.getByRole('button', { name: /use a different email/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /send magic code/i })).toBeInTheDocument(),
+    )
+  })
+})

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -335,9 +335,16 @@ export function LoginForm() {
       <div className="animate-slide-up">
         <div className="mb-8">
           <h1 className="text-xl font-semibold text-text-primary mb-1">Check your email</h1>
+          {/* The API answers identically whether or not the address has an
+              account, deliberately, so that this endpoint cannot be used to
+              enumerate registered emails. Claiming "we sent a code" asserts
+              something it never told us, and for an unknown address it is
+              simply untrue: the person then waits for mail that cannot
+              arrive. Say only what the server guarantees. (#248) */}
           <p className="text-sm text-text-secondary">
-            We sent a 6-digit code to{' '}
+            If{' '}
             <span className="text-text-primary font-medium">{email}</span>
+            {' '}has an account, a 6-digit code is on its way.
           </p>
         </div>
 
@@ -364,8 +371,15 @@ export function LoginForm() {
             ))}
           </div>
 
-          {codeError && (
+          {codeError ? (
             <p className="text-sm text-status-error -mt-3">{codeError}</p>
+          ) : (
+            // A mistyped address is the common case behind "no code arrived",
+            // and it is the one thing the person can check without us telling
+            // them whether the account exists.
+            <p className="text-sm text-text-tertiary -mt-3">
+              Didn&apos;t get a code? Check the address for typos.
+            </p>
           )}
 
           <Button type="submit" size="lg" loading={loading} className="w-full">
@@ -377,7 +391,7 @@ export function LoginForm() {
           <button
             type="button"
             onClick={() => { setStep('email'); setCode(['', '', '', '', '', '']); setCodeError('') }}
-            className="block w-full text-base text-text-tertiary hover:text-text-secondary transition-colors"
+            className="block w-full rounded-md border border-border bg-bg-secondary px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:border-border-focus hover:text-text-primary"
           >
             Use a different email
           </button>


### PR DESCRIPTION
## Summary

Closes #248.

Entering an address with no account still advanced to the 6-digit step and stated **"We sent a 6-digit code to …"**. No code was sent and none ever would be, so someone who mistyped their email waited on a screen for mail that could not arrive. The only way out was styled as tertiary text at the bottom.

## The backend is right and is untouched

`POST /auth/send-magic-code` answers identically whether or not the address has an account, deliberately, so it cannot be used to enumerate registered emails. That came out of the v1.7.x security cycle. The defect was that the UI asserted as fact something the API never told it.

## Changes

- **Say only what the server guarantees.** "If `<address>` has an account, a 6-digit code is on its way."
- **Put the actionable check next to the input.** "Didn't get a code? Check the address for typos." A mistyped address is the common cause, and it is the one thing a person can check without being told whether the account exists.
- **Make the remedy look like one.** "Use a different email" is now a secondary button rather than tertiary text.

Every response stays byte-identical from an attacker's point of view, so the anti-enumeration property is preserved.

## Testing

- [x] Backend tests pass (unchanged, frontend-only)
- [x] Frontend tests + build pass
- [x] Tested manually in browser

Four new tests in `components/auth/__tests__/login-form.test.tsx` (the component had none). One of them asserts the wording is **identical for a registered and an unregistered address**, so a future change cannot reintroduce the leak without failing a test. Mutation-checked: restoring the old "We sent a 6-digit code" copy fails two of them.

Verified in the running dev stack against `nosuchperson@gmail.com`, screenshot on the issue.

Worth noting from that run: `example.invalid` never reaches this screen at all, because the API's email validator rejects reserved TLDs with a clear error on the first step. The bug needs a syntactically valid, unregistered address to reproduce.

## Deliberately not included

The "FreeFrame is invite-only, so ask an admin for an invite" hint raised as an open question on the issue. It leaks nothing about a specific address, but it is a product decision rather than a bug fix, so it should be yours to make.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`