### PR TITLE
feat: optionally require a link in every project description

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,3 +148,9 @@ STUCK_PROCESSING_TIMEOUT_HOURS=6 # Re-dispatch a transcode for versions stuck at
 SOFT_DELETE_RETENTION_DAYS=30  # Hard-delete rows soft-deleted longer than N days (cascade + S3 reclaim); 0 = disabled
 ORPHAN_SWEEP_GRACE_HOURS=0    # S3 orphan sweeper: reclaim raw/+processed/ keys with no DB row; 0 = disabled; >0 = only keys older than N hours
 ORPHAN_SWEEP_DELETE=false     # false = report-only (log only); true = actually delete orphans
+
+# Require a link in every project description (off by default).
+# A regex matched against the description on create and update; the hint is what the user is told
+# when it does not match. Useful when an automation needs to find the brief a project came from.
+# REQUIRE_PROJECT_DESCRIPTION_PATTERN=trello\.com/c/
+# REQUIRE_PROJECT_DESCRIPTION_HINT=Paste the Trello card link for this project.

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -66,6 +66,22 @@ class Settings(BaseSettings):
     # smallest rung at the source's own size.
     transcoder_qualities: str = "1080p,720p,360p"
 
+    # Require every project's description to carry something - typically a link to the brief in
+    # whatever tool the team plans in (Trello, Notion, Asana, a ticket).
+    #
+    # A regex, matched against the description on create and update. Empty (the default) is off
+    # and nothing changes. The hint is what the user is told when it does not match: say what to
+    # paste, because "description is invalid" sends people looking for a formatting rule.
+    #
+    #   REQUIRE_PROJECT_DESCRIPTION_PATTERN=trello\.com/c/
+    #   REQUIRE_PROJECT_DESCRIPTION_HINT=Paste the Trello card link for this project.
+    #
+    # Why an instance would want this: anything reading projects over the API - an automation, a
+    # reporting job, a review bot - has no way back to the brief a project was made from unless
+    # somebody wrote it down, and asking after the fact never works.
+    require_project_description_pattern: str = ""
+    require_project_description_hint: str = ""
+
     # Maximum size (bytes) for a single uploaded file. 0 = unlimited (no per-file cap).
     # Note: S3 multipart still caps effective size at ~10,000 parts x chunk size.
     max_upload_bytes: int = 0

--- a/apps/api/routers/projects.py
+++ b/apps/api/routers/projects.py
@@ -1,3 +1,4 @@
+import re
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -38,8 +39,26 @@ def _require_project_owner(db: Session, project_id: uuid.UUID, user: User) -> Pr
         raise HTTPException(status_code=403, detail="Project owner access required")
     return member
 
+def _check_description_requirement(description: str | None) -> None:
+    """Enforce settings.require_project_description_pattern, when an instance sets one.
+
+    Off by default: an empty pattern skips this entirely, so existing instances see no change.
+    """
+    pattern = (settings.require_project_description_pattern or "").strip()
+    if not pattern:
+        return
+    if description and re.search(pattern, description, re.IGNORECASE):
+        return
+    hint = (settings.require_project_description_hint or "").strip()
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=hint or "This instance requires a link in the project description.",
+    )
+
+
 @router.post("", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
 def create_project(body: ProjectCreate, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    _check_description_requirement(body.description)
     project = Project(
         name=body.name,
         description=body.description,
@@ -154,6 +173,9 @@ def update_project(project_id: uuid.UUID, body: ProjectUpdate, db: Session = Dep
     if body.name is not None:
         project.name = body.name
     if body.description is not None:
+        # Closing the same door on the way out: a project that had to carry the link to be
+        # created should not be able to drop it on the next edit.
+        _check_description_requirement(body.description)
         project.description = body.description
     if body.is_public is not None:
         project.is_public = body.is_public

--- a/apps/api/tests/test_projects.py
+++ b/apps/api/tests/test_projects.py
@@ -178,3 +178,49 @@ def test_update_project(client, auth_headers, mock_db, test_user):
     )
     assert resp.status_code == 200
     assert resp.json()["name"] == "New Name"
+
+
+# ── settings.require_project_description_pattern ────────────────────────────────────────────
+#
+# Off by default, so nothing changes for an instance that does not set it. When it is set, a
+# project cannot be created - or edited - without whatever the pattern asks for, which is how an
+# automation reading projects over the API can find its way back to the brief.
+
+def test_description_requirement_is_off_by_default():
+    from apps.api.routers.projects import _check_description_requirement
+    from apps.api.config import settings
+
+    original = settings.require_project_description_pattern
+    settings.require_project_description_pattern = ""
+    try:
+        _check_description_requirement(None)          # must not raise
+        _check_description_requirement("anything")
+    finally:
+        settings.require_project_description_pattern = original
+
+
+def test_description_requirement_rejects_a_missing_link():
+    import pytest
+    from fastapi import HTTPException
+    from apps.api.routers.projects import _check_description_requirement
+    from apps.api.config import settings
+
+    original = (settings.require_project_description_pattern, settings.require_project_description_hint)
+    settings.require_project_description_pattern = r"trello\.com/c/"
+    settings.require_project_description_hint = "Paste the Trello card link."
+    try:
+        with pytest.raises(HTTPException) as e:
+            _check_description_requirement("no link here")
+        assert e.value.status_code == 400
+        # The message has to say what to paste; "invalid description" sends people hunting for a
+        # formatting rule.
+        assert "Trello card link" in e.value.detail
+
+        with pytest.raises(HTTPException):
+            _check_description_requirement(None)
+
+        # And accepts a real one, wherever it sits in the text, in either case.
+        _check_description_requirement("Brief: https://trello.com/c/m8O3AF67/80-bsgv17")
+        _check_description_requirement("HTTPS://TRELLO.COM/C/abc123 - winter campaign")
+    finally:
+        settings.require_project_description_pattern, settings.require_project_description_hint = original


### PR DESCRIPTION
### What

Two new settings, both empty by default:

| setting | meaning |
|---|---|
| `REQUIRE_PROJECT_DESCRIPTION_PATTERN` | regex matched against a project's description |
| `REQUIRE_PROJECT_DESCRIPTION_HINT` | what the user is told when it does not match |

When the pattern is empty (the default) nothing changes at all - the check returns immediately, so existing instances see no difference.

### Why

Anything reading projects over the API - an automation, a reporting job, a review bot - has no way back to the brief a project was created from unless somebody wrote it down, and asking after the fact never works.

We run FreeFrame next to an automated video reviewer. It can score craft from the file alone, but to check a cut against the script it needs the brief, which lives in Trello. Today it has to guess from file names. With this setting the link is simply always there.

### Details

- enforced on **update** as well as create - a project that had to carry the link to exist should not be able to drop it on the next edit
- case-insensitive, and the link may sit anywhere in the description
- the error message is the operator's own hint. `"description is invalid"` sends people hunting for a formatting rule; `"Paste the Trello card link"` tells them what to do
- documented in `.env.example`

Example:

```
REQUIRE_PROJECT_DESCRIPTION_PATTERN=trello\.com/c/
REQUIRE_PROJECT_DESCRIPTION_HINT=Paste the Trello card link for this project.
```

### Tests

Added to `apps/api/tests/test_projects.py`: off by default, rejects a missing link, accepts one anywhere in the text, case-insensitive.

### Not included

No frontend change. The New Project dialog already renders the API error, so the hint reaches the user as-is. Happy to add an inline requirement note if you would rather surface it before submit - it would need the setting exposed on a public endpoint, which felt like a bigger change than this needs.