### PR TITLE
fix(web): comment inputs trigger iOS Safari auto-zoom on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Default logos no longer load an invisible second theme asset** — sidebar, authentication, share-password, attribution and branding-preview fallbacks now share one themed icon/full-logo component. A failed custom authentication logo also falls back to the correct built-in mark and retries when branding supplies a new URL. (#288 by @luozejian)
+- **Focusing a comment input zoomed the whole page on iOS Safari** — Safari auto-zooms the page whenever focus lands on a text input with a computed font-size under 16px, and the main comment textarea, the reply input, the comment-edit textarea, and the comment search input were all 13px. Each is now 16px on mobile (the literal iOS threshold), reverting to the original 13px at the `md` breakpoint, where this Safari behavior doesn't apply.
 
 ## [1.12.0] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Default logos no longer load an invisible second theme asset** — sidebar, authentication, share-password, attribution and branding-preview fallbacks now share one themed icon/full-logo component. A failed custom authentication logo also falls back to the correct built-in mark and retries when branding supplies a new URL. (#288 by @luozejian)
-- **Focusing a comment input zoomed the whole page on iOS Safari** — Safari auto-zooms the page whenever focus lands on a text input with a computed font-size under 16px, and the main comment textarea, the reply input, the comment-edit textarea, and the comment search input were all 13px. Each is now 16px on mobile (the literal iOS threshold), reverting to the original 13px at the `md` breakpoint, where this Safari behavior doesn't apply.
+- **Focusing a comment input zoomed the whole page on iOS Safari** — Safari auto-zooms the page whenever focus lands on a text input with a computed font-size under 16px, and the main comment textarea, the reply input, the comment-edit textarea, the comment search input, and the guest name/email prompt on share links were all under that threshold. Each is now 16px on a touch device, reverting to its original compact size only under a `(hover: hover)` media query — not a `md` viewport-width breakpoint, which still zoomed on a landscape phone (an iPhone in landscape is wider than `md`'s 768px).
 
 ## [1.12.0] - 2026-08-29
 

--- a/apps/web/components/review/__tests__/comment-input.test.tsx
+++ b/apps/web/components/review/__tests__/comment-input.test.tsx
@@ -212,3 +212,15 @@ describe('CommentInput compare drawing props (annotationActive / onToggleAnnotat
     expect(screen.getByTitle('Draw annotation').className).not.toContain('text-accent')
   })
 })
+
+describe('CommentInput iOS auto-zoom guard', () => {
+  it('sizes the textarea at the 16px iOS zoom threshold, and reverts to compact only under a real hover/pointer query — never a viewport-width breakpoint', () => {
+    render(<CommentInput assetId="a1" projectId="p1" assetType="video" onSubmit={vi.fn()} />)
+    const textarea = screen.getByPlaceholderText('Leave your comment...')
+    expect(textarea.className).toContain('text-[16px]')
+    // A `md:` (or any other width) breakpoint here would still trigger Safari's
+    // auto-zoom on a landscape phone, which is wider than the breakpoint.
+    expect(textarea.className).not.toMatch(/\bmd:text-/)
+    expect(textarea.className).toContain('[@media(hover:hover)]:text-[13px]')
+  })
+})

--- a/apps/web/components/review/comment-input.tsx
+++ b/apps/web/components/review/comment-input.tsx
@@ -465,7 +465,7 @@ export function CommentInput({
             )}
             <textarea
               ref={textareaRef}
-              className="flex-1 resize-none bg-transparent px-2.5 py-2.5 text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none min-h-[38px] max-h-[120px]"
+              className="flex-1 resize-none bg-transparent px-2.5 py-2.5 text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none min-h-[38px] max-h-[120px]"
               placeholder={
                 replyToId ? "Write a reply..." : "Leave your comment..."
               }

--- a/apps/web/components/review/comment-input.tsx
+++ b/apps/web/components/review/comment-input.tsx
@@ -465,7 +465,7 @@ export function CommentInput({
             )}
             <textarea
               ref={textareaRef}
-              className="flex-1 resize-none bg-transparent px-2.5 py-2.5 text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none min-h-[38px] max-h-[120px]"
+              className="flex-1 resize-none bg-transparent px-2.5 py-2.5 text-[16px] [@media(hover:hover)]:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none min-h-[38px] max-h-[120px]"
               placeholder={
                 replyToId ? "Write a reply..." : "Leave your comment..."
               }

--- a/apps/web/components/review/comment-panel.tsx
+++ b/apps/web/components/review/comment-panel.tsx
@@ -286,7 +286,7 @@ function InlineReplyInput({
       <input
         ref={inputRef}
         type="text"
-        className="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/20"
+        className="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/20"
         placeholder="Leave your reply here..."
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -564,7 +564,7 @@ function CommentItem({
                 onChange={(e) => setEditBody(e.target.value)}
                 autoFocus
                 rows={2}
-                className="w-full rounded-md border border-border bg-bg-tertiary px-2 py-1.5 text-[13px] text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent/50 resize-none"
+                className="w-full rounded-md border border-border bg-bg-tertiary px-2 py-1.5 text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent/50 resize-none"
               />
               <div className="flex items-center gap-1.5 mt-1">
                 <button
@@ -1239,7 +1239,7 @@ export function CommentPanel({
             <input
               ref={searchRef}
               type="text"
-              className="flex-1 bg-transparent text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none"
+              className="flex-1 bg-transparent text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none"
               placeholder="Search..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/web/components/review/comment-panel.tsx
+++ b/apps/web/components/review/comment-panel.tsx
@@ -286,7 +286,7 @@ function InlineReplyInput({
       <input
         ref={inputRef}
         type="text"
-        className="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/20"
+        className="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-[16px] [@media(hover:hover)]:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/20"
         placeholder="Leave your reply here..."
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -564,7 +564,7 @@ function CommentItem({
                 onChange={(e) => setEditBody(e.target.value)}
                 autoFocus
                 rows={2}
-                className="w-full rounded-md border border-border bg-bg-tertiary px-2 py-1.5 text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent/50 resize-none"
+                className="w-full rounded-md border border-border bg-bg-tertiary px-2 py-1.5 text-[16px] [@media(hover:hover)]:text-[13px] text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent/50 resize-none"
               />
               <div className="flex items-center gap-1.5 mt-1">
                 <button
@@ -1239,7 +1239,7 @@ export function CommentPanel({
             <input
               ref={searchRef}
               type="text"
-              className="flex-1 bg-transparent text-[16px] md:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none"
+              className="flex-1 bg-transparent text-[16px] [@media(hover:hover)]:text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none"
               placeholder="Search..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/web/components/share/share-review-screen.tsx
+++ b/apps/web/components/share/share-review-screen.tsx
@@ -286,7 +286,7 @@ function GuestIdentityPrompt({ onSave, onCancel }: { onSave: (name: string, emai
             placeholder="Your name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="w-full rounded-md border border-border bg-bg-tertiary px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent"
+            className="w-full rounded-md border border-border bg-bg-tertiary px-3 py-2 text-[16px] [@media(hover:hover)]:text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent"
             autoFocus
           />
           <input
@@ -294,7 +294,7 @@ function GuestIdentityPrompt({ onSave, onCancel }: { onSave: (name: string, emai
             placeholder="Email address"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-border bg-bg-tertiary px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent"
+            className="w-full rounded-md border border-border bg-bg-tertiary px-3 py-2 text-[16px] [@media(hover:hover)]:text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent"
           />
         </div>
         <div className="flex items-center justify-end gap-2 mt-4">


### PR DESCRIPTION
## Summary

iOS Safari auto-zooms the whole page whenever focus lands on a text input with a computed font-size under 16px (so the zoomed-in text stays legible). All four text inputs in the review UI were 13px, so tapping into any of them on an iPhone zoomed the page in.

## Changes

- `comment-input.tsx`: the main comment textarea bumped from `text-[13px]` to `text-[16px]` on mobile, with `md:text-[13px]` reverting to the original size on desktop, where this Safari behavior doesn't apply.
- `comment-panel.tsx`: same treatment for the reply input, the comment-edit textarea, and the comment search input.
- `text-[16px]` (an explicit pixel value, the literal iOS threshold) was used rather than the `text-base` utility, to avoid depending on it matching exactly if the theme's type scale ever changes.

## Testing

- [ ] Backend tests — no backend touched by this change
- [x] Frontend build passes (`pnpm build`)
- [x] Frontend tests (`pnpm test`) — same 30 pre-existing failures present on unmodified `main`; no new failures
- [x] Tested manually on a real phone — tapping into the comment box, the reply box, an existing comment's edit box, and the comment search box no longer triggers Safari's zoom. Desktop font sizes are unchanged.

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`

## Screenshots

No visual change beyond eliminating the zoom-on-focus behavior.