### PR TITLE
fix(web): a file dropped on a share link navigates the guest away

### DIFF
--- a/apps/web/app/share/__tests__/layout-file-drag.test.tsx
+++ b/apps/web/app/share/__tests__/layout-file-drag.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * The share tree refuses a file drag the same way the dashboard shell does
+ * (see `(dashboard)/__tests__/layout-file-drag.test.tsx`).
+ *
+ * A share link has no drop target anywhere below this — folder-based upload
+ * is disabled in share mode — so a file dragged in from outside the browser
+ * always reaches here unclaimed. Left alone it navigates the tab to
+ * `file:///...`, which costs a guest more than it costs a signed-in user:
+ * there is no session to come back to, and any comment they had typed goes
+ * with the page.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ShareLayout from '../layout'
+
+const file = new File(['x'], 'notes.mov', { type: 'video/quicktime' })
+const fileDrag = () => ({ types: ['Files'], files: [file], dropEffect: 'none' })
+
+function renderShell() {
+  return render(
+    <ShareLayout>
+      <div data-testid="page">the share page</div>
+    </ShareLayout>,
+  )
+}
+
+describe('a file dropped on the share tree', () => {
+  it('is refused', () => {
+    renderShell()
+
+    expect(
+      fireEvent.dragOver(screen.getByTestId('page'), { dataTransfer: fileDrag() }),
+    ).toBe(false)
+    expect(
+      fireEvent.drop(screen.getByTestId('page'), { dataTransfer: fileDrag() }),
+    ).toBe(false)
+  })
+
+  it('says so to the pointer rather than only swallowing it', () => {
+    renderShell()
+    const dataTransfer = fileDrag()
+
+    fireEvent.dragOver(screen.getByTestId('page'), { dataTransfer })
+
+    expect(dataTransfer.dropEffect).toBe('none')
+  })
+
+  it('leaves a non-file drag alone', () => {
+    // Nothing in the share tree currently drags anything itself, but the
+    // refusal is keyed on carrying files rather than on being unclaimed, so
+    // it should not need to change if that ever stops being true.
+    renderShell()
+    const dataTransfer = { types: ['application/json'], files: [], dropEffect: 'move' }
+
+    expect(
+      fireEvent.dragOver(screen.getByTestId('page'), { dataTransfer }),
+    ).toBe(true)
+    expect(dataTransfer.dropEffect).toBe('move')
+  })
+})

--- a/apps/web/app/share/layout.tsx
+++ b/apps/web/app/share/layout.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { refuseFileDrag } from "@/lib/drag";
+
+// Mirrors the dashboard shell's own fix (see `(dashboard)/layout.tsx`): a
+// file dropped anywhere that does not accept it reaches the browser's own
+// handling, which navigates the tab to `file:///...` and loses the page. A
+// share link has no drop target anywhere in this tree (folder-based upload
+// is deliberately disabled in share mode), so nothing here ever needs to
+// stop this from bubbling up. It matters more here than on the dashboard: a
+// guest has no session to come back to, and loses any comment they had
+// typed along with the page.
+export default function ShareLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div onDragOver={refuseFileDrag} onDrop={refuseFileDrag}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #351.

## What was wrong

#327 refused an unclaimed file drag on the dashboard shell — the header, sidebar, and attribution badge are all siblings of the page rather than parts of it, and anything that reached the shell unclaimed was headed for the browser's own handling, which navigates the tab to `file:///...`. A share link renders through a completely separate tree (`app/share/[token]/page.tsx`) with no equivalent, so a guest dropping a file anywhere still loses the page. It costs more here than on the dashboard: a guest has no session to come back to, and any comment they had typed goes with the page.

## What's fixed

Same fix, same mechanism (`refuseFileDrag` from `lib/drag.ts` on `onDragOver`/`onDrop`), at the equivalent shell for this route: a new `app/share/layout.tsx`, playing the same role `(dashboard)/layout.tsx` plays for the dashboard tree. Folder-based upload is deliberately disabled in share mode (confirmed nothing under `/share` wires a legitimate drop target), so nothing here needs this to stop propagating — it only ever sees drags nothing wanted.

## Test

Added `app/share/__tests__/layout-file-drag.test.tsx`, following `(dashboard)/__tests__/layout-file-drag.test.tsx`'s own pattern: asserts the drag is refused with an explicit `dropEffect` rather than merely swallowed, and that a non-file drag is left alone. Confirmed the test fails against the old (fixed) code — reverted the layout to a plain pass-through and the "is refused" case failed as expected — then restored it.

Typecheck, full suite (`vitest run`: 494 passed), and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)