### PR TITLE
refactor(web): extract themed default logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Two consequences worth knowing. Guests who had identified themselves on a single-asset link will be asked once more, because the two paths stored that identity under different keys and the shared one wins. And the single-asset page no longer shows the instance's logo and share name above the player, since the folder path's asset view never did; making both show branding is tracked separately.
 
+### Fixed
+- **Default logos no longer load an invisible second theme asset** — sidebar, authentication, share-password, attribution and branding-preview fallbacks now share one themed icon/full-logo component. A failed custom authentication logo also falls back to the correct built-in mark and retries when branding supplies a new URL. (#288 by @luozejian)
+
 ## [1.12.0] - 2026-08-29
 
 ### Upgrade notes

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -113,10 +113,15 @@
   }
 }
 
+/*
+ * The logo owns its filter. Keeping these rules outside Tailwind's layers and
+ * scoping both themes through data-theme makes them outrank normal utility
+ * classes without resorting to !important.
+ */
+[data-theme="light"] .themed-default-logo { filter: none; }
+[data-theme="dark"] .themed-default-logo { filter: brightness(0) invert(1); }
+
 @layer components {
-  /* The shared logo loads one dark-ink asset; dark surfaces recolor it white. */
-  .themed-default-logo { filter: none; }
-  [data-theme="dark"] .themed-default-logo { filter: brightness(0) invert(1); }
 
   /* Smooth focus ring for interactive elements */
   .focus-ring {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -114,11 +114,9 @@
 }
 
 @layer components {
-  /* Theme-aware logo switching */
-  [data-theme="dark"] .logo-dark { display: block; }
-  [data-theme="dark"] .logo-light { display: none; }
-  [data-theme="light"] .logo-dark { display: none; }
-  [data-theme="light"] .logo-light { display: block; }
+  /* The shared logo loads one dark-ink asset; dark surfaces recolor it white. */
+  .themed-default-logo { filter: none; }
+  [data-theme="dark"] .themed-default-logo { filter: brightness(0) invert(1); }
 
   /* Smooth focus ring for interactive elements */
   .focus-ring {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -114,12 +114,20 @@
 }
 
 /*
- * The logo owns its filter. Keeping these rules outside Tailwind's layers and
- * scoping both themes through data-theme makes them outrank normal utility
- * classes without resorting to !important.
+ * The logo owns its filter. Tailwind v3 flattens the @tailwind directives at build
+ * time and emits no @layer at-rules, so nothing here gains layer priority. What keeps
+ * these ahead of a utility is specificity — two selectors against a utility's one —
+ * plus sitting after the utilities @tailwind emits. That covers bare utilities only:
+ * a variant-prefixed one (hover:, group-hover:, peer-*) is emitted later at equal or
+ * higher specificity and would still win, which is why callers pass sizing and layout
+ * classes only.
+ *
+ * Dark is the unscoped default so it matches :root at the top of this file: a document
+ * that never received a data-theme is painted with the dark palette, and the mark has
+ * to be legible against it.
  */
 [data-theme="light"] .themed-default-logo { filter: none; }
-[data-theme="dark"] .themed-default-logo { filter: brightness(0) invert(1); }
+:root:not([data-theme="light"]) .themed-default-logo { filter: brightness(0) invert(1); }
 
 @layer components {
 

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
 } from 'lucide-react'
 import { withBasePath } from '@/lib/base-path'
+import { resolveBrandingLogo } from '@/lib/branding-logo'
 import { Button } from '@/components/ui/button'
 import { FolderShareViewer } from '@/components/share/folder-share-viewer'
 import { ShareReviewScreen } from '@/components/share/share-review-screen'
@@ -137,7 +138,12 @@ function PasswordGate({ onSubmit, error, loading }: PasswordGateProps) {
   const { orgName, loginLogoUrl, orgLogoLight, orgLogoDark } =
     useBrandingStore()
   const theme = useResolvedTheme()
-  const displayLogo = loginLogoUrl || (theme === 'dark' ? (orgLogoDark ?? orgLogoLight) : (orgLogoLight ?? orgLogoDark)) || undefined
+  const displayLogo = resolveBrandingLogo({
+    theme,
+    darkUrl: orgLogoDark,
+    lightUrl: orgLogoLight,
+    preferredUrl: loginLogoUrl,
+  })
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-bg-primary p-4">

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -15,6 +15,7 @@ import { useBrandingStore } from '@/stores/branding-store'
 import { useShareAppearance } from '@/hooks/use-share-appearance'
 import { useResolvedTheme } from '@/hooks/use-resolved-theme'
 import { PoweredByBadge } from '@/components/shared/powered-by-badge'
+import { ThemedDefaultLogo } from '@/components/shared/themed-default-logo'
 
 import type { Asset, SharePermission, ProjectBranding, ShareLinkAppearance } from '@/types'
 
@@ -146,12 +147,11 @@ function PasswordGate({ onSubmit, error, loading }: PasswordGateProps) {
             // eslint-disable-next-line @next/next/no-img-element
             <img src={displayLogo} alt={orgName} className="h-10 object-contain" />
           ) : (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/logo-icon.png" alt="FreeFrame" className="logo-dark h-10 w-10" />
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/logo-icon-dark.png" alt="" aria-hidden="true" className="logo-light h-10 w-10" />
-            </>
+            <ThemedDefaultLogo
+              variant="icon"
+              alt="FreeFrame"
+              className="h-10 w-10"
+            />
           )}
           <div className="text-center">
             <h1 className="text-sm font-semibold text-text-primary">{orgName}</h1>

--- a/apps/web/components/auth/__tests__/auth-branding-header.test.tsx
+++ b/apps/web/components/auth/__tests__/auth-branding-header.test.tsx
@@ -46,6 +46,24 @@ describe('AuthBrandingHeader logo fallback', () => {
     )
   })
 
+  it('retries a previously failed URL after branding changes away and back', () => {
+    setBranding({ orgName: 'Example Studio', loginLogoUrl: BROKEN_LOGO })
+    render(<AuthBrandingHeader />)
+    fireEvent.error(screen.getByRole('img', { name: 'Example Studio' }))
+
+    act(() => useBrandingStore.setState({ loginLogoUrl: FRESH_LOGO }))
+    expect(screen.getByRole('img', { name: 'Example Studio' })).toHaveAttribute(
+      'src',
+      FRESH_LOGO,
+    )
+
+    act(() => useBrandingStore.setState({ loginLogoUrl: BROKEN_LOGO }))
+    expect(screen.getByRole('img', { name: 'Example Studio' })).toHaveAttribute(
+      'src',
+      BROKEN_LOGO,
+    )
+  })
+
   it('tries a new custom URL after a previous URL failed', () => {
     setBranding({ orgName: 'Example Studio', loginLogoUrl: BROKEN_LOGO })
     render(<AuthBrandingHeader />)

--- a/apps/web/components/auth/__tests__/auth-branding-header.test.tsx
+++ b/apps/web/components/auth/__tests__/auth-branding-header.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { HARDCODED_DEFAULTS, useBrandingStore } from '@/stores/branding-store'
+
+vi.mock('@/hooks/use-resolved-theme', () => ({ useResolvedTheme: () => 'light' }))
+
+import { AuthBrandingHeader } from '../auth-branding-header'
+
+const BROKEN_LOGO = 'https://assets.test/broken-logo.png'
+const FRESH_LOGO = 'https://assets.test/fresh-logo.png'
+
+function setBranding(overrides: Partial<ReturnType<typeof useBrandingStore.getState>> = {}) {
+  useBrandingStore.setState({
+    ...HARDCODED_DEFAULTS,
+    brandingFetchedAt: null,
+    loaded: true,
+    loading: false,
+    ...overrides,
+  })
+}
+
+describe('AuthBrandingHeader logo fallback', () => {
+  beforeEach(() => {
+    setBranding({ orgName: 'Example Studio' })
+  })
+
+  it('renders one themed full fallback when no custom logo exists', () => {
+    const { container } = render(<AuthBrandingHeader />)
+
+    const logo = screen.getByRole('img', { name: 'FreeFrame' })
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+    expect(logo).toHaveAttribute('src', '/logo-full-dark.svg')
+    expect(logo).toHaveClass('themed-default-logo', 'h-12')
+  })
+
+  it('replaces a failed custom logo with the themed fallback', () => {
+    setBranding({ orgName: 'Example Studio', loginLogoUrl: BROKEN_LOGO })
+    const { container } = render(<AuthBrandingHeader />)
+
+    fireEvent.error(screen.getByRole('img', { name: 'Example Studio' }))
+
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+    expect(screen.getByRole('img', { name: 'FreeFrame' })).toHaveAttribute(
+      'src',
+      '/logo-full-dark.svg',
+    )
+  })
+
+  it('tries a new custom URL after a previous URL failed', () => {
+    setBranding({ orgName: 'Example Studio', loginLogoUrl: BROKEN_LOGO })
+    render(<AuthBrandingHeader />)
+    fireEvent.error(screen.getByRole('img', { name: 'Example Studio' }))
+
+    act(() => useBrandingStore.setState({ loginLogoUrl: FRESH_LOGO }))
+
+    expect(screen.getByRole('img', { name: 'Example Studio' })).toHaveAttribute(
+      'src',
+      FRESH_LOGO,
+    )
+    expect(screen.queryByRole('img', { name: 'FreeFrame' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/components/auth/auth-branding-header.tsx
+++ b/apps/web/components/auth/auth-branding-header.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { useBrandingStore } from '@/stores/branding-store'
 import { useResolvedTheme } from '@/hooks/use-resolved-theme'
+import { resolveBrandingLogo } from '@/lib/branding-logo'
 import { ThemedDefaultLogo } from '@/components/shared/themed-default-logo'
 
 /** Brand mark shown above the card on every auth screen (login, setup, invite). */
@@ -10,27 +11,30 @@ export function AuthBrandingHeader() {
   const { orgName, loginLogoUrl, orgLogoLight, orgLogoDark, fetchBranding, loaded } =
     useBrandingStore()
   const theme = useResolvedTheme()
-  const [failedLogo, setFailedLogo] = React.useState<string | null>(null)
+  const [logoErrored, setLogoErrored] = React.useState(false)
 
   React.useEffect(() => {
     if (!loaded) fetchBranding()
   }, [loaded, fetchBranding])
 
-  const displayLogo =
-    loginLogoUrl ||
-    (theme === 'dark' ? (orgLogoDark ?? orgLogoLight) : (orgLogoLight ?? orgLogoDark)) ||
-    undefined
-  const showCustomLogo = displayLogo && displayLogo !== failedLogo
+  const displayLogo = resolveBrandingLogo({
+    theme,
+    darkUrl: orgLogoDark,
+    lightUrl: orgLogoLight,
+    preferredUrl: loginLogoUrl,
+  })
+
+  React.useEffect(() => setLogoErrored(false), [displayLogo])
 
   return (
     <div className="relative mb-8 text-center">
-      {showCustomLogo ? (
+      {displayLogo && !logoErrored ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={displayLogo}
           alt={orgName}
           className="h-12 mx-auto mb-3 object-contain"
-          onError={() => setFailedLogo(displayLogo)}
+          onError={() => setLogoErrored(true)}
         />
       ) : (
         <ThemedDefaultLogo

--- a/apps/web/components/auth/auth-branding-header.tsx
+++ b/apps/web/components/auth/auth-branding-header.tsx
@@ -3,15 +3,14 @@
 import * as React from 'react'
 import { useBrandingStore } from '@/stores/branding-store'
 import { useResolvedTheme } from '@/hooks/use-resolved-theme'
-
-const FALLBACK_LOGO = '/logo-full.svg'
+import { ThemedDefaultLogo } from '@/components/shared/themed-default-logo'
 
 /** Brand mark shown above the card on every auth screen (login, setup, invite). */
 export function AuthBrandingHeader() {
   const { orgName, loginLogoUrl, orgLogoLight, orgLogoDark, fetchBranding, loaded } =
     useBrandingStore()
   const theme = useResolvedTheme()
-  const usedFallback = React.useRef(false)
+  const [failedLogo, setFailedLogo] = React.useState<string | null>(null)
 
   React.useEffect(() => {
     if (!loaded) fetchBranding()
@@ -21,41 +20,24 @@ export function AuthBrandingHeader() {
     loginLogoUrl ||
     (theme === 'dark' ? (orgLogoDark ?? orgLogoLight) : (orgLogoLight ?? orgLogoDark)) ||
     undefined
+  const showCustomLogo = displayLogo && displayLogo !== failedLogo
 
   return (
     <div className="relative mb-8 text-center">
-      {displayLogo ? (
+      {showCustomLogo ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={displayLogo}
           alt={orgName}
           className="h-12 mx-auto mb-3 object-contain"
-          onError={(e) => {
-            // Swap in the default mark once — the DOM reports src as an absolute URL,
-            // so comparing it to the relative path never matches and an unreachable
-            // fallback would retrigger onError forever.
-            if (usedFallback.current) return
-            usedFallback.current = true
-            e.currentTarget.src = FALLBACK_LOGO
-          }}
+          onError={() => setFailedLogo(displayLogo)}
         />
       ) : (
-        // The default lockup is a flat silhouette, so it needs inverting per
-        // theme — same logo-dark/logo-light pair the sidebar uses.
-        <>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={FALLBACK_LOGO}
-            alt="FreeFrame"
-            className="logo-dark h-12 mx-auto mb-3 object-contain"
-          />
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="/logo-full-dark.svg"
-            alt="FreeFrame"
-            className="logo-light h-12 mx-auto mb-3 object-contain"
-          />
-        </>
+        <ThemedDefaultLogo
+          variant="full"
+          alt="FreeFrame"
+          className="h-12 mx-auto mb-3 object-contain"
+        />
       )}
       <h1 className="text-xl font-semibold text-text-primary">{orgName}</h1>
     </div>

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import { useUploadStore } from '@/stores/upload-store'
 import { useNotificationStore } from '@/stores/notification-store'
 import { useBrandingStore } from '@/stores/branding-store'
 import { useResolvedTheme } from '@/hooks/use-resolved-theme'
+import { resolveBrandingLogo } from '@/lib/branding-logo'
 import { Avatar } from '@/components/shared/avatar'
 import { ThemedDefaultLogo } from '@/components/shared/themed-default-logo'
 import { NotificationDrawer } from './notification-drawer'
@@ -53,10 +54,11 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   // so comparing it directly handed a system-light viewer the dark-background
   // logo on a light page.
   const theme = useResolvedTheme()
-  const customLogo =
-    theme === 'light'
-      ? orgLogoLight ?? orgLogoDark
-      : orgLogoDark ?? orgLogoLight
+  const customLogo = resolveBrandingLogo({
+    theme,
+    darkUrl: orgLogoDark,
+    lightUrl: orgLogoLight,
+  })
   const [notifOpen, setNotifOpen] = React.useState(false)
   const activeUploads = uploadFiles.filter((f) => f.status === 'uploading' || f.status === 'pending' || f.status === 'processing').length
   const { data: instance } = useSWR<InstanceSettings>(

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -20,6 +20,7 @@ import { useNotificationStore } from '@/stores/notification-store'
 import { useBrandingStore } from '@/stores/branding-store'
 import { useResolvedTheme } from '@/hooks/use-resolved-theme'
 import { Avatar } from '@/components/shared/avatar'
+import { ThemedDefaultLogo } from '@/components/shared/themed-default-logo'
 import { NotificationDrawer } from './notification-drawer'
 import useSWR from 'swr'
 import { api } from '@/lib/api'
@@ -91,20 +92,11 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
               className="h-7 w-7 shrink-0 object-contain rounded"
             />
           ) : (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={`/logo-icon.png`}
-                alt={orgName}
-                className="h-7 w-7 shrink-0 object-contain logo-dark"
-              />
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={`/logo-icon-dark.png`}
-                alt={orgName}
-                className="h-7 w-7 shrink-0 object-contain logo-light"
-              />
-            </>
+            <ThemedDefaultLogo
+              variant="icon"
+              alt={orgName}
+              className="h-7 w-7 shrink-0 object-contain"
+            />
           )}
           {!collapsed && (
             <span className="text-sm font-semibold text-text-primary tracking-tight truncate">

--- a/apps/web/components/settings/app-shell-mock.tsx
+++ b/apps/web/components/settings/app-shell-mock.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { Layers, Upload, Search, Bell, ChevronsLeft } from 'lucide-react'
 import { PoweredByBadge } from '@/components/shared/powered-by-badge'
+import { ThemedDefaultLogo } from '@/components/shared/themed-default-logo'
 
 /** Authored at a literal desktop size and scaled by the caller, so the internal
  *  proportions are the real app's by construction rather than by hand-matching. */
@@ -46,12 +47,11 @@ export function AppShellMock({ orgName, logoUrl, onLogoError }: MockProps) {
               className="h-7 w-7 shrink-0 rounded object-contain"
             />
           ) : (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/logo-icon.png" alt="" className="logo-dark h-7 w-7 shrink-0 object-contain" />
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/logo-icon-dark.png" alt="" className="logo-light h-7 w-7 shrink-0 object-contain" />
-            </>
+            <ThemedDefaultLogo
+              variant="icon"
+              decorative
+              className="h-7 w-7 shrink-0 object-contain"
+            />
           )}
           <span className="truncate text-sm font-semibold tracking-tight text-text-primary">
             {orgName}
@@ -217,12 +217,11 @@ export function LoginScreenMock({ orgName, logoUrl, onLogoError }: MockProps) {
             className="mx-auto mb-3 h-12 object-contain"
           />
         ) : (
-          <>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/logo-full.svg" alt="" className="logo-dark mx-auto mb-3 h-12 object-contain" />
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/logo-full-dark.svg" alt="" className="logo-light mx-auto mb-3 h-12 object-contain" />
-          </>
+          <ThemedDefaultLogo
+            variant="full"
+            decorative
+            className="mx-auto mb-3 h-12 object-contain"
+          />
         )}
         <h1 className="text-xl font-semibold text-text-primary">{orgName}</h1>
       </div>

--- a/apps/web/components/settings/branding-preview.tsx
+++ b/apps/web/components/settings/branding-preview.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { Eye } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { resolveBrandingLogo } from '@/lib/branding-logo'
 import { useBrandingStore } from '@/stores/branding-store'
 import { useResolvedTheme } from '@/hooks/use-resolved-theme'
 import {
@@ -37,13 +38,18 @@ export function BrandingPreview() {
   const theme = useResolvedTheme()
   const [screen, setScreen] = React.useState<ScreenKey>('app')
 
-  const appLogo =
-    theme === 'light' ? orgLogoLight ?? orgLogoDark : orgLogoDark ?? orgLogoLight
-  // Mirrors AuthBrandingHeader: the dedicated login logo wins on auth screens.
-  const authLogo =
-    loginLogoUrl ||
-    (theme === 'dark' ? orgLogoDark ?? orgLogoLight : orgLogoLight ?? orgLogoDark)
-  const logoUrl = screen === 'login' ? authLogo : appLogo
+  const appLogo = resolveBrandingLogo({
+    theme,
+    darkUrl: orgLogoDark,
+    lightUrl: orgLogoLight,
+  })
+  const authLogo = resolveBrandingLogo({
+    theme,
+    darkUrl: orgLogoDark,
+    lightUrl: orgLogoLight,
+    preferredUrl: loginLogoUrl,
+  })
+  const logoUrl = (screen === 'login' ? authLogo : appLogo) ?? null
 
   // A presigned logo URL that has expired would otherwise leave a broken-image
   // glyph exactly where the brand mark belongs. Fall back to the default icon,

--- a/apps/web/components/shared/__tests__/themed-default-logo.test.tsx
+++ b/apps/web/components/shared/__tests__/themed-default-logo.test.tsx
@@ -25,15 +25,24 @@ describe('ThemedDefaultLogo', () => {
     },
   )
 
-  it('applies the production theme filter despite a later filter class', () => {
-    const globalsCss = readFileSync(join(process.cwd(), 'app/globals.css'), 'utf8')
-    const logoRules = globalsCss.match(
-      /\[data-theme="(?:light|dark)"\]\s+\.themed-default-logo\s*\{[^}]+\}/g,
+  // Pins the two production rules to their theme scoping and to the values that make
+  // the dark-ink asset legible in either theme. It does not prove anything about
+  // beating Tailwind's own output: the generated utilities are not in this document,
+  // and `.filter-none` below is one selector, so it loses on specificity whatever its
+  // position. A variant-prefixed utility would still win, hence the caller contract.
+  it('ships both theme-scoped filter rules and applies them to the logo', () => {
+    // Anchored to this file rather than process.cwd(), which is the launching shell's
+    // directory and not vitest's root.
+    const globalsCss = readFileSync(
+      join(import.meta.dirname, '../../../app/globals.css'),
+      'utf8',
     )
+    const logoRules = globalsCss.match(/^.*\.themed-default-logo\s*\{[^}]*\}$/gm) ?? []
     expect(logoRules).toHaveLength(2)
+    expect(logoRules.every((rule) => rule.includes('data-theme'))).toBe(true)
 
     const style = document.createElement('style')
-    style.textContent = `${logoRules!.join('\n')}\n.filter-none { filter: none; }`
+    style.textContent = `${logoRules.join('\n')}\n.filter-none { filter: none; }`
     document.head.appendChild(style)
 
     try {
@@ -52,15 +61,21 @@ describe('ThemedDefaultLogo', () => {
     }
   })
 
-  it('does not expose style or srcSet overrides', () => {
-    type LogoProps = ComponentProps<typeof ThemedDefaultLogo>
-    type RestrictedPropsStayHidden = [
-      'style' extends keyof LogoProps ? false : true,
-      'srcSet' extends keyof LogoProps ? false : true,
-    ]
+  it('drops style and srcSet even when a caller forces them past the types', () => {
+    const forced = {
+      variant: 'icon',
+      alt: 'FreeFrame',
+      className: 'h-7 w-7',
+      style: { filter: 'none' },
+      srcSet: '/logo-icon.png 2x',
+    } as unknown as ComponentProps<typeof ThemedDefaultLogo>
 
-    const restrictedPropsStayHidden: RestrictedPropsStayHidden = [true, true]
-    expect(restrictedPropsStayHidden).toEqual([true, true])
+    const { container } = render(<ThemedDefaultLogo {...forced} />)
+
+    const logo = container.querySelector('img')!
+    expect(logo.getAttribute('style')).toBeNull()
+    expect(logo.getAttribute('srcset')).toBeNull()
+    expect(logo).toHaveAttribute('src', '/logo-icon-dark.png')
   })
 
   it('uses the full lockup asset and forwards safe native image props', () => {

--- a/apps/web/components/shared/__tests__/themed-default-logo.test.tsx
+++ b/apps/web/components/shared/__tests__/themed-default-logo.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -24,30 +25,45 @@ describe('ThemedDefaultLogo', () => {
     },
   )
 
-  it('applies the production light and dark theme filters', () => {
+  it('applies the production theme filter despite a later filter class', () => {
     const globalsCss = readFileSync(join(process.cwd(), 'app/globals.css'), 'utf8')
     const logoRules = globalsCss.match(
-      /(?:\[data-theme="dark"\]\s+)?\.themed-default-logo\s*\{[^}]+\}/g,
+      /\[data-theme="(?:light|dark)"\]\s+\.themed-default-logo\s*\{[^}]+\}/g,
     )
     expect(logoRules).toHaveLength(2)
 
     const style = document.createElement('style')
-    style.textContent = logoRules!.join('\n')
+    style.textContent = `${logoRules!.join('\n')}\n.filter-none { filter: none; }`
     document.head.appendChild(style)
 
-    const { container } = render(<ThemedDefaultLogo variant="icon" alt="FreeFrame" />)
-    const logo = container.querySelector('img')!
+    try {
+      const { container } = render(
+        <ThemedDefaultLogo variant="icon" alt="FreeFrame" className="filter-none" />,
+      )
+      const logo = container.querySelector('img')!
 
-    document.documentElement.setAttribute('data-theme', 'light')
-    expect(getComputedStyle(logo).filter).toBe('none')
+      document.documentElement.setAttribute('data-theme', 'light')
+      expect(getComputedStyle(logo).filter).toBe('none')
 
-    document.documentElement.setAttribute('data-theme', 'dark')
-    expect(getComputedStyle(logo).filter).toBe('brightness(0) invert(1)')
-
-    style.remove()
+      document.documentElement.setAttribute('data-theme', 'dark')
+      expect(getComputedStyle(logo).filter).toBe('brightness(0) invert(1)')
+    } finally {
+      style.remove()
+    }
   })
 
-  it('uses the full lockup asset and forwards native image props', () => {
+  it('does not expose style or srcSet overrides', () => {
+    type LogoProps = ComponentProps<typeof ThemedDefaultLogo>
+    type RestrictedPropsStayHidden = [
+      'style' extends keyof LogoProps ? false : true,
+      'srcSet' extends keyof LogoProps ? false : true,
+    ]
+
+    const restrictedPropsStayHidden: RestrictedPropsStayHidden = [true, true]
+    expect(restrictedPropsStayHidden).toEqual([true, true])
+  })
+
+  it('uses the full lockup asset and forwards safe native image props', () => {
     render(
       <ThemedDefaultLogo
         variant="full"

--- a/apps/web/components/shared/__tests__/themed-default-logo.test.tsx
+++ b/apps/web/components/shared/__tests__/themed-default-logo.test.tsx
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemedDefaultLogo } from '../themed-default-logo'
+
+describe('ThemedDefaultLogo', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it.each(['light', 'dark'] as const)(
+    'renders one canonical icon asset in the %s theme',
+    (theme) => {
+      document.documentElement.setAttribute('data-theme', theme)
+      const { container } = render(
+        <ThemedDefaultLogo variant="icon" alt="FreeFrame" className="h-7 w-7" />,
+      )
+
+      const images = container.querySelectorAll('img')
+      expect(images).toHaveLength(1)
+      expect(images[0]).toHaveAttribute('src', '/logo-icon-dark.png')
+      expect(images[0]).toHaveClass('themed-default-logo', 'h-7', 'w-7')
+    },
+  )
+
+  it('applies the production light and dark theme filters', () => {
+    const globalsCss = readFileSync(join(process.cwd(), 'app/globals.css'), 'utf8')
+    const logoRules = globalsCss.match(
+      /(?:\[data-theme="dark"\]\s+)?\.themed-default-logo\s*\{[^}]+\}/g,
+    )
+    expect(logoRules).toHaveLength(2)
+
+    const style = document.createElement('style')
+    style.textContent = logoRules!.join('\n')
+    document.head.appendChild(style)
+
+    const { container } = render(<ThemedDefaultLogo variant="icon" alt="FreeFrame" />)
+    const logo = container.querySelector('img')!
+
+    document.documentElement.setAttribute('data-theme', 'light')
+    expect(getComputedStyle(logo).filter).toBe('none')
+
+    document.documentElement.setAttribute('data-theme', 'dark')
+    expect(getComputedStyle(logo).filter).toBe('brightness(0) invert(1)')
+
+    style.remove()
+  })
+
+  it('uses the full lockup asset and forwards native image props', () => {
+    render(
+      <ThemedDefaultLogo
+        variant="full"
+        alt="FreeFrame lockup"
+        className="h-12"
+        data-testid="full-logo"
+        decoding="async"
+      />,
+    )
+
+    const logo = screen.getByRole('img', { name: 'FreeFrame lockup' })
+    expect(logo).toHaveAttribute('src', '/logo-full-dark.svg')
+    expect(logo).toHaveAttribute('decoding', 'async')
+    expect(logo).toHaveClass('themed-default-logo', 'h-12')
+  })
+
+  it('makes decorative marks silent to assistive technology', () => {
+    const { container } = render(
+      <ThemedDefaultLogo variant="icon" decorative className="h-3.5 w-3.5" />,
+    )
+
+    const logo = container.querySelector('img')
+    expect(logo).toHaveAttribute('alt', '')
+    expect(logo).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/components/shared/powered-by-badge.tsx
+++ b/apps/web/components/shared/powered-by-badge.tsx
@@ -11,17 +11,6 @@ interface PoweredByBadgeProps {
   showIcon?: boolean
 }
 
-/** Decorative mark for the adjacent "Powered by FreeFrame" label. */
-function FreeFrameMark() {
-  return (
-    <ThemedDefaultLogo
-      variant="icon"
-      decorative
-      className="h-3.5 w-3.5 shrink-0 object-contain"
-    />
-  )
-}
-
 const FREEFRAME_REPO_URL = 'https://github.com/Techiebutler/freeframe'
 
 export function PoweredByBadge({
@@ -39,7 +28,13 @@ export function PoweredByBadge({
   )
   const content = (
     <>
-      {showIcon && <FreeFrameMark />}
+      {showIcon && (
+        <ThemedDefaultLogo
+          variant="icon"
+          decorative
+          className="h-3.5 w-3.5 shrink-0 object-contain"
+        />
+      )}
       <span>
         Powered by {showOrgName ? orgName || 'FreeFrame' : 'FreeFrame'}
       </span>

--- a/apps/web/components/shared/powered-by-badge.tsx
+++ b/apps/web/components/shared/powered-by-badge.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { useBrandingStore } from '@/stores/branding-store'
 import { cn } from '@/lib/utils'
+import { ThemedDefaultLogo } from '@/components/shared/themed-default-logo'
 
 interface PoweredByBadgeProps {
   className?: string
@@ -10,19 +11,14 @@ interface PoweredByBadgeProps {
   showIcon?: boolean
 }
 
-/** The FreeFrame mark on its own: the same artwork the favicon defaults to
- *  (public/logo-icon.png), with no wordmark, since the line already reads
- *  "Powered by FreeFrame". Two files rather than one because the mark is a flat
- *  silhouette, so it needs inverting per theme — the same logo-dark/logo-light
- *  pair the sidebar uses. */
+/** Decorative mark for the adjacent "Powered by FreeFrame" label. */
 function FreeFrameMark() {
   return (
-    <>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src="/logo-icon.png" alt="" aria-hidden="true" className="logo-dark h-3.5 w-3.5 shrink-0 object-contain" />
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src="/logo-icon-dark.png" alt="" aria-hidden="true" className="logo-light h-3.5 w-3.5 shrink-0 object-contain" />
-    </>
+    <ThemedDefaultLogo
+      variant="icon"
+      decorative
+      className="h-3.5 w-3.5 shrink-0 object-contain"
+    />
   )
 }
 

--- a/apps/web/components/shared/themed-default-logo.tsx
+++ b/apps/web/components/shared/themed-default-logo.tsx
@@ -9,7 +9,7 @@ type LogoAccessibility =
 
 export type ThemedDefaultLogoProps = Omit<
   ComponentPropsWithoutRef<'img'>,
-  'src' | 'alt' | 'aria-hidden'
+  'src' | 'srcSet' | 'alt' | 'aria-hidden' | 'style'
 > & {
   variant: LogoVariant
 } & LogoAccessibility
@@ -22,7 +22,8 @@ const LOGO_SOURCES: Record<LogoVariant, string> = {
 /**
  * The built-in FreeFrame mark, recolored by the root data-theme in globals.css.
  * A single dark-ink asset keeps the markup hydration-safe and avoids fetching a
- * second image that would only be hidden by CSS.
+ * second image that would only be hidden by CSS. `className` is for sizing
+ * and layout only; theme/filter styling is owned by this component.
  */
 export function ThemedDefaultLogo({
   variant,

--- a/apps/web/components/shared/themed-default-logo.tsx
+++ b/apps/web/components/shared/themed-default-logo.tsx
@@ -24,6 +24,10 @@ const LOGO_SOURCES: Record<LogoVariant, string> = {
  * A single dark-ink asset keeps the markup hydration-safe and avoids fetching a
  * second image that would only be hidden by CSS. `className` is for sizing
  * and layout only; theme/filter styling is owned by this component.
+ *
+ * `style` and `srcSet` are omitted from the props type and pinned to undefined
+ * after the spread, so the ownership above holds at runtime too rather than
+ * resting on the caller being typechecked.
  */
 export function ThemedDefaultLogo({
   variant,
@@ -37,6 +41,8 @@ export function ThemedDefaultLogo({
     <img
       {...props}
       src={LOGO_SOURCES[variant]}
+      srcSet={undefined}
+      style={undefined}
       alt={decorative ? '' : alt}
       aria-hidden={decorative || undefined}
       className={cn('themed-default-logo', className)}

--- a/apps/web/components/shared/themed-default-logo.tsx
+++ b/apps/web/components/shared/themed-default-logo.tsx
@@ -1,0 +1,44 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import { cn } from '@/lib/utils'
+
+type LogoVariant = 'icon' | 'full'
+
+type LogoAccessibility =
+  | { decorative: true; alt?: never }
+  | { decorative?: false; alt: string }
+
+export type ThemedDefaultLogoProps = Omit<
+  ComponentPropsWithoutRef<'img'>,
+  'src' | 'alt' | 'aria-hidden'
+> & {
+  variant: LogoVariant
+} & LogoAccessibility
+
+const LOGO_SOURCES: Record<LogoVariant, string> = {
+  icon: '/logo-icon-dark.png',
+  full: '/logo-full-dark.svg',
+}
+
+/**
+ * The built-in FreeFrame mark, recolored by the root data-theme in globals.css.
+ * A single dark-ink asset keeps the markup hydration-safe and avoids fetching a
+ * second image that would only be hidden by CSS.
+ */
+export function ThemedDefaultLogo({
+  variant,
+  decorative = false,
+  alt,
+  className,
+  ...props
+}: ThemedDefaultLogoProps) {
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      {...props}
+      src={LOGO_SOURCES[variant]}
+      alt={decorative ? '' : alt}
+      aria-hidden={decorative || undefined}
+      className={cn('themed-default-logo', className)}
+    />
+  )
+}

--- a/apps/web/lib/__tests__/branding-logo.test.ts
+++ b/apps/web/lib/__tests__/branding-logo.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { resolveBrandingLogo } from '../branding-logo'
+
+const LOGOS = {
+  darkUrl: 'https://assets.test/logo-for-dark-background.png',
+  lightUrl: 'https://assets.test/logo-for-light-background.png',
+}
+
+describe('resolveBrandingLogo', () => {
+  it('prefers a surface-specific logo in either theme', () => {
+    expect(
+      resolveBrandingLogo({
+        theme: 'light',
+        ...LOGOS,
+        preferredUrl: 'https://assets.test/sign-in-logo.png',
+      }),
+    ).toBe('https://assets.test/sign-in-logo.png')
+  })
+
+  it.each([
+    ['dark', LOGOS.darkUrl],
+    ['light', LOGOS.lightUrl],
+  ] as const)('selects the matching configured logo in the %s theme', (theme, expected) => {
+    expect(resolveBrandingLogo({ theme, ...LOGOS })).toBe(expected)
+  })
+
+  it('falls back to the other theme logo when the preferred variant is absent', () => {
+    expect(
+      resolveBrandingLogo({ theme: 'dark', darkUrl: null, lightUrl: LOGOS.lightUrl }),
+    ).toBe(LOGOS.lightUrl)
+    expect(
+      resolveBrandingLogo({ theme: 'light', darkUrl: LOGOS.darkUrl, lightUrl: null }),
+    ).toBe(LOGOS.darkUrl)
+  })
+
+  it('returns undefined when no logo is configured', () => {
+    expect(resolveBrandingLogo({ theme: 'dark', darkUrl: null, lightUrl: null })).toBeUndefined()
+  })
+})

--- a/apps/web/lib/branding-logo.ts
+++ b/apps/web/lib/branding-logo.ts
@@ -1,0 +1,22 @@
+export type ResolvedTheme = 'dark' | 'light'
+
+interface ResolveBrandingLogoOptions {
+  theme: ResolvedTheme
+  darkUrl: string | null | undefined
+  lightUrl: string | null | undefined
+  /** A surface-specific logo, such as the dedicated sign-in mark. */
+  preferredUrl?: string | null
+}
+
+/** Select the configured logo for a resolved theme, with the other variant as fallback. */
+export function resolveBrandingLogo({
+  theme,
+  darkUrl,
+  lightUrl,
+  preferredUrl,
+}: ResolveBrandingLogoOptions): string | undefined {
+  if (preferredUrl) return preferredUrl
+
+  const themedUrl = theme === 'dark' ? darkUrl ?? lightUrl : lightUrl ?? darkUrl
+  return themedUrl || undefined
+}


### PR DESCRIPTION
## Summary
- add a shared `ThemedDefaultLogo` with icon/full variants, meaningful or decorative accessibility modes, and caller sizing classes
- render one canonical asset per logo and theme it through `data-theme` CSS, preserving share-page overrides without loading a hidden second image
- migrate all six duplicated fallback blocks across sidebar, auth, share password gate, powered-by badge, and branding mocks
- use the themed fallback when a custom auth logo fails, while allowing a new logo URL to retry

## Testing
- `pnpm test` — 47 files, 358 tests passed
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm build`

Closes #288
