### PR TITLE
fix(comments): refuse an empty marker export instead of downloading nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Exporting comments to an NLE no longer produces a silently empty marker file** — a version whose comments carry no timecode exported to an EDL with a header and nothing after it. The download succeeded, the file opened, and DaVinci Resolve reported nothing to import, so the cause surfaced three applications away from where it was and looked like a broken export rather than an empty one. The export now refuses, and says which of the three reasons applies: the version has no comments, none of them are attached to a timecode, or the only timecoded ones were resolved and excluded. CSV is unaffected and still carries every comment, which is what the message points at. (#84)
+- **A failed comment export now says so** — every error except the frame-rate prompt went to `console.error`, so an unsupported frame rate, a non-video asset and a version with nothing timecoded all produced a click that did nothing visible. The reason is shown in the comment panel, next to the control that failed. Structured error details from the API are read for their message rather than collapsing to "Export failed".
+
 ### Changed
 - **A share link to a single asset now opens the same review screen as one inside a folder** — the two paths rendered entirely different component trees, so sharing an asset on its own gave a plain video element and a bare comment box, while sharing the same asset inside a folder gave the real review stack. The single-asset path now renders that stack too, which brings it timecode-attached comments, annotation and mention controls, and a version switcher with version-scoped streams and comments. (#117, #123)
 

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -703,6 +703,31 @@ def comment_deep_link(
     return {"url": url}
 
 
+def _no_markers_reason(rows: list, include_resolved: bool) -> str:
+    """Why a marker export has nothing to place on a timeline.
+
+    Three different situations produce the same empty file and need different
+    answers from whoever is looking at it -- most of all the middle one, where
+    the comments are right there on screen and only the timecode is missing.
+    """
+    tops = [r for r in rows if r.parent_id is None]
+    if not tops:
+        return "This version has no comments to export."
+    if not any(r.timecode_start is not None for r in tops):
+        return (
+            "None of this version's comments are attached to a timecode, so there is "
+            "nothing to place on a timeline. A comment carries a timecode when it is "
+            "written with the clock attached in the review screen; a time typed into "
+            "the text is not one. Export as CSV to get the comment text instead."
+        )
+    if not include_resolved:
+        return (
+            "Every timecoded comment in this version is resolved, and this export "
+            "excludes resolved comments."
+        )
+    return "This version has no timecoded comments to export."
+
+
 @router.get("/assets/{asset_id}/comments/export")
 def export_comments(
     asset_id: uuid.UUID,
@@ -810,6 +835,15 @@ def export_comments(
         content = "\ufeff" + comment_export.to_csv(rows, spec)  # BOM for Excel
     else:
         markers = comment_export.build_markers(rows, spec, include_resolved)
+        if not markers:
+            # An empty marker file is the worst answer available here. The
+            # download succeeds, the file opens, and the NLE reports nothing to
+            # import -- so the failure surfaces three applications away from its
+            # cause, and looks like a broken export rather than an empty one.
+            raise HTTPException(status_code=422, detail={
+                "code": "no_timecoded_comments",
+                "message": _no_markers_reason(rows, include_resolved),
+            })
         if format == "edl":
             if len(markers) > comment_export.EDL_MAX_EVENTS:
                 log.warning(

--- a/apps/api/tests/test_comment_export_empty.py
+++ b/apps/api/tests/test_comment_export_empty.py
@@ -1,0 +1,154 @@
+"""An NLE export with nothing to place on a timeline must say so.
+
+Producing a valid but empty marker file is the failure this guards against: the
+download succeeds, the file opens, and the editing application reports nothing
+to import — so the cause surfaces three applications away from where it is, and
+looks like a broken export rather than an empty one.
+"""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.api.models.asset import AssetType, ProcessingStatus
+
+
+def _asset(asset_type=AssetType.video):
+    a = MagicMock()
+    a.id = uuid.uuid4()
+    a.name = "Demo Asset"
+    a.asset_type = asset_type
+    a.deleted_at = None
+    return a
+
+
+def _version(n=1):
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.version_number = n
+    v.processing_status = ProcessingStatus.ready
+    v.deleted_at = None
+    return v
+
+
+def _media(fps=25.0, duration=60.0):
+    m = MagicMock()
+    m.fps = fps
+    m.duration_seconds = duration
+    return m
+
+
+def _comment(body="Fix the logo", tc=None, resolved=False):
+    c = MagicMock()
+    c.id = uuid.uuid4()
+    c.parent_id = None
+    c.author_id = None
+    c.guest_author_id = None
+    c.body = body
+    c.timecode_start = tc
+    c.timecode_end = None
+    c.resolved = resolved
+    c.created_at = datetime(2026, 9, 4, tzinfo=timezone.utc)
+    return c
+
+
+def _export(client, headers, asset, version, fmt="edl", extra=""):
+    return client.get(
+        f"/assets/{asset.id}/comments/export?format={fmt}&version_id={version.id}{extra}",
+        headers=headers,
+    )
+
+
+@pytest.fixture
+def rows(mock_db):
+    """Wire the asset/version/media lookups; the test supplies the comments."""
+    asset, version = _asset(), _version()
+    mock_db.first.side_effect = [asset, version, _media()]
+    mock_db.order_by.return_value = mock_db
+    return asset, version
+
+
+# ------------------------------------------------------------ the three reasons
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_comments_without_a_timecode_are_explained_not_exported(
+    _, client, mock_db, auth_headers, rows
+):
+    """The case that prompted this: a reviewer typed the times into the text.
+
+    A share link without a timecode control leaves every comment at
+    timecode_start = NULL, so the version looks full of timed notes and exports
+    to a header and nothing else.
+    """
+    asset, version = rows
+    mock_db.all.side_effect = [[_comment("30:20 audio cuts out"), _comment("34:37 odd cut")]]
+
+    r = _export(client, auth_headers, asset, version)
+
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert detail["code"] == "no_timecoded_comments"
+    # Names the cause and the way out, because the comments are visibly there.
+    assert detail["message"].startswith("None of this version's comments are attached")
+    assert "CSV" in detail["message"]
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_a_version_with_no_comments_says_that_instead(
+    _, client, mock_db, auth_headers, rows
+):
+    asset, version = rows
+    mock_db.all.side_effect = [[]]
+
+    r = _export(client, auth_headers, asset, version)
+
+    assert r.status_code == 422
+    assert r.json()["detail"]["message"] == "This version has no comments to export."
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_excluding_resolved_comments_says_so_rather_than_reporting_none(
+    _, client, mock_db, auth_headers, rows
+):
+    # The timecodes are there; the filter is what emptied the export. Telling
+    # this apart from "nothing is timecoded" is the whole point of the message.
+    asset, version = rows
+    mock_db.all.side_effect = [[_comment(tc=12.0, resolved=True)]]
+
+    r = _export(client, auth_headers, asset, version, extra="&include_resolved=false")
+
+    assert r.status_code == 422
+    assert "resolved" in r.json()["detail"]["message"]
+
+
+# --------------------------------------------------------------- non-regression
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_one_timecoded_comment_is_still_exported(_, client, mock_db, auth_headers, rows):
+    """The guard must refuse empty exports, not thin ones."""
+    asset, version = rows
+    mock_db.all.side_effect = [[_comment("Fix the logo", tc=2.52)]]
+
+    r = _export(client, auth_headers, asset, version)
+
+    assert r.status_code == 200
+    assert "|M:Unknown: Fix the logo" in r.text
+
+
+@patch("apps.api.routers.comments.require_asset_access")
+def test_csv_still_exports_comments_that_have_no_timecode(
+    _, client, mock_db, auth_headers, rows
+):
+    """CSV carries every comment, timecoded or not, and must not be blocked.
+
+    It is the fallback the message above points at, so refusing it here would
+    send the user in a circle.
+    """
+    asset, version = rows
+    mock_db.all.side_effect = [[_comment("30:20 audio cuts out")]]
+
+    r = _export(client, auth_headers, asset, version, fmt="csv")
+
+    assert r.status_code == 200
+    assert "30:20 audio cuts out" in r.text

--- a/apps/web/components/review/__tests__/comment-panel-export-error.test.tsx
+++ b/apps/web/components/review/__tests__/comment-panel-export-error.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// vi.hoisted, because vi.mock is lifted above the imports and its factory may
+// not reach a plain top-level binding.
+const { exportComments, FakeFpsRequiredError } = vi.hoisted(() => {
+  class FakeFpsRequiredError extends Error {}
+  return { exportComments: vi.fn(), FakeFpsRequiredError }
+})
+
+vi.mock('@/lib/export-comments', () => ({
+  exportComments,
+  FpsRequiredError: FakeFpsRequiredError,
+}))
+
+import { useReviewStore } from '@/stores/review-store'
+import { CommentPanel } from '../comment-panel'
+
+const noop = async () => {}
+
+const comment = {
+  id: 'c1', asset_id: 'a1', version_id: 'v1', parent_id: null,
+  author: { id: 'u1', name: 'Maya Chen', avatar_url: null },
+  body: '30:20 audio cuts out', timecode_start: null, timecode_end: null,
+  resolved: false, visibility: 'public',
+  created_at: '2026-09-04T10:00:00.000Z', updated_at: '2026-09-04T10:00:00.000Z',
+  replies: [], reactions: [], attachments: [],
+} as never
+
+beforeEach(() => {
+  useReviewStore.getState().reset()
+  useReviewStore.getState().setCurrentAsset({ id: 'a1', asset_type: 'video' } as never)
+  useReviewStore.getState().setCurrentVersion({ id: 'v1' } as never)
+  Element.prototype.scrollIntoView = vi.fn()
+  exportComments.mockReset()
+})
+
+function renderPanel() {
+  return render(
+    <CommentPanel
+      comments={[comment]}
+      onResolve={noop} onDelete={noop}
+      onAddReaction={noop} onRemoveReaction={noop}
+      onReply={() => {}}
+    />,
+  )
+}
+
+function chooseExport(label: string) {
+  fireEvent.click(screen.getByTitle('Export comments'))
+  fireEvent.click(screen.getByText(label))
+}
+
+describe('a failed comment export', () => {
+  it('shows the reason in the panel instead of the console', async () => {
+    // The failure this exists for: a version whose comments carry their times
+    // in the text rather than as a timecode exports to an empty marker file, so
+    // the server refuses and explains. Sending that to console.error left the
+    // click looking like it had done nothing at all.
+    exportComments.mockRejectedValue(
+      new Error("None of this version's comments are attached to a timecode."),
+    )
+    renderPanel()
+
+    chooseExport('DaVinci Resolve (EDL)')
+
+    expect(
+      await screen.findByText("None of this version's comments are attached to a timecode."),
+    ).toBeTruthy()
+  })
+
+  it('says something even when the error carries no message', async () => {
+    exportComments.mockRejectedValue(new Error(''))
+    renderPanel()
+
+    chooseExport('CSV')
+
+    expect(await screen.findByText('Export failed')).toBeTruthy()
+  })
+
+  it('leaves the frame-rate case to its prompt rather than the message line', async () => {
+    // That one is answerable: the user picks a rate and the export retries. It
+    // must not also leave an error sitting in the panel.
+    exportComments.mockRejectedValue(new FakeFpsRequiredError())
+    renderPanel()
+
+    chooseExport('DaVinci Resolve (EDL)')
+
+    await waitFor(() => expect(exportComments).toHaveBeenCalled())
+    expect(screen.queryByText(/Export failed/)).toBeNull()
+  })
+
+  it('clears a previous failure when the next export is attempted', async () => {
+    exportComments.mockRejectedValueOnce(new Error('Unsupported frame rate 12'))
+    renderPanel()
+    chooseExport('CSV')
+    expect(await screen.findByText('Unsupported frame rate 12')).toBeTruthy()
+
+    exportComments.mockResolvedValueOnce(undefined)
+    chooseExport('CSV')
+
+    await waitFor(() =>
+      expect(screen.queryByText('Unsupported frame rate 12')).toBeNull(),
+    )
+  })
+})

--- a/apps/web/components/review/comment-panel.tsx
+++ b/apps/web/components/review/comment-panel.tsx
@@ -799,6 +799,7 @@ export function CommentPanel({
   const [filters, setFilters] = React.useState<FilterState>(EMPTY_FILTERS);
   const [replyingTo, setReplyingTo] = React.useState<string | null>(null);
   const [exportOpen, setExportOpen] = React.useState(false);
+  const [exportError, setExportError] = React.useState<string | null>(null);
   const [fpsPromptFormat, setFpsPromptFormat] =
     React.useState<ExportFormat | null>(null);
 
@@ -907,6 +908,7 @@ export function CommentPanel({
 
   async function handleExport(format: ExportFormat, fps?: number) {
     setExportOpen(false);
+    setExportError(null);
     const versionId = exportVersionId ?? currentVersion?.id;
     if (!currentAsset || !versionId) return;
     try {
@@ -920,7 +922,18 @@ export function CommentPanel({
       if (err instanceof FpsRequiredError) {
         setFpsPromptFormat(format);
       } else {
-        console.error(err);
+        // Every other export failure used to go to the console, where nobody
+        // looks: an unsupported frame rate, a non-video asset and a version with
+        // nothing timecoded all produced a click that did nothing at all. Shown
+        // in the panel rather than as a toast, next to the control that failed
+        // and alongside the fps prompt, which is where this component already
+        // answers for this button.
+        // `err.message` and not `err instanceof Error` alone: an Error with an
+        // empty message is falsy, and the line below renders on truthiness --
+        // so the branch meant to explain the failure would show nothing at all.
+        setExportError(
+          (err instanceof Error && err.message) || "Export failed",
+        );
       }
     }
   }
@@ -1230,6 +1243,12 @@ export function CommentPanel({
           </div>
         </div>
       </div>
+
+      {exportError && (
+        <div className="px-4 pb-2 shrink-0">
+          <p className="text-[11px] text-status-error">{exportError}</p>
+        </div>
+      )}
 
       {/* ─── Search bar ───────────────────────────────────────────── */}
       {searchOpen && (

--- a/apps/web/lib/__tests__/export-comments.test.ts
+++ b/apps/web/lib/__tests__/export-comments.test.ts
@@ -143,3 +143,37 @@ describe('exportComments', () => {
     vi.advanceTimersByTime(1000)
   })
 })
+
+describe('a 422 carrying a structured detail', () => {
+  it('surfaces the explanation instead of a bare "Export failed"', async () => {
+    // The endpoint answers an export with nothing to place on a timeline with
+    // {code, message}. Reading only the string form of `detail` reduced every
+    // one of those to "Export failed", which says no more than silence did.
+    mockFetch(422, {
+      detail: {
+        code: 'no_timecoded_comments',
+        message: "None of this version's comments are attached to a timecode.",
+      },
+    })
+
+    await expect(
+      exportComments({ assetId: 'a', versionId: 'v', format: 'edl' }),
+    ).rejects.toThrow("None of this version's comments are attached to a timecode.")
+  })
+
+  it('still raises FpsRequiredError for the one code with its own prompt', async () => {
+    mockFetch(422, { detail: { code: 'fps_required', message: 'Frame rate unknown' } })
+
+    await expect(
+      exportComments({ assetId: 'a', versionId: 'v', format: 'edl' }),
+    ).rejects.toBeInstanceOf(FpsRequiredError)
+  })
+
+  it('falls back when the detail carries no message at all', async () => {
+    mockFetch(422, { detail: { code: 'something_new' } })
+
+    await expect(
+      exportComments({ assetId: 'a', versionId: 'v', format: 'edl' }),
+    ).rejects.toThrow('Export failed')
+  })
+})

--- a/apps/web/lib/export-comments.ts
+++ b/apps/web/lib/export-comments.ts
@@ -35,8 +35,14 @@ export async function exportComments(opts: {
 
   if (res.status === 422) {
     const body = await res.json().catch(() => null)
-    if (body?.detail?.code === 'fps_required') throw new FpsRequiredError()
-    throw new Error(typeof body?.detail === 'string' ? body.detail : 'Export failed')
+    const detail = body?.detail
+    if (detail?.code === 'fps_required') throw new FpsRequiredError()
+    // A structured detail carries the explanation in `message`. Reading only the
+    // string form turned every one of those into a bare "Export failed", which
+    // is the same amount of information as saying nothing.
+    throw new Error(
+      typeof detail === 'string' ? detail : detail?.message || 'Export failed',
+    )
   }
   if (!res.ok) throw new Error(`Export failed (${res.status})`)
 


### PR DESCRIPTION
## Summary

Exporting a version's comments to an NLE produced a valid file with no events
when none of the comments carried a timecode:

```
TITLE: 255 ClausHartmann 1.2
FCM: DROP FRAME
```

The download succeeds, DaVinci Resolve imports it and reports nothing, and the
cause surfaces three applications away from where it is — looking like a broken
export rather than an empty one. Finding it took opening the file in a text
editor.

How it happened here, on a real instance: a reviewer commented through a
single-asset share link, which on that release rendered a plain textarea with no
timecode control, so all seven comments arrived with `timecode_start` NULL and
the times typed into the body (`"30:20 audio cuts out"`). #307 has since fixed
that side of it. This is the other half — that the export said nothing about it.

`build_markers` is right to skip comments with no timecode. The mistake is
serialising the empty result and calling it a download.

## Changes

- An NLE export that would contain no markers answers **422** with a coded
  detail, matching the `fps_required` path already in this handler.

- The message distinguishes the three situations that produce the same empty
  file, because they need different answers:

  - the version has no comments at all
  - it has comments, but none are attached to a timecode
  - the timecoded ones are all resolved, and this export excluded them

  The middle one is the case above and the one worth wording carefully: the
  comments are visibly on screen, so "no comments to export" would read as a
  lie. It names what a timecode is — a time typed into the text is not one —
  and points at CSV.

- **CSV is deliberately not blocked.** It carries every comment, timecoded or
  not, and it is what the message recommends; refusing it there would send the
  user in a circle. There is a test for that.

- In the client, every export error other than the fps prompt went to
  `console.error`. An unsupported frame rate, a non-video asset and now this all
  produced a click that did nothing visible. The reason is shown in the comment
  panel, beside the control that failed and alongside the fps prompt, which is
  where this component already answers for that button.

- `exportComments` read only the string form of `detail`, so every structured
  error collapsed to `"Export failed"`. It now reads `message`.

## Why the panel and not a toast

There is a `ToastProvider` in the root layout, and a toast was the first thing I
wrote. It made every existing test that renders `CommentPanel` fail, because
`useToast` throws without a provider and those tests have no reason to have one
— 44 tests across three files, plus the same trap for anyone adding a test
later. The panel already renders its own answer for this button (the fps
prompt), so the message goes next to it. Happy to switch it if you would rather
the app spoke with one voice here.

## Testing

- [x] Backend tests pass — 407 passed, 5 new in
      `apps/api/tests/test_comment_export_empty.py`, including the one that
      keeps CSV working when nothing is timecoded.
- [x] Frontend tests + build pass — 372 passed, 7 new across
      `lib/__tests__/export-comments.test.ts` and
      `components/review/__tests__/comment-panel-export-error.test.tsx`,
      `tsc --noEmit` clean.
- [x] Tested manually in browser — this started as a real export on our own
      instance, which is where the empty file came from.

One of the new tests caught a bug while being written: an `Error` with an empty
message left the panel rendering nothing, because the line is shown on
truthiness.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]` — two `Fixed` entries.