### PR TITLE
fix(web): compare view's scrubber has no touch support

### DIFF
--- a/apps/web/components/review/compare/__tests__/compare-scrubber.test.tsx
+++ b/apps/web/components/review/compare/__tests__/compare-scrubber.test.tsx
@@ -16,6 +16,10 @@ describe('CompareScrubber', () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       left: 0, top: 0, right: 630, bottom: 8, width: 630, height: 8, x: 0, y: 0, toJSON() {},
     })
+    // jsdom doesn't implement this at all (it's undefined, which is why the
+    // component calls it with `?.`) — stub it so a dropped call is visible
+    // rather than silently passing.
+    Element.prototype.setPointerCapture = vi.fn()
   })
 
   afterEach(() => {
@@ -97,6 +101,22 @@ describe('CompareScrubber', () => {
 
     fireEvent.pointerDown(track, { pointerId: 2, clientX: 315, isPrimary: true, button: 0 })
     expect(onSeek).toHaveBeenLastCalledWith((315 / 630) * 63)
+  })
+
+  it('captures the pointer on pointerdown, so the drag survives the finger leaving the track', () => {
+    render(<CompareScrubber {...base} />)
+    const track = screen.getByTestId('compare-track')
+
+    fireEvent.pointerDown(track, { pointerId: 1, clientX: 63, isPrimary: true, button: 0 })
+
+    expect(track.setPointerCapture).toHaveBeenCalledWith(1)
+  })
+
+  it('marks the track touch-none, so a drag is not fought by the browser\'s own scroll gesture', () => {
+    render(<CompareScrubber {...base} />)
+    const track = screen.getByTestId('compare-track')
+
+    expect(track.className).toContain('touch-none')
   })
 
   it('positions markers at (tc + offset) / total and reports clicks per side', () => {

--- a/apps/web/components/review/compare/__tests__/compare-scrubber.test.tsx
+++ b/apps/web/components/review/compare/__tests__/compare-scrubber.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { CompareScrubber } from '../compare-scrubber'
 
@@ -12,18 +12,91 @@ const base = {
 }
 
 describe('CompareScrubber', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, right: 630, bottom: 8, width: 630, height: 8, x: 0, y: 0, toJSON() {},
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('shows SMPTE timecode for the transport time', () => {
     render(<CompareScrubber {...base} />)
     expect(screen.getByText('00:00:10:00')).toBeInTheDocument()
   })
 
-  it('click on the track seeks by ratio', () => {
-    render(<CompareScrubber {...base} />)
+  it('seeks on pointerdown, tracks the drag on pointermove, and finalizes on pointerup', () => {
+    const onSeek = vi.fn()
+    render(<CompareScrubber {...base} onSeek={onSeek} />)
     const track = screen.getByTestId('compare-track')
-    track.getBoundingClientRect = () =>
-      ({ left: 0, width: 630, top: 0, height: 8, right: 630, bottom: 8, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
-    fireEvent.click(track, { clientX: 63 })
-    expect(base.onSeek).toHaveBeenCalledWith((63 / 630) * 63)
+
+    fireEvent.pointerDown(track, { pointerId: 1, clientX: 63, isPrimary: true, button: 0 })
+    expect(onSeek).toHaveBeenLastCalledWith((63 / 630) * 63)
+
+    fireEvent.pointerMove(track, { pointerId: 1, clientX: 315 })
+    expect(onSeek).toHaveBeenLastCalledWith((315 / 630) * 63)
+
+    fireEvent.pointerUp(track, { pointerId: 1, clientX: 630 })
+    expect(onSeek).toHaveBeenLastCalledWith(63)
+    expect(onSeek).toHaveBeenCalledTimes(3)
+  })
+
+  it('ignores a second pointer while dragging, so a two-finger grip cannot hijack the seek', () => {
+    const onSeek = vi.fn()
+    render(<CompareScrubber {...base} onSeek={onSeek} />)
+    const track = screen.getByTestId('compare-track')
+
+    fireEvent.pointerDown(track, { pointerId: 1, clientX: 63, isPrimary: true, button: 0 })
+    onSeek.mockClear()
+
+    fireEvent.pointerMove(track, { pointerId: 2, clientX: 600 })
+    expect(onSeek).not.toHaveBeenCalled()
+
+    fireEvent.pointerMove(track, { pointerId: 1, clientX: 315 })
+    expect(onSeek).toHaveBeenLastCalledWith((315 / 630) * 63)
+  })
+
+  it('ends the drag on pointercancel, so a later move on the page does not keep seeking', () => {
+    const onSeek = vi.fn()
+    render(<CompareScrubber {...base} onSeek={onSeek} />)
+    const track = screen.getByTestId('compare-track')
+
+    fireEvent.pointerDown(track, { pointerId: 1, clientX: 63, isPrimary: true, button: 0 })
+    fireEvent.pointerCancel(track, { pointerId: 1 })
+    onSeek.mockClear()
+
+    fireEvent.pointerMove(track, { pointerId: 1, clientX: 500 })
+    expect(onSeek).not.toHaveBeenCalled()
+
+    fireEvent.pointerDown(track, { pointerId: 3, clientX: 315, isPrimary: true, button: 0 })
+    expect(onSeek).toHaveBeenLastCalledWith((315 / 630) * 63)
+  })
+
+  it('ignores a non-primary pointer or a non-primary-button press on pointerdown', () => {
+    const onSeek = vi.fn()
+    render(<CompareScrubber {...base} onSeek={onSeek} />)
+    const track = screen.getByTestId('compare-track')
+
+    fireEvent.pointerDown(track, { pointerId: 1, clientX: 63, isPrimary: false, button: 0 })
+    expect(onSeek).not.toHaveBeenCalled()
+
+    fireEvent.pointerDown(track, { pointerId: 1, clientX: 63, isPrimary: true, button: 2 })
+    expect(onSeek).not.toHaveBeenCalled()
+  })
+
+  it('ends the drag on onLostPointerCapture, so the bar is never permanently latched', () => {
+    const onSeek = vi.fn()
+    render(<CompareScrubber {...base} onSeek={onSeek} />)
+    const track = screen.getByTestId('compare-track')
+
+    fireEvent.pointerDown(track, { pointerId: 1, clientX: 63, isPrimary: true, button: 0 })
+    fireEvent(track, new Event('lostpointercapture', { bubbles: true }))
+    onSeek.mockClear()
+
+    fireEvent.pointerDown(track, { pointerId: 2, clientX: 315, isPrimary: true, button: 0 })
+    expect(onSeek).toHaveBeenLastCalledWith((315 / 630) * 63)
   })
 
   it('positions markers at (tc + offset) / total and reports clicks per side', () => {

--- a/apps/web/components/review/compare/compare-scrubber.tsx
+++ b/apps/web/components/review/compare/compare-scrubber.tsx
@@ -85,7 +85,10 @@ function ScrubberCommentMarker({
     <div
       ref={markerRef}
       data-testid={`marker-${side}-${marker.id}`}
-      className={cn('absolute -translate-x-1/2 cursor-pointer', side === 'a' ? 'top-0' : 'bottom-0')}
+      className={cn(
+        'absolute -translate-x-1/2 cursor-pointer pointer-events-auto',
+        side === 'a' ? 'top-0' : 'bottom-0',
+      )}
       style={{ left: `${leftPercent}%` }}
       onMouseEnter={onHover}
       onMouseLeave={onLeave}
@@ -93,7 +96,7 @@ function ScrubberCommentMarker({
     >
       {/* Avatar dot */}
       <div
-        className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-bg-primary text-[9px] font-bold text-white shadow-md transition-transform hover:scale-110"
+        className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-bg-primary text-[9px] font-bold text-white shadow-md transition-transform [@media(hover:hover)]:hover:scale-110"
         style={{ backgroundColor: color }}
       >
         {initials}
@@ -158,13 +161,66 @@ function OffsetStepper({ side, label, offset, fps, onOffsetChange }: {
 export function CompareScrubber(props: CompareScrubberProps) {
   const { t, total, isPlaying, fps, onToggle, onSeek, markersA, markersB, timingA, timingB, onMarkerClick, onOffsetChange, labelA, labelB, onResetOffsets } = props
   const trackRef = React.useRef<HTMLDivElement>(null)
+  const activePointerIdRef = React.useRef<number | null>(null)
+  const [isDragging, setIsDragging] = React.useState(false)
   const [hovered, setHovered] = React.useState<HoveredMarker | null>(null)
 
-  const seekFromEvent = (clientX: number) => {
-    const rect = trackRef.current?.getBoundingClientRect()
-    if (!rect || rect.width === 0) return
-    onSeek(((clientX - rect.left) / rect.width) * total)
-  }
+  // Pointer Events throughout, mirroring progress-bar.tsx: a click-only
+  // handler here means a finger can tap-seek once but never drag, since
+  // there is no touch equivalent of a window `mousemove` listener.
+  const getTimeFromEvent = React.useCallback(
+    (clientX: number): number => {
+      const rect = trackRef.current?.getBoundingClientRect()
+      if (!rect || rect.width === 0) return 0
+      const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+      return ratio * total
+    },
+    [total],
+  )
+
+  const endDrag = React.useCallback(() => {
+    activePointerIdRef.current = null
+    setIsDragging(false)
+  }, [])
+
+  const handlePointerDown = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!e.isPrimary || e.button !== 0) return
+      if (activePointerIdRef.current !== null) return
+      activePointerIdRef.current = e.pointerId
+      e.currentTarget.setPointerCapture?.(e.pointerId)
+      setIsDragging(true)
+      onSeek(getTimeFromEvent(e.clientX))
+    },
+    [getTimeFromEvent, onSeek],
+  )
+
+  const handlePointerMove = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!isDragging || e.pointerId !== activePointerIdRef.current) return
+      onSeek(getTimeFromEvent(e.clientX))
+    },
+    [isDragging, getTimeFromEvent, onSeek],
+  )
+
+  const handlePointerUp = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.pointerId !== activePointerIdRef.current) return
+      onSeek(getTimeFromEvent(e.clientX))
+      endDrag()
+    },
+    [getTimeFromEvent, onSeek, endDrag],
+  )
+
+  const handlePointerCancel = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // iOS fires this instead of pointerup when the system takes the
+      // gesture mid-drag (a second finger starting a pinch, an edge swipe).
+      if (e.pointerId !== activePointerIdRef.current) return
+      endDrag()
+    },
+    [endDrag],
+  )
 
   return (
     <div className="flex items-center gap-4 border-t border-border bg-bg-primary px-4 py-2">
@@ -178,42 +234,65 @@ export function CompareScrubber(props: CompareScrubberProps) {
       </button>
 
       <div className="relative flex-1 py-6">
-        {/* A markers above the track */}
-        {markersA.map((m) => (
-          <ScrubberCommentMarker
-            key={m.id}
-            marker={m}
-            side="a"
-            fps={fps}
-            leftPercent={markerPosition(m.tc, timingA, total) * 100}
-            isHovered={hovered?.side === 'a' && hovered.id === m.id}
-            onHover={() => setHovered({ side: 'a', id: m.id })}
-            onLeave={() => setHovered(null)}
-            onClick={() => onMarkerClick('a', m)}
-          />
-        ))}
+        {/* Track — handlers live here; the invisible hit-area extension below
+            is a plain overflowing child, and the marker rows render after
+            this in the DOM (see below) so a dot always wins hit-testing over
+            the extension where the two overlap, the same ordering
+            progress-bar.tsx relies on for its own comment-markers row. */}
         <div
           ref={trackRef}
           data-testid="compare-track"
-          onClick={(e) => seekFromEvent(e.clientX)}
-          className="relative h-2 cursor-pointer rounded-full bg-bg-tertiary"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
+          onLostPointerCapture={endDrag}
+          className="relative h-2 cursor-pointer touch-none rounded-full bg-bg-tertiary"
         >
+          {/* Invisible hit-area extension — widens the 8px track to a more
+              graspable touch target. The two marker rows sit in the same
+              py-6 gutter this reaches into, which is fine: they render after
+              this element and get pointer-events-auto back on each dot, so a
+              dot still wins hit-testing at any pixel the two share. */}
+          <div className="absolute -top-2 -bottom-2 inset-x-0" />
           <div className="absolute inset-y-0 left-0 rounded-full bg-accent" style={{ width: `${total > 0 ? (t / total) * 100 : 0}%` }} />
         </div>
-        {/* B markers below the track */}
-        {markersB.map((m) => (
-          <ScrubberCommentMarker
-            key={m.id}
-            marker={m}
-            side="b"
-            fps={fps}
-            leftPercent={markerPosition(m.tc, timingB, total) * 100}
-            isHovered={hovered?.side === 'b' && hovered.id === m.id}
-            onHover={() => setHovered({ side: 'b', id: m.id })}
-            onLeave={() => setHovered(null)}
-            onClick={() => onMarkerClick('b', m)}
-          />
-        ))}
+
+        {/* A markers above the track. pointer-events-none on the row so its
+            own empty space doesn't shadow the track's hit-area extension
+            above it; pointer-events-auto is restored on each marker itself. */}
+        <div className="pointer-events-none">
+          {markersA.map((m) => (
+            <ScrubberCommentMarker
+              key={m.id}
+              marker={m}
+              side="a"
+              fps={fps}
+              leftPercent={markerPosition(m.tc, timingA, total) * 100}
+              isHovered={hovered?.side === 'a' && hovered.id === m.id}
+              onHover={() => setHovered({ side: 'a', id: m.id })}
+              onLeave={() => setHovered(null)}
+              onClick={() => onMarkerClick('a', m)}
+            />
+          ))}
+        </div>
+
+        {/* B markers below the track — same treatment. */}
+        <div className="pointer-events-none">
+          {markersB.map((m) => (
+            <ScrubberCommentMarker
+              key={m.id}
+              marker={m}
+              side="b"
+              fps={fps}
+              leftPercent={markerPosition(m.tc, timingB, total) * 100}
+              isHovered={hovered?.side === 'b' && hovered.id === m.id}
+              onHover={() => setHovered({ side: 'b', id: m.id })}
+              onLeave={() => setHovered(null)}
+              onClick={() => onMarkerClick('b', m)}
+            />
+          ))}
+        </div>
       </div>
 
       <span className="font-mono text-[12px] tabular-nums text-text-secondary">{formatTimecode(t, fps ?? 24)}</span>


### PR DESCRIPTION
Fixes #353.

## What was wrong

The compare scrubber never got the touch work the main player's did in #323:

- The track only seeks `onClick`, with no drag — no touch equivalent of the window `mousemove` listener a drag needs, so a finger can tap-seek once but never scrub.
- The track is a plain 8px `h-2`, no widened hit area.
- The two comment-marker rows (above and below the track) use `onMouseEnter`/`onMouseLeave` for their hover preview, unreachable on touch, and the avatar dot's unguarded `hover:scale-110` carries the same risk #339 found on the main grid: a tap on anything with `:hover`-driven styling gets treated as entering hover on iOS, so the click doesn't fire until a second tap.

## What's fixed

Ported the model #323 already built for `progress-bar.tsx` rather than reinventing it: Pointer Events throughout, a captured drag with an `isPrimary`/`button` guard on pointerdown, `pointercancel` and `onLostPointerCapture` so a drag can't latch permanently, `touch-none` on the track, and an invisible absolutely-positioned hit-area extension that doesn't add to layout height. Also gated the marker avatar's `hover:scale-110` behind `[@media(hover:hover)]:`, matching #339's fix for the same class of bug.

One thing specific to this component: it has **two** marker rows (above and below the track) where #323's has one. Applied the same `pointer-events-none`-on-the-row / `pointer-events-auto`-on-the-marker treatment to both, and moved both rows to render after the track in the DOM — the track's hit-area extension reaches into both rows' gutters, and a marker has to be later in paint order than the extension to win hit-testing wherever the two overlap. #323's single row already rendered after its track for the same reason; this one needed it on both sides.

**Left as-is, deliberately:** the hover-driven tooltip preview stays mouse/trackpad-only. A tap already calls `onMarkerClick` (the same action a click does), so a touch user reaches the underlying comment in one tap regardless — there's no unique content in the transient preview to justify a separate tap-triggered version of it. Also didn't touch whether compare mode should be offered below `md` at all — #353 raises that as a separate scoping question and explicitly leaves it open.

## Verification

Typecheck, full suite (`vitest run`: 494 passed), and `next build` all clean. Extended the existing test file with #323's own coverage shape (drag continuation, two-finger-grip rejection, pointercancel, non-primary pointer/button rejection, `onLostPointerCapture` recovery) — 12 tests total, up from 7. Confirmed 4 of the 5 new tests fail against the pre-fix click-only code (stashed the fix, reran, restored) to make sure they're testing real behavior rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)