### PR TITLE
fix(web): viewer-identity menu unreachable on touch in the share folder browser

### DIFF
--- a/apps/web/components/share/folder-share-viewer.tsx
+++ b/apps/web/components/share/folder-share-viewer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import {
   Folder,
   File,
@@ -931,45 +932,52 @@ export function FolderShareViewer({
         <div className="flex items-center gap-3 min-w-0 flex-1">
           {/* Viewer avatar (logged-in user) or project avatar */}
           {viewerName ? (
-            <div className="relative group shrink-0">
-              <button className="flex h-7 w-7 items-center justify-center rounded-full text-[10px] font-bold text-text-primary bg-green-600 hover:ring-2 hover:ring-green-400/50 transition-all">
-                {viewerName.split(' ').map(n => n[0]).join('').substring(0, 2).toUpperCase()}
-              </button>
-              {/* Dropdown */}
-              <div className="hidden group-hover:block absolute left-0 top-full mt-1 z-50 w-56 rounded-lg border border-border bg-bg-elevated shadow-xl py-1">
-                <div className="px-3 py-2 border-b border-border">
-                  <p className="text-sm font-medium text-text-primary">{viewerName}</p>
-                </div>
-                <button
-                  onClick={() => {
-                    // Ensure cookie is set from localStorage before navigating
-                    if (typeof window !== 'undefined') {
-                      const token = localStorage.getItem('ff_access_token')
-                      if (token) {
-                        document.cookie = `ff_access_token=${token}; path=/; max-age=${60 * 60 * 24 * 7}; SameSite=Lax`
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild>
+                <button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-text-primary bg-green-600 [@media(hover:hover)]:hover:ring-2 [@media(hover:hover)]:hover:ring-green-400/50 transition-all outline-none">
+                  {viewerName.split(' ').map(n => n[0]).join('').substring(0, 2).toUpperCase()}
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  align="start"
+                  sideOffset={4}
+                  className="z-50 w-56 rounded-lg border border-border bg-bg-elevated shadow-xl py-1 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+                >
+                  <div className="px-3 py-2 border-b border-border">
+                    <p className="text-sm font-medium text-text-primary">{viewerName}</p>
+                  </div>
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      // Ensure cookie is set from localStorage before navigating
+                      if (typeof window !== 'undefined') {
+                        const token = localStorage.getItem('ff_access_token')
+                        if (token) {
+                          document.cookie = `ff_access_token=${token}; path=/; max-age=${60 * 60 * 24 * 7}; SameSite=Lax`
+                        }
+                        window.location.href = withBasePath('/projects')
                       }
-                      window.location.href = withBasePath('/projects')
-                    }
-                  }}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-tertiary transition-colors"
-                >
-                  Back to Dashboard
-                </button>
-                <button
-                  onClick={() => {
-                    if (typeof window !== 'undefined') {
-                      localStorage.removeItem('ff_access_token')
-                      localStorage.removeItem('ff_refresh_token')
-                      document.cookie = 'ff_access_token=; path=/; max-age=0'
-                      window.location.href = withBasePath('/login')
-                    }
-                  }}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-red-500/10 transition-colors"
-                >
-                  Log out
-                </button>
-              </div>
-            </div>
+                    }}
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-bg-tertiary cursor-pointer outline-none transition-colors"
+                  >
+                    Back to Dashboard
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    onSelect={() => {
+                      if (typeof window !== 'undefined') {
+                        localStorage.removeItem('ff_access_token')
+                        localStorage.removeItem('ff_refresh_token')
+                        document.cookie = 'ff_access_token=; path=/; max-age=0'
+                        window.location.href = withBasePath('/login')
+                      }
+                    }}
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-red-500/10 cursor-pointer outline-none transition-colors"
+                  >
+                    Log out
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           ) : branding?.logo_url ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img


### PR DESCRIPTION
Fixes #349, for the one control it named that's still actually broken.

## What was wrong

The dropdown that lets a signed-in viewer get back to the dashboard or log out (`FolderShareViewer`'s top bar, when `viewerName` is set) was `hidden group-hover:block` — revealed only by hovering the avatar button, with no click handler at all. A phone never delivers hover, so this menu was permanently unreachable on touch: not just invisible, unopenable.

## What's fixed

Replaced the hand-rolled hover reveal with the Radix `DropdownMenu` already used for the same shape elsewhere in this app (`asset-card.tsx`'s "···" menu) — click/tap opens it, outside-click and Escape close it, on every input type. Desktop is visually unchanged; only the trigger mechanism moved from CSS `:hover` to a real click handler with proper focus/dismiss behavior for free.

## On the other two controls #349 named

I couldn't reproduce the exact `text-transparent`/`border-white` snippets quoted in the issue against the current `main` — grepping the file for `transparent` and `border-white` turns up nothing. Checking blame: #339 (mine, merged the morning after #349 was filed) already gated the version badge, the grid card's download-button overlay, and the list row's own overlay behind `[@media(hover:hover)]:`, as part of its own click-routing fix to this same file. My read is #349 was filed against the pre-#339 state of the file and the three call-outs landed as a side effect of that PR, before it merged.

I did a full pass for any remaining un-gated `hover:`/`group-hover:` visibility rule in the file to make sure nothing else was missed — this viewer-identity menu was the only one left.

## Verification

Typecheck and the full suite are clean (`tsc --noEmit`, `vitest run`: 494 passed). No automated coverage added for this one specifically — `FolderShareViewer`'s top bar isn't exercised by any existing test, and mounting the full component means stubbing its folder/asset fetch, which felt like more scaffolding than this fix warrants on its own. Manually verified the click-to-open/outside-click-to-close/Escape-to-close behavior in a browser at both desktop and mobile viewport widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)